### PR TITLE
Port CAKE OS calendar fix and BambooHR enhancements

### DIFF
--- a/backend/core/calendar_client.py
+++ b/backend/core/calendar_client.py
@@ -79,11 +79,12 @@ def get_event(service, event_id: str, calendar_id: str = "primary") -> dict:
 
 
 def search_events(service, query: str, time_min: str | None = None,
-                  time_max: str | None = None, max_results: int = 20) -> list[dict]:
+                  time_max: str | None = None, max_results: int = 20,
+                  calendar_id: str = "primary") -> list[dict]:
     """Search calendar events by text query."""
     try:
         kwargs = {
-            "calendarId": "primary",
+            "calendarId": calendar_id,
             "q": query,
             "maxResults": max_results,
             "singleEvents": True,

--- a/backend/integrations/bamboohr/client.py
+++ b/backend/integrations/bamboohr/client.py
@@ -68,6 +68,65 @@ class BambooHRClient:
             logger.error("BambooHR get_employee error: %s", e)
             return {"error": str(e)}
 
+    def api_request(
+        self,
+        method: str,
+        path: str,
+        params: dict | None = None,
+        body: dict | None = None,
+        timeout: int = 30,
+    ) -> dict:
+        """Execute an arbitrary BambooHR API request.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE, PATCH).
+            path: API path (e.g. "/api/v1/time_off/whos_out").
+                  The /api/v1 prefix is mapped to the client's base URL.
+            params: Query parameters.
+            body: JSON request body (for POST/PUT/PATCH).
+            timeout: Request timeout in seconds.
+
+        Returns:
+            Dict with 'ok' (bool), 'status_code' (int), and 'data' (parsed JSON or raw text).
+        """
+        import re
+
+        method = method.upper()
+        if method not in ("GET", "POST", "PUT", "DELETE", "PATCH"):
+            return {"ok": False, "status_code": 0, "data": f"Invalid HTTP method: {method}"}
+
+        # Map OpenAPI spec paths (/api/v1/...) to the client's base URL
+        stripped = re.sub(r"^/api/v1(?:_\d+)?", "", path)
+        url = f"{self.base_url}{stripped}"
+
+        headers = {"Accept": "application/json"}
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+
+        try:
+            resp = httpx.request(
+                method,
+                url,
+                auth=self._auth,
+                headers=headers,
+                params=params,
+                json=body if body is not None else None,
+                timeout=timeout,
+            )
+            ok = 200 <= resp.status_code < 300
+            try:
+                data = resp.json()
+            except Exception:
+                data = resp.text
+            if not ok:
+                logger.warning(
+                    "BambooHR API %s %s returned %s", method, path, resp.status_code
+                )
+            return {"ok": ok, "status_code": resp.status_code, "data": data}
+        except Exception as e:
+            logger.error("BambooHR API request failed: %s %s — %s", method, path, e)
+            return {"ok": False, "status_code": 0, "data": str(e)}
+
     def get_time_off_requests(
         self, start_date: str, end_date: str, status: str = "approved"
     ) -> list[dict]:

--- a/backend/integrations/bamboohr/client.py
+++ b/backend/integrations/bamboohr/client.py
@@ -6,6 +6,8 @@ Credentials loaded from data/integrations/bamboohr.json.
 """
 
 import logging
+import re
+
 import httpx
 
 logger = logging.getLogger(__name__)
@@ -89,8 +91,6 @@ class BambooHRClient:
         Returns:
             Dict with 'ok' (bool), 'status_code' (int), and 'data' (parsed JSON or raw text).
         """
-        import re
-
         method = method.upper()
         if method not in ("GET", "POST", "PUT", "DELETE", "PATCH"):
             return {"ok": False, "status_code": 0, "data": f"Invalid HTTP method: {method}"}

--- a/backend/integrations/bamboohr/tools.py
+++ b/backend/integrations/bamboohr/tools.py
@@ -1,12 +1,22 @@
-"""Chatty — BambooHR agent tools."""
+"""Chatty — BambooHR agent tools.
+
+Curated high-value tools (employee name resolution, formatted output) plus
+a generic tool for full BambooHR API coverage.
+"""
 
 from .client import get_client
 
 BAMBOOHR_TOOL_DEFS = [
     {
         "name": "bamboohr_get_directory",
-        "description": "Get the BambooHR employee directory — names, titles, departments.",
-        "input_schema": {"type": "object", "properties": {}, "required": []},
+        "description": "Get the BambooHR employee directory — names, titles, departments. Optionally filter by department.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "department": {"type": "string", "description": "Filter by department name (case-insensitive partial match)"},
+            },
+            "required": [],
+        },
         "kind": "integration",
     },
     {
@@ -21,6 +31,77 @@ BAMBOOHR_TOOL_DEFS = [
         },
         "kind": "integration",
     },
+    {
+        "name": "bamboohr_get_employee_details",
+        "description": "Get a full employee profile by name. Resolves name to ID automatically.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "employee_name": {"type": "string", "description": "Employee name (first, last, or full)"},
+                "fields": {"type": "string", "description": "Comma-separated field names to return. Defaults to a broad set of common fields."},
+            },
+            "required": ["employee_name"],
+        },
+        "kind": "integration",
+    },
+    {
+        "name": "bamboohr_whos_out",
+        "description": "Check who is out of office today or in a date range.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (defaults to today)"},
+                "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+            },
+            "required": [],
+        },
+        "kind": "integration",
+    },
+    {
+        "name": "bamboohr_get_time_off_requests",
+        "description": "List time-off requests for a date range, optionally filtered by employee name or status.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
+                "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+                "employee_name": {"type": "string", "description": "Filter by employee name"},
+                "status": {"type": "string", "description": "Filter by status (approved, denied, cancelled, requested)"},
+            },
+            "required": ["start_date", "end_date"],
+        },
+        "kind": "integration",
+    },
+    {
+        "name": "bamboohr_get_time_off_balance",
+        "description": "Check an employee's PTO/time-off balance by name.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "employee_name": {"type": "string", "description": "Employee name"},
+                "end_date": {"type": "string", "description": "Balance as of this date (YYYY-MM-DD, defaults to today)"},
+            },
+            "required": ["employee_name"],
+        },
+        "kind": "integration",
+    },
+    {
+        "name": "bamboohr_api_request",
+        "description": "Execute any BambooHR API request. Use for endpoints not covered by other tools. Common paths: /api/v1/employees/directory, /api/v1/time_off/whos_out, /api/v1/employees/{id}.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "method": {"type": "string", "description": "HTTP method (GET, POST, PUT, DELETE)", "enum": ["GET", "POST", "PUT", "DELETE"]},
+                "path": {"type": "string", "description": "API path (e.g. /api/v1/time_off/whos_out)"},
+                "params": {"type": "object", "description": "Query parameters"},
+                "body": {"type": "object", "description": "JSON request body (for POST/PUT)"},
+                "path_params": {"type": "object", "description": "Path parameter substitutions for {placeholders}"},
+            },
+            "required": ["method", "path"],
+        },
+        "kind": "integration",
+    },
+    # Keep legacy tool name for backwards compatibility
     {
         "name": "bamboohr_get_time_off",
         "description": "Get approved time-off requests for a date range.",
@@ -37,12 +118,82 @@ BAMBOOHR_TOOL_DEFS = [
 ]
 
 
-def bamboohr_get_directory() -> dict:
+# ── Employee name resolution ─────────────────────────────────────────────
+
+
+def _resolve_employee(employee_name: str) -> tuple[dict | None, dict | None]:
+    """Resolve an employee name to a directory entry.
+
+    Uses the BambooHR directory API (no external dependencies).
+
+    Returns (employee_dict, None) on unique match,
+    or (None, error_dict) if ambiguous or not found.
+    """
+    client = get_client()
+    if not client:
+        return None, {"error": "BambooHR not configured or unavailable"}
+
+    employees = client.get_employee_directory()
+    if not employees:
+        return None, {"error": "Could not fetch employee directory"}
+
+    name_lower = employee_name.strip().lower()
+
+    # Exact match on displayName
+    exact = [e for e in employees if (e.get("displayName", "") or "").lower() == name_lower]
+    if len(exact) == 1:
+        return exact[0], None
+
+    # Fuzzy: all query words appear in the display name
+    fuzzy = [
+        e for e in employees
+        if all(word in (e.get("displayName", "") or "").lower() for word in name_lower.split())
+    ]
+    if len(fuzzy) == 1:
+        return fuzzy[0], None
+    if len(fuzzy) > 1:
+        names = [
+            f"{e.get('displayName', '')} (ID {e.get('id', '')}, {e.get('department', '')})"
+            for e in fuzzy
+        ]
+        return None, {
+            "error": f"Multiple employees match '{employee_name}'. Please be more specific.",
+            "matches": names,
+        }
+
+    return None, {"error": f"Could not find employee matching '{employee_name}'"}
+
+
+# ── Tool handlers ─────────────────────────────────────────────────────────
+
+
+def bamboohr_get_directory(department: str | None = None) -> dict:
     client = get_client()
     if not client:
         return {"error": "BambooHR not configured or unavailable"}
     employees = client.get_employee_directory()
-    return {"employees": employees, "count": len(employees)}
+
+    if department:
+        dept_lower = department.lower()
+        employees = [
+            e for e in employees
+            if dept_lower in (e.get("department", "") or "").lower()
+        ]
+
+    condensed = []
+    for e in employees:
+        condensed.append({
+            "id": e.get("id", ""),
+            "displayName": e.get("displayName", ""),
+            "firstName": e.get("firstName", ""),
+            "lastName": e.get("lastName", ""),
+            "jobTitle": e.get("jobTitle", ""),
+            "department": e.get("department", ""),
+            "location": e.get("location", ""),
+            "workEmail": e.get("workEmail", ""),
+        })
+
+    return {"employees": condensed, "count": len(condensed)}
 
 
 def bamboohr_get_employee(employee_id: str) -> dict:
@@ -52,16 +203,179 @@ def bamboohr_get_employee(employee_id: str) -> dict:
     return client.get_employee(employee_id)
 
 
-def bamboohr_get_time_off(start_date: str, end_date: str) -> dict:
+def bamboohr_get_employee_details(
+    employee_name: str, fields: str | None = None,
+) -> dict:
+    emp, err = _resolve_employee(employee_name)
+    if err:
+        return err
+
     client = get_client()
     if not client:
         return {"error": "BambooHR not configured or unavailable"}
-    requests = client.get_time_off_requests(start_date, end_date)
+
+    params: dict = {}
+    if fields:
+        params["fields"] = fields
+    else:
+        params["fields"] = (
+            "firstName,lastName,preferredName,displayName,jobTitle,department,"
+            "division,location,workEmail,workPhone,mobilePhone,hireDate,"
+            "status,employmentHistoryStatus,supervisor,dateOfBirth,"
+            "address1,city,state,zip"
+        )
+
+    emp_id = emp.get("id", "")
+    path = f"/api/v1/employees/{emp_id}"
+    result = client.api_request("GET", path, params=params)
+    if not result["ok"]:
+        return {"error": f"BambooHR API error: {result['status_code']}", "detail": result["data"]}
+
+    return {
+        "employee": emp.get("displayName", ""),
+        "employee_id": emp_id,
+        "details": result["data"],
+    }
+
+
+def bamboohr_whos_out(
+    start_date: str | None = None, end_date: str | None = None,
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "BambooHR not configured or unavailable"}
+
+    params: dict = {}
+    if start_date:
+        params["start"] = start_date
+    if end_date:
+        params["end"] = end_date
+
+    result = client.api_request("GET", "/api/v1/time_off/whos_out", params=params)
+    if not result["ok"]:
+        return {"error": f"BambooHR API error: {result['status_code']}", "detail": result["data"]}
+
+    data = result["data"]
+    if not isinstance(data, list):
+        return {"entries": [], "message": "No one is out for this period"}
+
+    entries = []
+    for item in data:
+        entries.append({
+            "type": item.get("type", ""),
+            "name": item.get("name", ""),
+            "start": item.get("start", ""),
+            "end": item.get("end", ""),
+        })
+
+    return {"entries": entries, "count": len(entries)}
+
+
+def bamboohr_get_time_off_requests(
+    start_date: str,
+    end_date: str,
+    employee_name: str | None = None,
+    status: str | None = None,
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "BambooHR not configured or unavailable"}
+
+    params: dict = {"start": start_date, "end": end_date}
+    if status:
+        params["status"] = status
+
+    if employee_name:
+        emp, err = _resolve_employee(employee_name)
+        if err:
+            return err
+        params["employeeId"] = emp.get("id", "")
+
+    result = client.api_request("GET", "/api/v1/time_off/requests", params=params)
+    if not result["ok"]:
+        return {"error": f"BambooHR API error: {result['status_code']}", "detail": result["data"]}
+
+    data = result["data"]
+    if not isinstance(data, list):
+        data = []
+
+    requests = []
+    for req in data:
+        requests.append({
+            "id": req.get("id", ""),
+            "employee_name": req.get("name", ""),
+            "status": req.get("status", {}).get("status", "") if isinstance(req.get("status"), dict) else req.get("status", ""),
+            "type": req.get("type", {}).get("name", "") if isinstance(req.get("type"), dict) else req.get("type", ""),
+            "start": req.get("start", ""),
+            "end": req.get("end", ""),
+            "notes": req.get("notes", {}).get("employee", "") if isinstance(req.get("notes"), dict) else "",
+            "amount": req.get("amount", {}).get("amount", "") if isinstance(req.get("amount"), dict) else req.get("amount", ""),
+        })
+
     return {"requests": requests, "count": len(requests)}
 
 
+def bamboohr_get_time_off_balance(
+    employee_name: str, end_date: str | None = None,
+) -> dict:
+    from datetime import date
+
+    emp, err = _resolve_employee(employee_name)
+    if err:
+        return err
+
+    client = get_client()
+    if not client:
+        return {"error": "BambooHR not configured or unavailable"}
+
+    end = end_date or date.today().isoformat()
+    emp_id = emp.get("id", "")
+    path = f"/api/v1/employees/{emp_id}/time_off/calculator"
+    result = client.api_request("GET", path, params={"end": end})
+    if not result["ok"]:
+        return {"error": f"BambooHR API error: {result['status_code']}", "detail": result["data"]}
+
+    return {
+        "employee": emp.get("displayName", ""),
+        "employee_id": emp_id,
+        "as_of": end,
+        "balances": result["data"],
+    }
+
+
+def bamboohr_get_time_off(start_date: str, end_date: str) -> dict:
+    """Legacy wrapper — delegates to the richer get_time_off_requests."""
+    return bamboohr_get_time_off_requests(start_date, end_date)
+
+
+def bamboohr_api_request(
+    method: str,
+    path: str,
+    params: dict | None = None,
+    body: dict | None = None,
+    path_params: dict | None = None,
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "BambooHR not configured or unavailable"}
+
+    if path_params:
+        for key, value in path_params.items():
+            path = path.replace(f"{{{key}}}", str(value))
+
+    if "{" in path:
+        return {"error": f"Unresolved path parameters in '{path}'. Provide path_params for all {{placeholders}}."}
+
+    return client.api_request(method, path, params=params, body=body)
+
+
 TOOL_EXECUTORS = {
-    "bamboohr_get_directory": lambda **kw: bamboohr_get_directory(),
+    "bamboohr_get_directory": lambda **kw: bamboohr_get_directory(**kw),
     "bamboohr_get_employee": lambda **kw: bamboohr_get_employee(**kw),
+    "bamboohr_get_employee_details": lambda **kw: bamboohr_get_employee_details(**kw),
+    "bamboohr_whos_out": lambda **kw: bamboohr_whos_out(**kw),
+    "bamboohr_get_time_off_requests": lambda **kw: bamboohr_get_time_off_requests(**kw),
+    "bamboohr_get_time_off_balance": lambda **kw: bamboohr_get_time_off_balance(**kw),
+    "bamboohr_api_request": lambda **kw: bamboohr_api_request(**kw),
     "bamboohr_get_time_off": lambda **kw: bamboohr_get_time_off(**kw),
 }

--- a/backend/integrations/bamboohr/tools.py
+++ b/backend/integrations/bamboohr/tools.py
@@ -4,6 +4,8 @@ Curated high-value tools (employee name resolution, formatted output) plus
 a generic tool for full BambooHR API coverage.
 """
 
+from datetime import date
+
 from .client import get_client
 
 BAMBOOHR_TOOL_DEFS = [
@@ -318,8 +320,6 @@ def bamboohr_get_time_off_requests(
 def bamboohr_get_time_off_balance(
     employee_name: str, end_date: str | None = None,
 ) -> dict:
-    from datetime import date
-
     emp, err = _resolve_employee(employee_name)
     if err:
         return err


### PR DESCRIPTION
## Summary
- **Calendar bug fix**: `search_events()` now respects the `calendar_id` parameter instead of hardcoding `"primary"` — agents can search non-primary calendars (shared, family, team)
- **BambooHR client**: Added generic `api_request()` method for arbitrary BambooHR API calls
- **BambooHR tools**: 5 new tools (who's out, time-off requests with name/status filters, PTO balance, employee details by name, generic API request) plus department filter on directory and employee name resolution helper

## Test plan
- [ ] Verify `search_events` passes `calendar_id` through the full chain: tool_definitions → tool_registry → calendar_tools → calendar_client
- [ ] Test `bamboohr_whos_out` with no args and with date range
- [ ] Test `bamboohr_get_time_off_requests` with employee name and status filters
- [ ] Test `bamboohr_get_time_off_balance` with an employee name
- [ ] Test `bamboohr_get_employee_details` with partial and full names
- [ ] Test `bamboohr_api_request` with a known endpoint
- [ ] Test `bamboohr_get_directory` with department filter
- [ ] Verify existing tools (`bamboohr_get_employee`, `bamboohr_get_time_off`) still work