### PR TITLE
Onboarding wizard + multi-provider auth with ChatGPT proxy

### DIFF
--- a/backend/chatgpt-proxy/package.json
+++ b/backend/chatgpt-proxy/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "chatty-chatgpt-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Node.js sidecar that proxies OpenAI-format requests through pi-ai to ChatGPT's backend API",
+  "dependencies": {
+    "@mariozechner/pi-ai": "0.63.0"
+  }
+}

--- a/backend/chatgpt-proxy/server.mjs
+++ b/backend/chatgpt-proxy/server.mjs
@@ -1,0 +1,241 @@
+/**
+ * ChatGPT Proxy Sidecar
+ *
+ * A minimal HTTP server that accepts OpenAI-format chat completion requests
+ * and forwards them through pi-ai to ChatGPT's backend API using a ChatGPT
+ * OAuth token (from the Codex CLI).
+ *
+ * Endpoints:
+ *   POST /v1/chat/completions  — proxied chat completion (streaming SSE)
+ *   POST /v1/validate          — validate a ChatGPT token
+ *   GET  /health               — health check
+ *
+ * The Python backend calls this instead of chatgpt.com directly.
+ */
+
+import { createServer } from "node:http";
+import { streamSimple, getModel } from "@mariozechner/pi-ai";
+
+const PORT = parseInt(process.env.CHATGPT_PROXY_PORT || "9877", 10);
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+// Codex-compatible model IDs (standard GPT models aren't supported with ChatGPT tokens)
+const CODEX_MODELS = ["gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2-codex"];
+const DEFAULT_CODEX_MODEL = "gpt-5.4";
+
+/**
+ * Map standard model names to Codex equivalents.
+ */
+function resolveModelId(requestedModel) {
+  if (CODEX_MODELS.includes(requestedModel)) return requestedModel;
+  // Map common model names to the default codex model
+  return DEFAULT_CODEX_MODEL;
+}
+
+/**
+ * Build a pi-ai model object for the ChatGPT backend.
+ */
+function buildCodexModel(modelId) {
+  const base = getModel("openai", "gpt-4o");
+  return {
+    ...base,
+    id: modelId,
+    provider: "openai-codex",
+    api: "openai-codex-responses",
+    baseUrl: "https://chatgpt.com/backend-api",
+  };
+}
+
+/**
+ * Convert OpenAI messages format to pi-ai messages format.
+ */
+function convertMessages(openaiMessages) {
+  return openaiMessages
+    .filter((m) => m.role === "user" || m.role === "assistant")
+    .map((m) => ({
+      role: m.role,
+      content:
+        typeof m.content === "string"
+          ? [{ type: "text", text: m.content }]
+          : m.content,
+    }));
+}
+
+/**
+ * Handle POST /v1/chat/completions
+ * Accepts standard OpenAI chat completion request, streams back SSE.
+ */
+async function handleChatCompletions(req, res, body) {
+  const token = (req.headers.authorization || "").replace("Bearer ", "");
+  if (!token) {
+    res.writeHead(401, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Missing Authorization header" }));
+    return;
+  }
+
+  const modelId = resolveModelId(body.model || "gpt-4o");
+  const model = buildCodexModel(modelId);
+
+  const systemPrompt =
+    body.messages?.find((m) => m.role === "system")?.content ||
+    "You are a helpful assistant.";
+  const messages = convertMessages(
+    body.messages?.filter((m) => m.role !== "system") || [],
+  );
+
+  // Stream SSE response
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+
+  try {
+    const stream = streamSimple(
+      model,
+      {
+        systemPrompt,
+        messages,
+      },
+      {
+        apiKey: token,
+        maxTokens: body.max_tokens || 16384,
+        temperature: body.temperature,
+      },
+    );
+
+    for await (const event of stream) {
+      if (event.type === "text_delta") {
+        const chunk = {
+          choices: [
+            {
+              index: 0,
+              delta: { content: event.delta },
+              finish_reason: null,
+            },
+          ],
+        };
+        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      } else if (event.type === "done") {
+        const chunk = {
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        };
+        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        res.write("data: [DONE]\n\n");
+      }
+    }
+  } catch (err) {
+    const errorChunk = {
+      error: { message: err.message || "Stream error" },
+    };
+    res.write(`data: ${JSON.stringify(errorChunk)}\n\n`);
+    res.write("data: [DONE]\n\n");
+  }
+
+  res.end();
+}
+
+/**
+ * Handle POST /v1/validate
+ * Quick validation that the token works by making a minimal request.
+ */
+async function handleValidate(req, res, body) {
+  const token = body.token;
+  if (!token) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ valid: false, error: "No token provided" }));
+    return;
+  }
+
+  const model = buildCodexModel(DEFAULT_CODEX_MODEL);
+
+  try {
+    const stream = streamSimple(
+      model,
+      {
+        systemPrompt: "You are a helpful assistant.",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "hi" }] },
+        ],
+      },
+      { apiKey: token, maxTokens: 1, transport: "sse" },
+    );
+
+    // Consume just enough to confirm it works
+    for await (const event of stream) {
+      if (event.type === "text_delta" || event.type === "done") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ valid: true }));
+        return;
+      }
+    }
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ valid: true }));
+  } catch (err) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({ valid: false, error: err.message || "Validation failed" }),
+    );
+  }
+}
+
+const server = createServer(async (req, res) => {
+  // CORS for local dev
+  res.setHeader("Access-Control-Allow-Origin", "*");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok", service: "chatgpt-proxy" }));
+    return;
+  }
+
+  if (req.method !== "POST") {
+    res.writeHead(405, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Method not allowed" }));
+    return;
+  }
+
+  try {
+    const body = await parseBody(req);
+
+    if (req.url === "/v1/chat/completions") {
+      await handleChatCompletions(req, res, body);
+    } else if (req.url === "/v1/validate") {
+      await handleValidate(req, res, body);
+    } else {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+    }
+  } catch (err) {
+    console.error("Request error:", err);
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: err.message || "Internal error" }));
+    }
+  }
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`ChatGPT proxy sidecar listening on http://127.0.0.1:${PORT}`);
+});

--- a/backend/core/providers/__init__.py
+++ b/backend/core/providers/__init__.py
@@ -29,15 +29,42 @@ def get_ai_provider(agent_provider: str | None = None, agent_model: str | None =
 
     if profile_name.startswith("anthropic:"):
         from core.providers.anthropic_provider import AnthropicProvider
+        if profile.get("type") == "setup_token":
+            return AnthropicProvider(api_key=profile.get("token", ""), model=model or "claude-opus-4-6")
         return AnthropicProvider(api_key=profile.get("key", ""), model=model or "claude-opus-4-6")
 
     elif profile_name.startswith("openai:"):
         from core.providers.openai_provider import OpenAIProvider
+        if profile.get("type") == "api_key":
+            return OpenAIProvider(access_token=profile.get("key", ""), model=model or "gpt-4o")
+        if profile.get("type") == "chatgpt_oauth":
+            access_token = profile.get("access", "")
+            # Refresh token if expired
+            if store.is_token_expired("openai"):
+                try:
+                    import asyncio
+                    from core.providers.chatgpt_refresh import refresh_chatgpt_token
+                    tokens = asyncio.get_event_loop().run_until_complete(
+                        refresh_chatgpt_token(profile.get("refresh", ""))
+                    )
+                    access_token = tokens["access_token"]
+                    store.set_chatgpt_oauth(
+                        access_token=tokens["access_token"],
+                        refresh_token=tokens["refresh_token"],
+                        expires_in=tokens["expires_in"],
+                        model=model or "gpt-4o",
+                    )
+                except Exception as e:
+                    import logging
+                    logging.getLogger(__name__).warning("ChatGPT token refresh failed: %s", e)
+            return OpenAIProvider(access_token=access_token, model=model or "gpt-4o", use_chatgpt_api=True)
         access_token = profile.get("access", "")
         return OpenAIProvider(access_token=access_token, model=model or "gpt-4o")
 
     elif profile_name.startswith("google:"):
         from core.providers.google_provider import GoogleProvider
+        if profile.get("type") == "api_key":
+            return GoogleProvider(api_key=profile.get("key", ""), model=model or "gemini-2.0-flash-exp")
         access_token = profile.get("access", "")
         return GoogleProvider(access_token=access_token, model=model or "gemini-2.0-flash-exp")
 

--- a/backend/core/providers/anthropic_provider.py
+++ b/backend/core/providers/anthropic_provider.py
@@ -21,9 +21,10 @@ ANTHROPIC_MODELS = [
 
 
 class AnthropicProvider(AIProvider):
-    def __init__(self, api_key: str, model: str = "claude-opus-4-6"):
+    def __init__(self, api_key: str = "", auth_token: str = "", model: str = "claude-opus-4-6"):
         super().__init__(model=model)
         self.api_key = api_key
+        self.auth_token = auth_token
 
     @property
     def provider_name(self) -> str:
@@ -46,7 +47,10 @@ class AnthropicProvider(AIProvider):
         tools: list[dict],
         system_prompt: str,
     ) -> AsyncGenerator[dict, None]:
-        client = anthropic.AsyncAnthropic(api_key=self.api_key)
+        client = anthropic.AsyncAnthropic(
+            api_key=self.api_key or None,
+            auth_token=self.auth_token or None,
+        )
         anthropic_tools = self._format_tools(tools)
 
         # Convert messages: filter to user/assistant only
@@ -157,8 +161,18 @@ class AnthropicProvider(AIProvider):
 
     async def validate(self) -> bool:
         try:
-            client = anthropic.Anthropic(api_key=self.api_key)
-            client.models.list()
+            client = anthropic.Anthropic(
+                api_key=self.api_key or None,
+                auth_token=self.auth_token or None,
+            )
+            # Use messages.create — works with both API keys and OAuth tokens
+            # (models.list rejects OAuth tokens passed as api_key)
+            client.messages.create(
+                model="claude-haiku-4-5-20251001",
+                max_tokens=1,
+                messages=[{"role": "user", "content": "hi"}],
+            )
             return True
-        except Exception:
+        except Exception as e:
+            logger.error("Anthropic validation failed: %s", e)
             return False

--- a/backend/core/providers/chatgpt_refresh.py
+++ b/backend/core/providers/chatgpt_refresh.py
@@ -1,0 +1,49 @@
+"""
+Chatty — ChatGPT OAuth token refresh.
+
+Refreshes expired ChatGPT OAuth tokens using the Codex CLI's registered
+client ID at auth.openai.com/oauth/token.
+"""
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Codex CLI's registered OAuth client ID (public, embedded in the CLI)
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+TOKEN_URL = "https://auth.openai.com/oauth/token"
+
+
+async def refresh_chatgpt_token(refresh_token: str) -> dict:
+    """
+    Exchange a ChatGPT refresh token for a new access token.
+
+    Returns:
+        {"access_token": str, "refresh_token": str, "expires_in": int}
+
+    Raises:
+        ValueError on failure.
+    """
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            TOKEN_URL,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": CODEX_CLIENT_ID,
+            },
+            timeout=15,
+        )
+
+        if resp.status_code != 200:
+            logger.error("ChatGPT token refresh failed: %s %s", resp.status_code, resp.text[:200])
+            raise ValueError(f"Token refresh failed (HTTP {resp.status_code})")
+
+        data = resp.json()
+        return {
+            "access_token": data["access_token"],
+            "refresh_token": data.get("refresh_token", refresh_token),
+            "expires_in": data.get("expires_in", 864000),
+        }

--- a/backend/core/providers/credentials.py
+++ b/backend/core/providers/credentials.py
@@ -8,8 +8,10 @@ Schema:
     "active_provider": "anthropic" | "openai" | "google",
     "active_model": "claude-opus-4-6",
     "profiles": {
-        "anthropic:default": {"type": "api_key", "key": "sk-ant-..."},
-        "openai:default":    {"type": "oauth", "access": "...", "refresh": "...", "expires": 1234567890},
+        "anthropic:default": {"type": "api_key", "key": "sk-ant-..."}
+                           | {"type": "setup_token", "token": "..."},
+        "openai:default":    {"type": "api_key", "key": "sk-..."}
+                           | {"type": "oauth", "access": "...", "refresh": "...", "expires": 1234567890},
         "google:default":    {"type": "oauth", "access": "...", "refresh": "...", "expires": 1234567890}
     }
 }
@@ -27,7 +29,7 @@ PROFILES_PATH = DATA_DIR / "auth-profiles.json"
 
 PROVIDER_DEFAULTS = {
     "anthropic": "claude-opus-4-6",
-    "openai": "gpt-4o",
+    "openai": "gpt-5.4",
     "google": "gemini-2.0-flash-exp",
 }
 
@@ -71,7 +73,41 @@ class CredentialStore:
                 return True
             if p.get("type") == "oauth" and p.get("access"):
                 return True
+            if p.get("type") == "setup_token" and p.get("token"):
+                return True
+            if p.get("type") == "chatgpt_oauth" and p.get("access"):
+                return True
         return False
+
+    def set_chatgpt_oauth(
+        self,
+        access_token: str,
+        refresh_token: str,
+        expires_in: int,
+        model: str | None = None,
+    ):
+        """Store ChatGPT OAuth tokens (from Codex CLI) and set OpenAI as active."""
+        if "profiles" not in self.data:
+            self.data["profiles"] = {}
+        self.data["profiles"]["openai:default"] = {
+            "type": "chatgpt_oauth",
+            "access": access_token,
+            "refresh": refresh_token,
+            "expires": int(time.time()) + expires_in,
+        }
+        self.data["active_provider"] = "openai"
+        self.data["active_model"] = model or PROVIDER_DEFAULTS.get("openai", "")
+        self._save()
+
+    def set_setup_token(self, provider: str, token: str, model: str | None = None):
+        """Store a setup-token (e.g. from `claude setup-token`) and set as active."""
+        profile_name = f"{provider}:default"
+        if "profiles" not in self.data:
+            self.data["profiles"] = {}
+        self.data["profiles"][profile_name] = {"type": "setup_token", "token": token}
+        self.data["active_provider"] = provider
+        self.data["active_model"] = model or PROVIDER_DEFAULTS.get(provider, "")
+        self._save()
 
     def set_api_key(self, provider: str, key: str, model: str | None = None):
         """Store an API key for the given provider and set it as active."""
@@ -147,6 +183,17 @@ class CredentialStore:
             elif p.get("type") == "oauth":
                 profiles[provider] = {
                     "type": "oauth",
+                    "configured": bool(p.get("access")),
+                    "expired": self.is_token_expired(provider),
+                }
+            elif p.get("type") == "setup_token":
+                profiles[provider] = {
+                    "type": "setup_token",
+                    "configured": bool(p.get("token")),
+                }
+            elif p.get("type") == "chatgpt_oauth":
+                profiles[provider] = {
+                    "type": "chatgpt_oauth",
                     "configured": bool(p.get("access")),
                     "expired": self.is_token_expired(provider),
                 }

--- a/backend/core/providers/google_provider.py
+++ b/backend/core/providers/google_provider.py
@@ -22,9 +22,10 @@ GOOGLE_MODELS = [
 
 
 class GoogleProvider(AIProvider):
-    def __init__(self, access_token: str, model: str = "gemini-2.0-flash-exp"):
+    def __init__(self, access_token: str = "", api_key: str = "", model: str = "gemini-2.0-flash-exp"):
         super().__init__(model=model)
         self.access_token = access_token
+        self.api_key = api_key
 
     @property
     def provider_name(self) -> str:
@@ -65,9 +66,12 @@ class GoogleProvider(AIProvider):
             yield {"type": "_turn_complete", "tool_calls": [], "stop_reason": "error"}
             return
 
-        # Configure with OAuth token
-        credentials = Credentials(token=self.access_token)
-        genai.configure(credentials=credentials)
+        # Configure with API key or OAuth token
+        if self.api_key:
+            genai.configure(api_key=self.api_key)
+        else:
+            credentials = Credentials(token=self.access_token)
+            genai.configure(credentials=credentials)
 
         gemini_tools = self._format_tools(tools)
 
@@ -163,9 +167,12 @@ class GoogleProvider(AIProvider):
     async def validate(self) -> bool:
         try:
             import google.generativeai as genai
-            from google.oauth2.credentials import Credentials
-            credentials = Credentials(token=self.access_token)
-            genai.configure(credentials=credentials)
+            if self.api_key:
+                genai.configure(api_key=self.api_key)
+            else:
+                from google.oauth2.credentials import Credentials
+                credentials = Credentials(token=self.access_token)
+                genai.configure(credentials=credentials)
             list(genai.list_models())
             return True
         except Exception:

--- a/backend/core/providers/openai_provider.py
+++ b/backend/core/providers/openai_provider.py
@@ -15,18 +15,29 @@ from core.providers.base import AIProvider
 logger = logging.getLogger(__name__)
 
 OPENAI_MODELS = [
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
+    "o3",
+    "o4-mini",
     "gpt-4o",
     "gpt-4o-mini",
-    "gpt-4-turbo",
-    "o1",
-    "o3-mini",
 ]
+
+CHATGPT_PROXY_URL = "http://127.0.0.1:9877/v1"
 
 
 class OpenAIProvider(AIProvider):
-    def __init__(self, access_token: str, model: str = "gpt-4o"):
+    def __init__(self, access_token: str, model: str = "gpt-4o", use_chatgpt_api: bool = False):
         super().__init__(model=model)
         self.access_token = access_token
+        self.use_chatgpt_api = use_chatgpt_api
+
+    def _build_client_kwargs(self) -> dict:
+        kwargs: dict = {"api_key": self.access_token}
+        if self.use_chatgpt_api:
+            kwargs["base_url"] = CHATGPT_PROXY_URL
+        return kwargs
 
     @property
     def provider_name(self) -> str:
@@ -52,7 +63,7 @@ class OpenAIProvider(AIProvider):
         tools: list[dict],
         system_prompt: str,
     ) -> AsyncGenerator[dict, None]:
-        client = openai.AsyncOpenAI(api_key=self.access_token)
+        client = openai.AsyncOpenAI(**self._build_client_kwargs())
         openai_tools = self._format_tools(tools)
 
         # Build messages with system prompt prepended
@@ -176,8 +187,12 @@ class OpenAIProvider(AIProvider):
 
     async def validate(self) -> bool:
         try:
-            client = openai.OpenAI(api_key=self.access_token)
-            client.models.list()
+            client = openai.OpenAI(**self._build_client_kwargs())
+            client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=1,
+            )
             return True
         except Exception:
             return False

--- a/backend/core/providers/router.py
+++ b/backend/core/providers/router.py
@@ -13,6 +13,7 @@ GET  /api/providers/{provider}/models   — list models for a provider
 import asyncio
 import logging
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
@@ -53,6 +54,25 @@ async def connect_anthropic(body: AnthropicConnectRequest, user=Depends(get_curr
     return {"ok": True, "provider": "anthropic", "model": body.model}
 
 
+class SetupTokenRequest(BaseModel):
+    token: str
+    model: str = "claude-opus-4-6"
+
+
+@router.post("/anthropic/setup-token")
+async def connect_anthropic_token(body: SetupTokenRequest, user=Depends(get_current_user)):
+    """Validate and store a setup-token from `claude setup-token`."""
+    from core.providers.anthropic_provider import AnthropicProvider
+    token = body.token.strip()
+    provider = AnthropicProvider(api_key=token, model=body.model)
+    if not await provider.validate():
+        raise HTTPException(status_code=400, detail="Invalid setup token. Run `claude setup-token` in your terminal and paste the result.")
+
+    store = CredentialStore()
+    store.set_setup_token("anthropic", body.token, model=body.model)
+    return {"ok": True, "provider": "anthropic", "model": body.model}
+
+
 # ── Connect Google / OpenAI (PKCE OAuth) ─────────────────────────────────────
 
 class OAuthStartRequest(BaseModel):
@@ -76,6 +96,42 @@ async def connect_google(user=Depends(get_current_user)):
         model="gemini-2.0-flash-exp",
     )
     return {"ok": True, "provider": "google"}
+
+
+class GoogleKeyRequest(BaseModel):
+    api_key: str
+    model: str = "gemini-2.0-flash-exp"
+
+
+@router.post("/google/connect-key")
+async def connect_google_key(body: GoogleKeyRequest, user=Depends(get_current_user)):
+    """Validate and store a Google AI (Gemini) API key."""
+    from core.providers.google_provider import GoogleProvider
+    provider = GoogleProvider(api_key=body.api_key, model=body.model)
+    if not await provider.validate():
+        raise HTTPException(status_code=400, detail="Invalid Google AI API key")
+
+    store = CredentialStore()
+    store.set_api_key("google", body.api_key, model=body.model)
+    return {"ok": True, "provider": "google", "model": body.model}
+
+
+class OpenAIKeyRequest(BaseModel):
+    api_key: str
+    model: str = "gpt-4o"
+
+
+@router.post("/openai/connect-key")
+async def connect_openai_key(body: OpenAIKeyRequest, user=Depends(get_current_user)):
+    """Validate and store an OpenAI API key."""
+    from core.providers.openai_provider import OpenAIProvider
+    provider = OpenAIProvider(access_token=body.api_key, model=body.model)
+    if not await provider.validate():
+        raise HTTPException(status_code=400, detail="Invalid OpenAI API key")
+
+    store = CredentialStore()
+    store.set_api_key("openai", body.api_key, model=body.model)
+    return {"ok": True, "provider": "openai", "model": body.model}
 
 
 @router.post("/openai/connect")
@@ -166,3 +222,76 @@ async def refresh_google(user=Depends(get_current_user)):
         expires_in=tokens.get("expires_in", 3600),
     )
     return {"ok": True}
+
+
+# ── CLI credential sync ──────────────────────────────────────────────────────
+
+@router.post("/openai/sync-cli")
+async def sync_openai_cli(user=Depends(get_current_user)):
+    """Import OpenAI credentials from local CLI config (~/.codex/auth.json)."""
+    import json
+    from pathlib import Path
+
+    # Try known OpenAI CLI credential locations
+    candidates = [
+        Path.home() / ".codex" / "auth.json",
+        Path.home() / ".openai" / "auth.json",
+    ]
+
+    for cred_path in candidates:
+        if not cred_path.exists():
+            continue
+        try:
+            data = json.loads(cred_path.read_text())
+            auth_mode = data.get("auth_mode", "")
+
+            # Prefer an explicit API key if set
+            api_key = data.get("OPENAI_API_KEY") or data.get("api_key")
+
+            if api_key:
+                from core.providers.openai_provider import OpenAIProvider
+                provider = OpenAIProvider(access_token=api_key)
+                if await provider.validate():
+                    store = CredentialStore()
+                    store.set_api_key("openai", api_key, model="gpt-4o")
+                    return {"ok": True, "provider": "openai", "source": str(cred_path)}
+
+            # ChatGPT mode: validate via the Node.js proxy sidecar
+            if auth_mode == "chatgpt":
+                tokens = data.get("tokens", {})
+                access_token = tokens.get("access_token")
+                refresh_token = tokens.get("refresh_token", "")
+                if access_token:
+                    # Validate through the ChatGPT proxy
+                    try:
+                        validate_resp = await httpx.AsyncClient().post(
+                            "http://127.0.0.1:9877/v1/validate",
+                            json={"token": access_token},
+                            timeout=30,
+                        )
+                        result = validate_resp.json()
+                        if result.get("valid"):
+                            store = CredentialStore()
+                            store.set_chatgpt_oauth(
+                                access_token=access_token,
+                                refresh_token=refresh_token,
+                                expires_in=864000,  # ~10 days
+                            )
+                            return {"ok": True, "provider": "openai", "source": str(cred_path), "mode": "chatgpt"}
+                        else:
+                            raise HTTPException(status_code=400, detail=result.get("error", "Token validation failed"))
+                    except httpx.ConnectError:
+                        raise HTTPException(
+                            status_code=503,
+                            detail="ChatGPT proxy is not running. Start it with: node backend/chatgpt-proxy/server.mjs",
+                        )
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to read %s: %s", cred_path, e)
+
+    raise HTTPException(
+        status_code=404,
+        detail="No OpenAI CLI credentials found. Install the OpenAI CLI and sign in first, or use an API key instead."
+    )

--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -36,8 +36,8 @@ export function DashboardPage() {
       if (brandingData.accent_color) {
         document.documentElement.style.setProperty('--brand-color', brandingData.accent_color);
       }
-    }).catch(() => {
-      // If provider check fails, show dashboard anyway (graceful degradation)
+    }).catch(err => {
+      console.error('Dashboard load error:', err);
     }).finally(() => setLoading(false));
   }, [navigate]);
 

--- a/frontend/src/onboarding/steps/ProviderStep.tsx
+++ b/frontend/src/onboarding/steps/ProviderStep.tsx
@@ -1,45 +1,74 @@
 import { useState, useEffect } from 'react';
 import { api } from '../../core/api/client';
 import type { ProviderStatus } from '../../core/types';
-import { ApiKeyEntry } from '../../setup/ApiKeyEntry';
-import { OAuthConnect } from '../../setup/OAuthConnect';
 
 interface Props {
   onComplete: () => void;
 }
 
-const PROVIDERS = [
+type AuthMethod = 'setup-token' | 'api-key' | 'cli-sync';
+
+interface ProviderDef {
+  id: string;
+  name: string;
+  icon: string;
+  methods: { id: AuthMethod; label: string; description: string }[];
+}
+
+const PROVIDERS: ProviderDef[] = [
   {
     id: 'anthropic',
     name: 'Anthropic (Claude)',
-    icon: '🤖',
-    authType: 'api_key' as const,
-    guidance: 'Create an API key at console.anthropic.com',
-    link: 'https://console.anthropic.com/settings/keys',
-    linkLabel: 'Open Anthropic Console',
-    note: 'Paste your API key below',
+    icon: '\u{1F916}',
+    methods: [
+      {
+        id: 'api-key',
+        label: 'API Key',
+        description: 'Paste an API key from console.anthropic.com',
+      },
+    ],
   },
   {
     id: 'openai',
     name: 'OpenAI (GPT)',
-    icon: '⚡',
-    authType: 'oauth' as const,
-    guidance: 'Sign in with your OpenAI account',
-    note: 'Covers GPT-4o and other ChatGPT models',
+    icon: '\u26A1',
+    methods: [
+      {
+        id: 'api-key',
+        label: 'API Key',
+        description: 'Paste an API key from platform.openai.com',
+      },
+      {
+        id: 'cli-sync',
+        label: 'Import from CLI',
+        description: 'Import credentials from the OpenAI CLI if installed',
+      },
+    ],
   },
   {
     id: 'google',
     name: 'Google (Gemini)',
-    icon: '✨',
-    authType: 'oauth' as const,
-    guidance: 'Sign in with your Google account',
-    note: 'Also enables Gmail + Google Calendar',
+    icon: '\u2728',
+    methods: [
+      {
+        id: 'api-key',
+        label: 'API Key',
+        description: 'Paste an API key from aistudio.google.com',
+      },
+    ],
   },
 ];
 
 export function ProviderStep({ onComplete }: Props) {
   const [status, setStatus] = useState<ProviderStatus | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [activeMethod, setActiveMethod] = useState<Record<string, AuthMethod>>({});
+
+  // Form state
+  const [tokenValue, setTokenValue] = useState('');
+  const [keyValue, setKeyValue] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   function reload() {
     api<ProviderStatus>('/api/providers').then(setStatus).catch(console.error);
@@ -50,6 +79,182 @@ export function ProviderStep({ onComplete }: Props) {
   const anyConnected = status
     ? Object.values(status.profiles).some(p => p.configured)
     : false;
+
+  function getMethod(providerId: string): AuthMethod {
+    return activeMethod[providerId] || PROVIDERS.find(p => p.id === providerId)!.methods[0].id;
+  }
+
+  function clearForm() {
+    setError('');
+    setKeyValue('');
+    setTokenValue('');
+  }
+
+  async function submitSetupToken() {
+    if (!tokenValue.trim()) return;
+    setLoading(true); setError('');
+    try {
+      await api('/api/providers/anthropic/setup-token', {
+        method: 'POST',
+        body: JSON.stringify({ token: tokenValue.trim() }),
+      });
+      setTokenValue('');
+      reload();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Invalid token');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitApiKey(provider: string) {
+    if (!keyValue.trim()) return;
+    setLoading(true); setError('');
+    try {
+      const endpoint = (provider === 'openai' || provider === 'google')
+        ? `/api/providers/${provider}/connect-key`
+        : `/api/providers/${provider}/connect`;
+      await api(endpoint, {
+        method: 'POST',
+        body: JSON.stringify({ api_key: keyValue.trim() }),
+      });
+      setKeyValue('');
+      reload();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Invalid API key');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function syncOpenAICli() {
+    setLoading(true); setError('');
+    try {
+      await api('/api/providers/openai/sync-cli', { method: 'POST' });
+      reload();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'No CLI credentials found');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function renderAuthForm(provider: ProviderDef) {
+    const method = getMethod(provider.id);
+
+    if (method === 'setup-token') {
+      return (
+        <div className="space-y-3">
+          <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+            <p className="text-gray-300 text-sm mb-2">1. Open your terminal and run:</p>
+            <code className="block bg-gray-800 text-indigo-400 px-3 py-2 rounded text-sm font-mono select-all">
+              claude setup-token
+            </code>
+            <p className="text-gray-300 text-sm mt-3">2. Copy the token and paste it below:</p>
+          </div>
+          <input
+            type="password"
+            value={tokenValue}
+            onChange={e => setTokenValue(e.target.value)}
+            placeholder="Paste your setup token here"
+            onKeyDown={e => e.key === 'Enter' && submitSetupToken()}
+            className="w-full bg-gray-700 border border-gray-600 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
+          />
+          {error && <p className="text-red-400 text-xs">{error}</p>}
+          <button
+            onClick={submitSetupToken}
+            disabled={loading || !tokenValue.trim()}
+            className="w-full py-2.5 bg-brand text-white text-sm font-semibold rounded-lg hover:opacity-90 transition disabled:opacity-50"
+          >
+            {loading ? 'Validating...' : 'Connect'}
+          </button>
+        </div>
+      );
+    }
+
+    if (method === 'api-key') {
+      const config: Record<string, { placeholder: string; link: string; linkLabel: string }> = {
+        anthropic: {
+          placeholder: 'sk-ant-...',
+          link: 'https://console.anthropic.com/settings/keys',
+          linkLabel: 'Open Anthropic Console',
+        },
+        openai: {
+          placeholder: 'sk-...',
+          link: 'https://platform.openai.com/api-keys',
+          linkLabel: 'Open OpenAI Platform',
+        },
+        google: {
+          placeholder: 'AIza...',
+          link: 'https://aistudio.google.com/apikey',
+          linkLabel: 'Open Google AI Studio',
+        },
+      };
+      const c = config[provider.id];
+      return (
+        <div className="space-y-3">
+          <a
+            href={c.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-indigo-400 text-sm hover:text-indigo-300 transition"
+          >
+            {c.linkLabel}
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </a>
+          <input
+            type="password"
+            value={keyValue}
+            onChange={e => setKeyValue(e.target.value)}
+            placeholder={c.placeholder}
+            onKeyDown={e => e.key === 'Enter' && submitApiKey(provider.id)}
+            className="w-full bg-gray-700 border border-gray-600 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
+          />
+          {error && <p className="text-red-400 text-xs">{error}</p>}
+          <button
+            onClick={() => submitApiKey(provider.id)}
+            disabled={loading || !keyValue.trim()}
+            className="w-full py-2.5 bg-brand text-white text-sm font-semibold rounded-lg hover:opacity-90 transition disabled:opacity-50"
+          >
+            {loading ? 'Validating...' : 'Connect'}
+          </button>
+        </div>
+      );
+    }
+
+    if (method === 'cli-sync') {
+      return (
+        <div className="space-y-3">
+          <p className="text-gray-400 text-sm">
+            If you have the OpenAI CLI (Codex) installed and signed in, Chatty can import your credentials automatically.
+          </p>
+          <a
+            href="https://github.com/openai/codex"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-indigo-400 text-sm hover:text-indigo-300 transition"
+          >
+            Install the OpenAI CLI
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </a>
+          {error && <p className="text-red-400 text-xs">{error}</p>}
+          <button
+            onClick={syncOpenAICli}
+            disabled={loading}
+            className="w-full py-2.5 bg-brand text-white text-sm font-semibold rounded-lg hover:opacity-90 transition disabled:opacity-50"
+          >
+            {loading ? 'Searching...' : 'Import from CLI'}
+          </button>
+        </div>
+      );
+    }
+
+    return null;
+  }
 
   return (
     <div>
@@ -76,7 +281,12 @@ export function ProviderStep({ onComplete }: Props) {
               }`}
             >
               <button
-                onClick={() => !isConnected && setExpanded(isExpanded ? null : p.id)}
+                onClick={() => {
+                  if (!isConnected) {
+                    setExpanded(isExpanded ? null : p.id);
+                    clearForm();
+                  }
+                }}
                 className="w-full p-4 flex items-center justify-between text-left"
                 disabled={isConnected}
               >
@@ -84,7 +294,9 @@ export function ProviderStep({ onComplete }: Props) {
                   <span className="text-2xl">{p.icon}</span>
                   <div>
                     <p className="text-white font-medium">{p.name}</p>
-                    <p className="text-gray-400 text-xs mt-0.5">{p.note}</p>
+                    <p className="text-gray-400 text-xs mt-0.5">
+                      {p.methods.map(m => m.label).join(' / ')}
+                    </p>
                   </div>
                 </div>
 
@@ -95,39 +307,39 @@ export function ProviderStep({ onComplete }: Props) {
                   </div>
                 ) : (
                   <span className={`text-gray-400 text-sm transition ${isExpanded ? 'rotate-180' : ''}`}>
-                    ▾
+                    &#9662;
                   </span>
                 )}
               </button>
 
               {isExpanded && !isConnected && (
                 <div className="px-4 pb-4 border-t border-gray-700 pt-4">
-                  <p className="text-gray-300 text-sm mb-3">{p.guidance}</p>
-
-                  {p.link && (
-                    <a
-                      href={p.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 text-indigo-400 text-sm hover:text-indigo-300 transition mb-4"
-                    >
-                      {p.linkLabel}
-                      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                      </svg>
-                    </a>
+                  {/* Method selector (only if multiple methods) */}
+                  {p.methods.length > 1 && (
+                    <div className="flex gap-2 mb-4">
+                      {p.methods.map(m => {
+                        const isActive = getMethod(p.id) === m.id;
+                        return (
+                          <button
+                            key={m.id}
+                            onClick={() => {
+                              setActiveMethod(prev => ({ ...prev, [p.id]: m.id }));
+                              clearForm();
+                            }}
+                            className={`px-3 py-1.5 rounded-lg text-xs font-medium transition ${
+                              isActive
+                                ? 'bg-indigo-500/20 text-indigo-400 border border-indigo-500/50'
+                                : 'bg-gray-700 text-gray-400 border border-gray-600 hover:bg-gray-600'
+                            }`}
+                          >
+                            {m.label}
+                          </button>
+                        );
+                      })}
+                    </div>
                   )}
 
-                  {/* Placeholder for future screenshot */}
-                  <div className="bg-gray-900 border border-dashed border-gray-700 rounded-lg p-4 mb-4 text-center">
-                    <p className="text-gray-500 text-xs">Screenshot guide coming soon</p>
-                  </div>
-
-                  {p.authType === 'api_key' ? (
-                    <ApiKeyEntry provider={p.id} onConnected={reload} />
-                  ) : (
-                    <OAuthConnect provider={p.id} onConnected={reload} />
-                  )}
+                  {renderAuthForm(p)}
                 </div>
               )}
             </div>

--- a/frontend/src/setup/ProviderSetup.tsx
+++ b/frontend/src/setup/ProviderSetup.tsx
@@ -2,12 +2,15 @@ import { useState, useEffect } from 'react';
 import { api } from '../core/api/client';
 import type { ProviderStatus } from '../core/types';
 import { ApiKeyEntry } from './ApiKeyEntry';
-import { OAuthConnect } from './OAuthConnect';
+import { SetupTokenEntry } from './SetupTokenEntry';
 import { ModelSelector } from './ModelSelector';
+
+type AuthTab = 'setup-token' | 'api-key';
 
 export function ProviderSetup() {
   const [status, setStatus] = useState<ProviderStatus | null>(null);
   const [loading, setLoading] = useState(true);
+  const [authTab, setAuthTab] = useState<Record<string, AuthTab>>({});
 
   function reload() {
     api<ProviderStatus>('/api/providers')
@@ -25,10 +28,61 @@ export function ProviderSetup() {
   );
 
   const providers = [
-    { id: 'anthropic', name: 'Anthropic (Claude)', icon: '🤖', authType: 'api_key' },
-    { id: 'openai', name: 'OpenAI (GPT)', icon: '⚡', authType: 'oauth' },
-    { id: 'google', name: 'Google Gemini', icon: '✨', authType: 'oauth' },
+    {
+      id: 'anthropic',
+      name: 'Anthropic (Claude)',
+      icon: '\u{1F916}',
+      tabs: [{ id: 'api-key' as AuthTab, label: 'API Key' }],
+      defaultTab: 'api-key' as AuthTab,
+    },
+    {
+      id: 'openai',
+      name: 'OpenAI (GPT)',
+      icon: '\u26A1',
+      tabs: [{ id: 'api-key' as AuthTab, label: 'API Key' }],
+      defaultTab: 'api-key' as AuthTab,
+    },
+    {
+      id: 'google',
+      name: 'Google (Gemini)',
+      icon: '\u2728',
+      tabs: [{ id: 'api-key' as AuthTab, label: 'API Key' }],
+      defaultTab: 'api-key' as AuthTab,
+    },
   ];
+
+  function getTab(providerId: string): AuthTab {
+    return authTab[providerId] || providers.find(p => p.id === providerId)!.defaultTab;
+  }
+
+  function renderConnectUI(p: typeof providers[0]) {
+    const tab = getTab(p.id);
+
+    return (
+      <div>
+        {p.tabs.length > 1 && (
+          <div className="flex gap-2 mb-3">
+            {p.tabs.map(t => (
+              <button
+                key={t.id}
+                onClick={() => setAuthTab(prev => ({ ...prev, [p.id]: t.id }))}
+                className={`px-3 py-1 rounded-lg text-xs font-medium transition ${
+                  tab === t.id
+                    ? 'bg-indigo-500/20 text-indigo-400 border border-indigo-500/50'
+                    : 'bg-gray-700 text-gray-400 border border-gray-600 hover:bg-gray-600'
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {tab === 'setup-token' && <SetupTokenEntry onConnected={reload} />}
+        {tab === 'api-key' && <ApiKeyEntry provider={p.id} onConnected={reload} />}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">
@@ -60,13 +114,7 @@ export function ProviderSetup() {
               )}
             </div>
 
-            {!isConnected ? (
-              p.authType === 'api_key' ? (
-                <ApiKeyEntry provider={p.id} onConnected={reload} />
-              ) : (
-                <OAuthConnect provider={p.id} onConnected={reload} />
-              )
-            ) : (
+            {!isConnected ? renderConnectUI(p) : (
               <div className="space-y-3">
                 <ModelSelector
                   provider={p.id}

--- a/frontend/src/setup/SetupTokenEntry.tsx
+++ b/frontend/src/setup/SetupTokenEntry.tsx
@@ -2,30 +2,25 @@ import { useState } from 'react';
 import { api } from '../core/api/client';
 
 interface Props {
-  provider: string;
   onConnected: () => void;
 }
 
-export function ApiKeyEntry({ provider, onConnected }: Props) {
-  const [key, setKey] = useState('');
+export function SetupTokenEntry({ onConnected }: Props) {
+  const [token, setToken] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
   async function connect() {
-    if (!key.trim()) return;
+    if (!token.trim()) return;
     setLoading(true); setError('');
     try {
-      // OpenAI and Google use /connect-key for API key auth (separate from OAuth /connect)
-      const endpoint = (provider === 'openai' || provider === 'google')
-        ? `/api/providers/${provider}/connect-key`
-        : `/api/providers/${provider}/connect`;
-      await api(endpoint, {
+      await api('/api/providers/anthropic/setup-token', {
         method: 'POST',
-        body: JSON.stringify({ api_key: key.trim() }),
+        body: JSON.stringify({ token: token.trim() }),
       });
       onConnected();
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Invalid API key');
+      setError(err instanceof Error ? err.message : 'Invalid setup token');
     } finally {
       setLoading(false);
     }
@@ -33,18 +28,21 @@ export function ApiKeyEntry({ provider, onConnected }: Props) {
 
   return (
     <div className="space-y-3">
+      <p className="text-gray-400 text-xs">
+        Run <code className="text-indigo-400 bg-gray-900 px-1.5 py-0.5 rounded">claude setup-token</code> in your terminal, then paste the result below.
+      </p>
       <input
         type="password"
-        value={key}
-        onChange={e => setKey(e.target.value)}
-        placeholder="sk-ant-..."
+        value={token}
+        onChange={e => setToken(e.target.value)}
+        placeholder="Paste your setup token"
         onKeyDown={e => e.key === 'Enter' && connect()}
         className="w-full bg-gray-700 border border-gray-600 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
       />
       {error && <p className="text-red-400 text-xs">{error}</p>}
       <button
         onClick={connect}
-        disabled={loading || !key.trim()}
+        disabled={loading || !token.trim()}
         className="w-full py-2.5 bg-brand text-white text-sm font-semibold rounded-lg hover:opacity-90 transition disabled:opacity-50"
       >
         {loading ? 'Validating...' : 'Connect'}


### PR DESCRIPTION
## Summary
- Step-by-step onboarding wizard at `/setup` walks new users through connecting an AI provider and optionally setting up integrations (Odoo, QuickBooks, BambooHR, CRM)
- Multi-provider auth: Anthropic (API key), OpenAI (API key + ChatGPT CLI import via Node.js pi-ai proxy sidecar), Google (Gemini API key)
- Node.js sidecar (`backend/chatgpt-proxy/`) uses pi-ai to route ChatGPT OAuth tokens through `chatgpt.com/backend-api`, enabling Codex CLI users to connect without a separate API key
- Updated model lists: GPT-5.4 default, o3, o4-mini

## Test plan
- [ ] Clear `data/auth-profiles.json`, log in — redirects to `/setup`
- [ ] Connect Anthropic with API key — green checkmark, Continue enabled
- [ ] OpenAI: "Import from CLI" with Codex installed — imports ChatGPT token via proxy
- [ ] OpenAI: API key paste — validates and connects
- [ ] Google: API key from aistudio.google.com — validates and connects
- [ ] Select integrations and walk through setup forms
- [ ] Skip integrations — goes straight to dashboard
- [ ] Refresh after provider connected — dashboard loads normally
- [ ] Start chatgpt-proxy: `node backend/chatgpt-proxy/server.mjs`
- [ ] Verify `npx tsc --noEmit` and `npx vite build` pass