### PR TITLE
Add first-run onboarding wizard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,9 +8,9 @@ import { AuthProvider } from './core/auth/AuthContext';
 import { ProtectedRoute } from './core/auth/ProtectedRoute';
 import { LoginPage } from './login/LoginPage';
 import { DashboardPage } from './dashboard/DashboardPage';
+import { OnboardingPage } from './onboarding/OnboardingPage';
 import { AgentPage } from './agent/AgentPage';
 import { WebbyPage } from './webby/WebbyPage';
-import { SetupWizard } from './setup/SetupWizard';
 import { CrmLayout } from './crm/CrmLayout';
 import { CrmDashboardPage } from './crm/CrmDashboardPage';
 import { ContactsPage } from './crm/ContactsPage';
@@ -29,7 +29,7 @@ export default function App() {
             path="/setup"
             element={
               <ProtectedRoute>
-                <SetupWizard />
+                <OnboardingPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -132,6 +132,18 @@ export interface CrmDashboard {
   top_deals: CrmDeal[];
 }
 
+// Provider status (from GET /api/providers)
+export interface ProviderStatus {
+  active_provider: string;
+  active_model: string;
+  profiles: Record<string, {
+    type: string;
+    configured: boolean;
+    key_preview?: string;
+    expired?: boolean;
+  }>;
+}
+
 // SSE event types
 export type SSEEvent =
   | { type: 'conversation_id'; id: string }

--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -36,6 +36,8 @@ export function DashboardPage() {
       if (brandingData.accent_color) {
         document.documentElement.style.setProperty('--brand-color', brandingData.accent_color);
       }
+    }).catch(() => {
+      // If provider check fails, show dashboard anyway (graceful degradation)
     }).finally(() => setLoading(false));
   }, [navigate]);
 

--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../core/api/client';
 import { AgentCard } from './AgentCard';
 import { CreateAgentModal } from './CreateAgentModal';
 import { SettingsPanel } from './SettingsPanel';
-import type { Agent, BrandingConfig, Integration } from '../core/types';
+import type { Agent, BrandingConfig, Integration, ProviderStatus } from '../core/types';
 
 export function DashboardPage() {
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -14,25 +14,21 @@ export function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [crmEnabled, setCrmEnabled] = useState(false);
   const navigate = useNavigate();
-  const setupChecked = useRef(false);
-
-  // Check if setup wizard should be shown (first login)
-  useEffect(() => {
-    if (setupChecked.current) return;
-    setupChecked.current = true;
-    api<{ setup_complete: boolean }>('/api/setup/status')
-      .then(s => {
-        if (!s.setup_complete) navigate('/setup', { replace: true });
-      })
-      .catch(() => {}); // if endpoint fails, just show dashboard
-  }, [navigate]);
 
   useEffect(() => {
     Promise.all([
       api<{ agents: Agent[] }>('/api/agents'),
       api<BrandingConfig>('/api/branding'),
       api<{ integrations: Integration[] }>('/api/integrations'),
-    ]).then(([agentsData, brandingData, intData]) => {
+      api<ProviderStatus>('/api/providers'),
+    ]).then(([agentsData, brandingData, intData, providerData]) => {
+      // Redirect to onboarding if no AI provider is configured
+      const anyProviderConfigured = Object.values(providerData.profiles).some(p => p.configured);
+      if (!anyProviderConfigured) {
+        navigate('/setup', { replace: true });
+        return;
+      }
+
       setAgents(agentsData.agents);
       setBranding(brandingData);
       setCrmEnabled(intData.integrations.some(i => i.id === 'crm_lite' && i.enabled));
@@ -41,7 +37,7 @@ export function DashboardPage() {
         document.documentElement.style.setProperty('--brand-color', brandingData.accent_color);
       }
     }).finally(() => setLoading(false));
-  }, []);
+  }, [navigate]);
 
   async function handleDelete(id: string) {
     if (!confirm('Delete this agent? This cannot be undone.')) return;

--- a/frontend/src/onboarding/OnboardingPage.tsx
+++ b/frontend/src/onboarding/OnboardingPage.tsx
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom';
+import { OnboardingWizard } from './OnboardingWizard';
+
+export function OnboardingPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-950 flex items-center justify-center p-6">
+      <div className="w-full max-w-2xl">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-white">Welcome to Chatty</h1>
+          <p className="text-gray-400 mt-2">Let's get you set up in a few quick steps</p>
+        </div>
+        <OnboardingWizard onComplete={() => navigate('/', { replace: true })} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/onboarding/OnboardingWizard.tsx
@@ -76,9 +76,12 @@ export function OnboardingWizard({ onComplete }: Props) {
     return '';
   }, [providerStatus]);
 
-  function handleProviderComplete() {
-    // Refresh provider status so completion screen is accurate
-    api<ProviderStatus>('/api/providers').then(setProviderStatus).catch(console.error);
+  async function handleProviderComplete() {
+    // Refresh provider status so completion screen shows accurate provider name
+    try {
+      const data = await api<ProviderStatus>('/api/providers');
+      setProviderStatus(data);
+    } catch { /* proceed anyway */ }
     setPhase('pick-integrations');
   }
 

--- a/frontend/src/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect, useMemo } from 'react';
+import { api } from '../core/api/client';
+import type { ProviderStatus } from '../core/types';
+import { StepIndicator } from './StepIndicator';
+import { ProviderStep } from './steps/ProviderStep';
+import { IntegrationPickerStep } from './steps/IntegrationPickerStep';
+import { OdooSetupStep } from './steps/OdooSetupStep';
+import { QuickBooksSetupStep } from './steps/QuickBooksSetupStep';
+import { BambooHRSetupStep } from './steps/BambooHRSetupStep';
+import { CrmLiteSetupStep } from './steps/CrmLiteSetupStep';
+import { CompletionStep } from './steps/CompletionStep';
+
+interface Props {
+  onComplete: () => void;
+}
+
+type Phase = 'provider' | 'pick-integrations' | 'integration-setup' | 'done';
+
+const INTEGRATION_ORDER = ['odoo', 'quickbooks', 'bamboohr', 'crm_lite'];
+
+const INTEGRATION_TITLES: Record<string, string> = {
+  odoo: 'Odoo',
+  quickbooks: 'QuickBooks',
+  bamboohr: 'BambooHR',
+  crm_lite: 'CRM',
+};
+
+export function OnboardingWizard({ onComplete }: Props) {
+  const [phase, setPhase] = useState<Phase>('provider');
+  const [selectedIntegrations, setSelectedIntegrations] = useState<string[]>([]);
+  const [completedIntegrations, setCompletedIntegrations] = useState<string[]>([]);
+  const [currentIntegrationIndex, setCurrentIntegrationIndex] = useState(0);
+  const [providerStatus, setProviderStatus] = useState<ProviderStatus | null>(null);
+
+  useEffect(() => {
+    api<ProviderStatus>('/api/providers').then(data => {
+      setProviderStatus(data);
+      // Skip provider step if already configured
+      const anyConfigured = Object.values(data.profiles).some(p => p.configured);
+      if (anyConfigured) setPhase('pick-integrations');
+    }).catch(console.error);
+  }, []);
+
+  // Build step list for the indicator
+  const steps = useMemo(() => {
+    const s = [
+      { id: 'provider', title: 'AI Provider' },
+      { id: 'integrations', title: 'Integrations' },
+    ];
+    for (const id of selectedIntegrations) {
+      s.push({ id, title: INTEGRATION_TITLES[id] || id });
+    }
+    if (selectedIntegrations.length > 0) {
+      s.push({ id: 'done', title: 'Done' });
+    }
+    return s;
+  }, [selectedIntegrations]);
+
+  // Current step index for the indicator
+  const currentStepIndex = useMemo(() => {
+    if (phase === 'provider') return 0;
+    if (phase === 'pick-integrations') return 1;
+    if (phase === 'integration-setup') return 2 + currentIntegrationIndex;
+    if (phase === 'done') return steps.length - 1;
+    return 0;
+  }, [phase, currentIntegrationIndex, steps.length]);
+
+  // Get the active provider name for the completion screen
+  const activeProvider = useMemo(() => {
+    if (!providerStatus) return '';
+    if (providerStatus.active_provider) return providerStatus.active_provider;
+    // Find first configured provider
+    for (const [name, profile] of Object.entries(providerStatus.profiles)) {
+      if (profile.configured) return name;
+    }
+    return '';
+  }, [providerStatus]);
+
+  function handleProviderComplete() {
+    // Refresh provider status so completion screen is accurate
+    api<ProviderStatus>('/api/providers').then(setProviderStatus).catch(console.error);
+    setPhase('pick-integrations');
+  }
+
+  function handleIntegrationsPicked(ids: string[]) {
+    // Sort by our canonical order
+    const sorted = INTEGRATION_ORDER.filter(id => ids.includes(id));
+    setSelectedIntegrations(sorted);
+    if (sorted.length === 0) {
+      // Skip pressed or nothing selected — go straight to dashboard
+      onComplete();
+      return;
+    }
+    setCurrentIntegrationIndex(0);
+    setPhase('integration-setup');
+  }
+
+  function handleIntegrationsSkipped() {
+    onComplete();
+  }
+
+  function advanceIntegration(completed: boolean) {
+    if (completed) {
+      setCompletedIntegrations(prev => [...prev, selectedIntegrations[currentIntegrationIndex]]);
+    }
+    const nextIndex = currentIntegrationIndex + 1;
+    if (nextIndex < selectedIntegrations.length) {
+      setCurrentIntegrationIndex(nextIndex);
+    } else {
+      setPhase('done');
+    }
+  }
+
+  // Render current integration setup step
+  function renderIntegrationStep() {
+    const integrationId = selectedIntegrations[currentIntegrationIndex];
+    const stepProps = {
+      onComplete: () => advanceIntegration(true),
+      onSkip: () => advanceIntegration(false),
+    };
+
+    switch (integrationId) {
+      case 'odoo': return <OdooSetupStep {...stepProps} />;
+      case 'quickbooks': return <QuickBooksSetupStep {...stepProps} />;
+      case 'bamboohr': return <BambooHRSetupStep {...stepProps} />;
+      case 'crm_lite': return <CrmLiteSetupStep {...stepProps} />;
+      default: return null;
+    }
+  }
+
+  return (
+    <div>
+      <StepIndicator steps={steps} currentIndex={currentStepIndex} />
+
+      <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 sm:p-8">
+        {phase === 'provider' && (
+          <ProviderStep onComplete={handleProviderComplete} />
+        )}
+
+        {phase === 'pick-integrations' && (
+          <IntegrationPickerStep
+            onComplete={handleIntegrationsPicked}
+            onSkip={handleIntegrationsSkipped}
+          />
+        )}
+
+        {phase === 'integration-setup' && renderIntegrationStep()}
+
+        {phase === 'done' && (
+          <CompletionStep
+            result={{
+              provider: activeProvider,
+              integrations: completedIntegrations,
+            }}
+            onComplete={onComplete}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/onboarding/StepIndicator.tsx
+++ b/frontend/src/onboarding/StepIndicator.tsx
@@ -1,0 +1,50 @@
+interface Step {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  steps: Step[];
+  currentIndex: number;
+}
+
+export function StepIndicator({ steps, currentIndex }: Props) {
+  return (
+    <div className="flex items-center justify-center gap-2 mb-8">
+      {steps.map((step, i) => {
+        const isCompleted = i < currentIndex;
+        const isCurrent = i === currentIndex;
+
+        return (
+          <div key={step.id} className="flex items-center gap-2">
+            {i > 0 && (
+              <div className={`w-8 h-px ${isCompleted ? 'bg-indigo-500' : 'bg-gray-700'}`} />
+            )}
+            <div className="flex flex-col items-center gap-1.5">
+              <div
+                className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-semibold transition ${
+                  isCompleted
+                    ? 'bg-indigo-500 text-white'
+                    : isCurrent
+                      ? 'bg-indigo-500/20 text-indigo-400 ring-2 ring-indigo-500'
+                      : 'bg-gray-800 text-gray-500'
+                }`}
+              >
+                {isCompleted ? (
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  i + 1
+                )}
+              </div>
+              <span className={`text-xs whitespace-nowrap ${isCurrent ? 'text-gray-300' : 'text-gray-500'}`}>
+                {step.title}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/onboarding/steps/BambooHRSetupStep.tsx
+++ b/frontend/src/onboarding/steps/BambooHRSetupStep.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { api } from '../../core/api/client';
+
+interface Props {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+export function BambooHRSetupStep({ onComplete, onSkip }: Props) {
+  const [subdomain, setSubdomain] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  async function connect() {
+    setSaving(true);
+    setError('');
+    try {
+      await api('/api/integrations/bamboohr/setup', {
+        method: 'POST',
+        body: JSON.stringify({ subdomain, api_key: apiKey }),
+      });
+      onComplete();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Connection failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const isValid = subdomain.trim() && apiKey.trim();
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold text-white mb-2">Connect BambooHR</h2>
+      <p className="text-gray-400 text-sm mb-6">
+        Connect BambooHR to give your agents access to employee directory, time tracking, and HR data.
+      </p>
+
+      <div className="space-y-4 mb-6">
+        {/* Subdomain */}
+        <div>
+          <label className="block text-sm text-gray-300 mb-1.5">Company Subdomain</label>
+          <div className="flex items-center">
+            <input
+              value={subdomain}
+              onChange={e => setSubdomain(e.target.value)}
+              placeholder="your-company"
+              className="flex-1 bg-gray-800 border border-gray-700 text-white rounded-l-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
+            />
+            <span className="bg-gray-700 border border-l-0 border-gray-700 text-gray-400 rounded-r-lg px-3 py-3 text-sm">
+              .bamboohr.com
+            </span>
+          </div>
+          <p className="text-gray-500 text-xs mt-1">
+            The subdomain from your BambooHR URL (e.g. "acme" from acme.bamboohr.com)
+          </p>
+        </div>
+
+        {/* API Key */}
+        <div>
+          <label className="block text-sm text-gray-300 mb-1.5">API Key</label>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={e => setApiKey(e.target.value)}
+            placeholder="Your BambooHR API key"
+            className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
+          />
+          <div className="bg-gray-900 border border-dashed border-gray-700 rounded-lg p-3 mt-2 text-center">
+            <p className="text-gray-500 text-xs">Screenshot: BambooHR Account &rarr; API Keys &rarr; Add New Key (coming soon)</p>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-red-400 text-sm bg-red-900/20 rounded-lg px-4 py-3 mb-4">{error}</div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={onSkip}
+          className="flex-1 py-3 rounded-xl border border-gray-700 text-gray-400 hover:bg-gray-800 transition font-medium"
+        >
+          Skip
+        </button>
+        <button
+          onClick={connect}
+          disabled={saving || !isValid}
+          className="flex-1 py-3 bg-brand text-white font-semibold rounded-xl hover:opacity-90 transition disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          {saving ? 'Connecting...' : 'Connect BambooHR'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/onboarding/steps/CompletionStep.tsx
+++ b/frontend/src/onboarding/steps/CompletionStep.tsx
@@ -1,0 +1,82 @@
+interface SetupResult {
+  provider: string;
+  integrations: string[];
+}
+
+interface Props {
+  result: SetupResult;
+  onComplete: () => void;
+}
+
+const PROVIDER_NAMES: Record<string, string> = {
+  anthropic: 'Anthropic (Claude)',
+  openai: 'OpenAI (GPT)',
+  google: 'Google (Gemini)',
+};
+
+const INTEGRATION_NAMES: Record<string, string> = {
+  odoo: 'Odoo',
+  quickbooks: 'QuickBooks',
+  bamboohr: 'BambooHR',
+  crm_lite: 'CRM',
+};
+
+export function CompletionStep({ result, onComplete }: Props) {
+  return (
+    <div className="text-center">
+      <div className="w-16 h-16 bg-green-500/20 rounded-full flex items-center justify-center mx-auto mb-6">
+        <svg className="w-8 h-8 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+
+      <h2 className="text-xl font-bold text-white mb-2">You're all set!</h2>
+      <p className="text-gray-400 text-sm mb-8">
+        Here's what we connected:
+      </p>
+
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-5 mb-8 text-left">
+        <div className="space-y-3">
+          {/* Provider */}
+          <div className="flex items-center gap-3">
+            <div className="w-5 h-5 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0">
+              <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <span className="text-gray-300 text-sm">
+              AI Provider: <span className="text-white font-medium">{PROVIDER_NAMES[result.provider] || result.provider}</span>
+            </span>
+          </div>
+
+          {/* Integrations */}
+          {result.integrations.map(id => (
+            <div key={id} className="flex items-center gap-3">
+              <div className="w-5 h-5 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0">
+                <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <span className="text-gray-300 text-sm">
+                {INTEGRATION_NAMES[id] || id}
+              </span>
+            </div>
+          ))}
+
+          {result.integrations.length === 0 && (
+            <p className="text-gray-500 text-xs ml-8">
+              No integrations connected — you can add them anytime from Settings.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <button
+        onClick={onComplete}
+        className="w-full py-3 bg-brand text-white font-semibold rounded-xl hover:opacity-90 transition"
+      >
+        Go to Chatty
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/onboarding/steps/CrmLiteSetupStep.tsx
+++ b/frontend/src/onboarding/steps/CrmLiteSetupStep.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { api } from '../../core/api/client';
+
+interface Props {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+export function CrmLiteSetupStep({ onComplete, onSkip }: Props) {
+  const [enabling, setEnabling] = useState(false);
+  const [error, setError] = useState('');
+
+  async function enable() {
+    setEnabling(true);
+    setError('');
+    try {
+      await api('/api/integrations/crm_lite/setup', { method: 'POST' });
+      onComplete();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Setup failed');
+    } finally {
+      setEnabling(false);
+    }
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold text-white mb-2">Enable Built-in CRM</h2>
+      <p className="text-gray-400 text-sm mb-6">
+        Chatty includes a lightweight CRM — no external account needed. Your agents can manage contacts,
+        deals, tasks, and your sales pipeline.
+      </p>
+
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-5 mb-6">
+        <h3 className="text-white font-medium mb-3">What you get</h3>
+        <ul className="text-gray-400 text-sm space-y-2">
+          <li className="flex items-start gap-2">
+            <span className="text-indigo-400 mt-0.5">&#x2022;</span>
+            <span><span className="text-gray-300">Contacts</span> — store and search your contacts</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-indigo-400 mt-0.5">&#x2022;</span>
+            <span><span className="text-gray-300">Deals</span> — track opportunities and pipeline stages</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-indigo-400 mt-0.5">&#x2022;</span>
+            <span><span className="text-gray-300">Tasks</span> — manage follow-ups and to-dos</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-indigo-400 mt-0.5">&#x2022;</span>
+            <span><span className="text-gray-300">Activity log</span> — automatic tracking of interactions</span>
+          </li>
+        </ul>
+      </div>
+
+      {error && (
+        <div className="text-red-400 text-sm bg-red-900/20 rounded-lg px-4 py-3 mb-4">{error}</div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={onSkip}
+          className="flex-1 py-3 rounded-xl border border-gray-700 text-gray-400 hover:bg-gray-800 transition font-medium"
+        >
+          Skip
+        </button>
+        <button
+          onClick={enable}
+          disabled={enabling}
+          className="flex-1 py-3 bg-brand text-white font-semibold rounded-xl hover:opacity-90 transition disabled:opacity-50"
+        >
+          {enabling ? 'Enabling...' : 'Enable CRM'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/onboarding/steps/IntegrationPickerStep.tsx
+++ b/frontend/src/onboarding/steps/IntegrationPickerStep.tsx
@@ -1,0 +1,115 @@
+import { useState, useEffect } from 'react';
+import { api } from '../../core/api/client';
+import type { Integration } from '../../core/types';
+
+interface Props {
+  onComplete: (selectedIds: string[]) => void;
+  onSkip: () => void;
+}
+
+export function IntegrationPickerStep({ onComplete, onSkip }: Props) {
+  const [integrations, setIntegrations] = useState<Integration[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api<{ integrations: Integration[] }>('/api/integrations')
+      .then(data => {
+        // Only show integrations that aren't stubs and aren't already configured
+        const available = data.integrations.filter(
+          i => i.auth_type !== 'stub' && !i.configured
+        );
+        setIntegrations(available);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  function toggle(id: string) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="w-6 h-6 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold text-white mb-2">Connect Your Services</h2>
+      <p className="text-gray-400 text-sm mb-6">
+        Select the services you'd like to connect. Your agents will be able to use these to help you.
+        You can always set these up later in Settings.
+      </p>
+
+      {integrations.length === 0 ? (
+        <div className="text-center py-8">
+          <p className="text-gray-400">All integrations are already configured!</p>
+          <button
+            onClick={onSkip}
+            className="mt-4 w-full py-3 bg-brand text-white font-semibold rounded-xl hover:opacity-90 transition"
+          >
+            Continue to Chatty
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-2 mb-8">
+            {integrations.map(integration => {
+              const isSelected = selected.has(integration.id);
+              return (
+                <button
+                  key={integration.id}
+                  onClick={() => toggle(integration.id)}
+                  className={`w-full flex items-center gap-4 p-4 rounded-xl border transition text-left ${
+                    isSelected
+                      ? 'bg-indigo-500/10 border-indigo-500/50'
+                      : 'bg-gray-800 border-gray-700 hover:border-gray-600'
+                  }`}
+                >
+                  <div className={`w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0 transition ${
+                    isSelected ? 'bg-indigo-500 border-indigo-500' : 'border-gray-600'
+                  }`}>
+                    {isSelected && (
+                      <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                      </svg>
+                    )}
+                  </div>
+                  <span className="text-2xl">{integration.icon}</span>
+                  <div>
+                    <p className="text-white font-medium">{integration.name}</p>
+                    <p className="text-gray-400 text-xs mt-0.5">{integration.description}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              onClick={onSkip}
+              className="flex-1 py-3 rounded-xl border border-gray-700 text-gray-400 hover:bg-gray-800 transition font-medium"
+            >
+              Skip
+            </button>
+            <button
+              onClick={() => onComplete(Array.from(selected))}
+              disabled={selected.size === 0}
+              className="flex-1 py-3 bg-brand text-white font-semibold rounded-xl hover:opacity-90 transition disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              Set Up Selected
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/onboarding/steps/OdooSetupStep.tsx
+++ b/frontend/src/onboarding/steps/OdooSetupStep.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { api } from '../../core/api/client';
+
+interface Props {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+export function OdooSetupStep({ onComplete, onSkip }: Props) {
+  const [url, setUrl] = useState('');
+  const [database, setDatabase] = useState('');
+  const [username, setUsername] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  async function connect() {
+    setSaving(true);
+    setError('');
+    try {
+      await api('/api/integrations/odoo/setup', {
+        method: 'POST',
+        body: JSON.stringify({ url, database, username, api_key: apiKey }),
+      });
+      onComplete();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Connection failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const isValid = url.trim() && database.trim() && username.trim() && apiKey.trim();
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold text-white mb-2">Connect Odoo</h2>
+      <p className="text-gray-400 text-sm mb-6">
+        Connect your Odoo ERP to give your agents access to inventory, sales, accounting, and more.
+      </p>
+
+      <div className="space-y-4 mb-6">
+        {/* URL */}
+        <div>
+          <label className="block text-sm text-gray-300 mb-1.5">Odoo URL</label>
+          <input
+            value={url}
+            onChange={e => setUrl(e.target.value)}
+            placeholder="https://mycompany.odoo.com"
+            className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
+          />
+          <p className="text-gray-500 text-xs mt-1">Your Odoo instance URL</p>
+        </div>
+
+        {/* Database */}
+        <div>
+          <label className="block text-sm text-gray-300 mb-1.5">Database Name</label>
+          <input
+            value={database}
+            onChange={e => setDatabase(e.target.value)}
+            placeholder="mycompany-main"
+            className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
+          />
+          <div className="bg-gray-900 border border-dashed border-gray-700 rounded-lg p-3 mt-2 text-center">
+            <p className="text-gray-500 text-xs">Screenshot: Odoo Settings &rarr; Database Name (coming soon)</p>
+          </div>
+        </div>
+
+        {/* Username */}
+        <div>
+          <label className="block text-sm text-gray-300 mb-1.5">Username / Email</label>
+          <input
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            placeholder="admin@mycompany.com"
+            className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
+          />
+          <p className="text-gray-500 text-xs mt-1">The email you use to log into Odoo</p>
+        </div>
+
+        {/* API Key */}
+        <div>
+          <label className="block text-sm text-gray-300 mb-1.5">API Key</label>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={e => setApiKey(e.target.value)}
+            placeholder="Your Odoo API key"
+            className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
+          />
+          <div className="bg-gray-900 border border-dashed border-gray-700 rounded-lg p-3 mt-2 text-center">
+            <p className="text-gray-500 text-xs">Screenshot: Odoo Settings &rarr; Users &rarr; API Keys (coming soon)</p>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-red-400 text-sm bg-red-900/20 rounded-lg px-4 py-3 mb-4">{error}</div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={onSkip}
+          className="flex-1 py-3 rounded-xl border border-gray-700 text-gray-400 hover:bg-gray-800 transition font-medium"
+        >
+          Skip
+        </button>
+        <button
+          onClick={connect}
+          disabled={saving || !isValid}
+          className="flex-1 py-3 bg-brand text-white font-semibold rounded-xl hover:opacity-90 transition disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          {saving ? 'Connecting...' : 'Connect Odoo'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/onboarding/steps/ProviderStep.tsx
+++ b/frontend/src/onboarding/steps/ProviderStep.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from 'react';
+import { api } from '../../core/api/client';
+import type { ProviderStatus } from '../../core/types';
+import { ApiKeyEntry } from '../../setup/ApiKeyEntry';
+import { OAuthConnect } from '../../setup/OAuthConnect';
+
+interface Props {
+  onComplete: () => void;
+}
+
+const PROVIDERS = [
+  {
+    id: 'anthropic',
+    name: 'Anthropic (Claude)',
+    icon: '🤖',
+    authType: 'api_key' as const,
+    guidance: 'Create an API key at console.anthropic.com',
+    link: 'https://console.anthropic.com/settings/keys',
+    linkLabel: 'Open Anthropic Console',
+    note: 'Paste your API key below',
+  },
+  {
+    id: 'openai',
+    name: 'OpenAI (GPT)',
+    icon: '⚡',
+    authType: 'oauth' as const,
+    guidance: 'Sign in with your OpenAI account',
+    note: 'Covers GPT-4o and other ChatGPT models',
+  },
+  {
+    id: 'google',
+    name: 'Google (Gemini)',
+    icon: '✨',
+    authType: 'oauth' as const,
+    guidance: 'Sign in with your Google account',
+    note: 'Also enables Gmail + Google Calendar',
+  },
+];
+
+export function ProviderStep({ onComplete }: Props) {
+  const [status, setStatus] = useState<ProviderStatus | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  function reload() {
+    api<ProviderStatus>('/api/providers').then(setStatus).catch(console.error);
+  }
+
+  useEffect(() => { reload(); }, []);
+
+  const anyConnected = status
+    ? Object.values(status.profiles).some(p => p.configured)
+    : false;
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold text-white mb-2">Connect an AI Provider</h2>
+      <p className="text-gray-400 text-sm mb-6">
+        Your agents need an AI provider to work. Connect at least one to continue.
+      </p>
+
+      <div className="space-y-3 mb-8">
+        {PROVIDERS.map(p => {
+          const profile = status?.profiles?.[p.id];
+          const isConnected = profile?.configured ?? false;
+          const isExpanded = expanded === p.id;
+
+          return (
+            <div
+              key={p.id}
+              className={`bg-gray-800 rounded-xl border transition ${
+                isConnected
+                  ? 'border-green-500/40'
+                  : isExpanded
+                    ? 'border-indigo-500/50'
+                    : 'border-gray-700'
+              }`}
+            >
+              <button
+                onClick={() => !isConnected && setExpanded(isExpanded ? null : p.id)}
+                className="w-full p-4 flex items-center justify-between text-left"
+                disabled={isConnected}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl">{p.icon}</span>
+                  <div>
+                    <p className="text-white font-medium">{p.name}</p>
+                    <p className="text-gray-400 text-xs mt-0.5">{p.note}</p>
+                  </div>
+                </div>
+
+                {isConnected ? (
+                  <div className="flex items-center gap-2">
+                    <span className="w-2 h-2 bg-green-400 rounded-full" />
+                    <span className="text-green-400 text-xs font-medium">Connected</span>
+                  </div>
+                ) : (
+                  <span className={`text-gray-400 text-sm transition ${isExpanded ? 'rotate-180' : ''}`}>
+                    ▾
+                  </span>
+                )}
+              </button>
+
+              {isExpanded && !isConnected && (
+                <div className="px-4 pb-4 border-t border-gray-700 pt-4">
+                  <p className="text-gray-300 text-sm mb-3">{p.guidance}</p>
+
+                  {p.link && (
+                    <a
+                      href={p.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-indigo-400 text-sm hover:text-indigo-300 transition mb-4"
+                    >
+                      {p.linkLabel}
+                      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                      </svg>
+                    </a>
+                  )}
+
+                  {/* Placeholder for future screenshot */}
+                  <div className="bg-gray-900 border border-dashed border-gray-700 rounded-lg p-4 mb-4 text-center">
+                    <p className="text-gray-500 text-xs">Screenshot guide coming soon</p>
+                  </div>
+
+                  {p.authType === 'api_key' ? (
+                    <ApiKeyEntry provider={p.id} onConnected={reload} />
+                  ) : (
+                    <OAuthConnect provider={p.id} onConnected={reload} />
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        onClick={onComplete}
+        disabled={!anyConnected}
+        className="w-full py-3 bg-brand text-white font-semibold rounded-xl hover:opacity-90 transition disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        Continue
+      </button>
+
+      {!anyConnected && (
+        <p className="text-gray-500 text-xs text-center mt-3">
+          Connect at least one provider to continue
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/onboarding/steps/QuickBooksSetupStep.tsx
+++ b/frontend/src/onboarding/steps/QuickBooksSetupStep.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { api } from '../../core/api/client';
+
+interface Props {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+export function QuickBooksSetupStep({ onComplete, onSkip }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'waiting' | 'done' | 'error'>('idle');
+  const [error, setError] = useState('');
+
+  async function startOAuth() {
+    setLoading(true);
+    setError('');
+    setStatus('waiting');
+    try {
+      await api('/api/integrations/quickbooks/setup', { method: 'POST' });
+      setStatus('done');
+      onComplete();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Setup failed';
+      setError(msg);
+      setStatus('error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold text-white mb-2">Connect QuickBooks</h2>
+      <p className="text-gray-400 text-sm mb-6">
+        Connect QuickBooks Online to let your agents access invoices, bills, payments, and financial reports.
+      </p>
+
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-5 mb-6">
+        <h3 className="text-white font-medium mb-2">How it works</h3>
+        <ol className="text-gray-400 text-sm space-y-2 list-decimal list-inside">
+          <li>Click "Connect QuickBooks" below</li>
+          <li>A browser window will open to Intuit's login page</li>
+          <li>Sign in and authorize Chatty to access your QuickBooks data</li>
+          <li>You'll be redirected back automatically</li>
+        </ol>
+      </div>
+
+      {status === 'waiting' && (
+        <div className="flex items-center gap-3 text-sm text-indigo-300 bg-indigo-900/20 rounded-lg px-4 py-3 mb-4">
+          <div className="w-4 h-4 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin flex-shrink-0" />
+          <span>Browser opened — complete authorization to continue...</span>
+        </div>
+      )}
+
+      {status === 'done' && (
+        <div className="text-sm text-green-400 bg-green-900/20 rounded-lg px-4 py-3 mb-4">
+          Connected successfully!
+        </div>
+      )}
+
+      {error && (
+        <div className="text-red-400 text-sm bg-red-900/20 rounded-lg px-4 py-3 mb-4">{error}</div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={onSkip}
+          className="flex-1 py-3 rounded-xl border border-gray-700 text-gray-400 hover:bg-gray-800 transition font-medium"
+        >
+          Skip
+        </button>
+        {status !== 'done' && (
+          <button
+            onClick={startOAuth}
+            disabled={loading}
+            className="flex-1 py-3 bg-brand text-white font-semibold rounded-xl hover:opacity-90 transition disabled:opacity-50 flex items-center justify-center gap-2"
+          >
+            {loading ? (
+              <>
+                <div className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                Waiting...
+              </>
+            ) : (
+              'Connect QuickBooks'
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/setup/ProviderSetup.tsx
+++ b/frontend/src/setup/ProviderSetup.tsx
@@ -1,20 +1,9 @@
 import { useState, useEffect } from 'react';
 import { api } from '../core/api/client';
+import type { ProviderStatus } from '../core/types';
 import { ApiKeyEntry } from './ApiKeyEntry';
 import { OAuthConnect } from './OAuthConnect';
 import { ModelSelector } from './ModelSelector';
-
-// Matches CredentialStore.to_dict() response shape
-interface ProviderStatus {
-  active_provider: string;
-  active_model: string;
-  profiles: Record<string, {
-    type: string;
-    configured: boolean;
-    key_preview?: string;
-    expired?: boolean;
-  }>;
-}
 
 export function ProviderSetup() {
   const [status, setStatus] = useState<ProviderStatus | null>(null);


### PR DESCRIPTION
## Summary
- Adds a step-by-step onboarding wizard at `/setup` that walks new users through connecting an AI provider and optionally setting up service integrations (Odoo, QuickBooks, BambooHR, CRM)
- Dashboard auto-redirects to `/setup` when no AI provider is configured (first-run detection)
- Reuses existing `ApiKeyEntry` and `OAuthConnect` components inside guided wizard steps with instruction text and screenshot placeholders

## Test plan
- [ ] Clear `data/auth-profiles.json`, log in — should redirect to `/setup`
- [ ] Connect an Anthropic API key — green checkmark appears, Continue button enables
- [ ] Select integrations and walk through each setup form
- [ ] Click "Skip" on integration picker — goes straight to dashboard
- [ ] Refresh after provider connected — dashboard loads normally (no redirect)
- [ ] Verify `npx tsc --noEmit` and `npx vite build` pass cleanly