### PR TITLE
Fix AI connection error: model sent as "default"

### DIFF
--- a/backend/core/providers/__init__.py
+++ b/backend/core/providers/__init__.py
@@ -25,7 +25,8 @@ def get_ai_provider(agent_provider: str | None = None, agent_model: str | None =
         return None
 
     provider_type = profile.get("type")
-    model = agent_model or store.data.get("active_model", "")
+    raw_model = agent_model or store.data.get("active_model", "")
+    model = raw_model if raw_model and raw_model != "default" else ""
 
     if profile_name.startswith("anthropic:"):
         from core.providers.anthropic_provider import AnthropicProvider

--- a/backend/core/providers/credentials.py
+++ b/backend/core/providers/credentials.py
@@ -107,7 +107,11 @@ class CredentialStore:
 
     def set_active_model(self, model: str):
         """Update the active model."""
-        self.data["active_model"] = model
+        if model and model != "default":
+            self.data["active_model"] = model
+        else:
+            provider = self.data.get("active_provider", "")
+            self.data["active_model"] = PROVIDER_DEFAULTS.get(provider, "")
         self._save()
 
     def set_active_provider(self, provider: str):

--- a/frontend/src/setup/ProviderSetup.tsx
+++ b/frontend/src/setup/ProviderSetup.tsx
@@ -78,7 +78,7 @@ export function ProviderSetup() {
                     onClick={async () => {
                       await api('/api/providers/active', {
                         method: 'PUT',
-                        body: JSON.stringify({ provider: p.id, model: currentModel || 'default' }),
+                        body: JSON.stringify({ provider: p.id, model: currentModel || '' }),
                       });
                       reload();
                     }}


### PR DESCRIPTION
## Summary
- **Root cause**: `ProviderSetup.tsx` sent the literal string `"default"` as the model name when no model was selected, causing every AI provider API to return a 404
- Frontend fallback changed from `'default'` to `''` (empty string)
- Backend credential store now resolves `"default"` or empty to the provider's actual default model (`claude-opus-4-6`, `gpt-4o`, `gemini-2.0-flash-exp`)
- Provider factory treats `"default"` as empty so per-provider fallbacks always kick in

## Test plan
- [ ] Connect an Anthropic API key, click "Set as active" without selecting a model — chat should work
- [ ] Repeat for OpenAI and Google providers
- [ ] Select a specific model from the dropdown, set as active — that model should be used
- [ ] Verify existing deployed instances self-heal after re-selecting a provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)