### PR TITLE
Add keychain-backed encryption for credentials at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ WEBBY_GITHUB_TOKEN=
 # e.g. myusername/my-website
 WEBBY_GITHUB_REPO=
 
+# ─── Encryption ─────────────────────────────────────────────────────────────
+# For deployed instances: Fernet encryption key for credentials at rest.
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# Leave blank for local use (key stored in OS keychain automatically).
+ENCRYPTION_KEY=
+
 # ─── Server ──────────────────────────────────────────────────────────────────
 # CORS origins (comma-separated). Defaults to localhost dev servers.
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/backend/core/encryption.py
+++ b/backend/core/encryption.py
@@ -1,0 +1,207 @@
+"""
+Chatty — Encryption at rest for credentials.
+
+Encrypts sensitive fields (API keys, OAuth tokens) using Fernet (AES-128-CBC)
+before writing to disk. The encryption key is sourced from (in priority order):
+
+1. ENCRYPTION_KEY environment variable  (deployed instances — Railway, etc.)
+2. OS keychain via `keyring` library     (local macOS / Windows / Linux)
+3. File fallback: data/.encryption-key   (headless Linux, CI, Docker)
+
+Encrypted values are prefixed with "enc:v1:" so plaintext values (pre-migration)
+are detected and auto-encrypted on first load.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).parent.parent / "data"
+KEY_FILE_PATH = DATA_DIR / ".encryption-key"
+
+KEYCHAIN_SERVICE = "chatty"
+KEYCHAIN_ACCOUNT = "encryption-key"
+
+ENCRYPTED_PREFIX = "enc:v1:"
+
+# JSON keys whose values contain secrets and must be encrypted on disk.
+SENSITIVE_FIELDS = frozenset({
+    "key",              # API keys  (auth-profiles.json)
+    "token",            # setup tokens (auth-profiles.json)
+    "access",           # OAuth access tokens
+    "refresh",          # OAuth refresh tokens
+    "api_key",          # integration API keys (odoo, bamboohr)
+    "access_token",     # integration OAuth (quickbooks)
+    "refresh_token",    # integration OAuth (quickbooks)
+    "client_secret",    # integration OAuth (quickbooks)
+})
+
+
+# ---------------------------------------------------------------------------
+# Key management
+# ---------------------------------------------------------------------------
+
+class EncryptionKeyManager:
+    """Resolve or generate a Fernet encryption key.  Result is cached."""
+
+    _cached_key: bytes | None = None
+
+    @classmethod
+    def get_key(cls) -> bytes:
+        if cls._cached_key is not None:
+            return cls._cached_key
+
+        key = cls._try_env() or cls._try_keychain() or cls._try_file()
+        if not key:
+            key = cls._generate_and_store()
+
+        cls._cached_key = key
+        return key
+
+    @classmethod
+    def reset_cache(cls) -> None:
+        """Clear the cached key (useful for tests)."""
+        cls._cached_key = None
+
+    # -- sources -------------------------------------------------------------
+
+    @classmethod
+    def _try_env(cls) -> bytes | None:
+        raw = os.environ.get("ENCRYPTION_KEY")
+        if not raw:
+            return None
+        try:
+            key = raw.encode()
+            Fernet(key)  # validate
+            logger.info("Using encryption key from ENCRYPTION_KEY env var")
+            return key
+        except Exception:
+            logger.warning("ENCRYPTION_KEY env var is not a valid Fernet key, ignoring")
+            return None
+
+    @classmethod
+    def _try_keychain(cls) -> bytes | None:
+        try:
+            import keyring
+            stored = keyring.get_password(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
+            if stored:
+                key = stored.encode()
+                Fernet(key)  # validate
+                logger.info("Using encryption key from OS keychain")
+                return key
+        except Exception as exc:
+            logger.debug("Keychain not available: %s", exc)
+        return None
+
+    @classmethod
+    def _try_file(cls) -> bytes | None:
+        if not KEY_FILE_PATH.exists():
+            return None
+        try:
+            key = KEY_FILE_PATH.read_text().strip().encode()
+            Fernet(key)  # validate
+            logger.info("Using encryption key from file: %s", KEY_FILE_PATH)
+            return key
+        except Exception:
+            logger.warning("Key file exists but is invalid, will regenerate")
+            return None
+
+    # -- generation ----------------------------------------------------------
+
+    @classmethod
+    def _generate_and_store(cls) -> bytes:
+        key = Fernet.generate_key()
+
+        # Try keychain first
+        stored_in_keychain = False
+        try:
+            import keyring
+            keyring.set_password(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, key.decode())
+            stored_in_keychain = True
+            logger.info("Generated new encryption key, stored in OS keychain")
+        except Exception as exc:
+            logger.debug("Cannot store in keychain: %s", exc)
+
+        if not stored_in_keychain:
+            DATA_DIR.mkdir(parents=True, exist_ok=True)
+            KEY_FILE_PATH.write_text(key.decode())
+            KEY_FILE_PATH.chmod(0o600)
+            logger.info(
+                "Generated new encryption key, stored in file: %s", KEY_FILE_PATH
+            )
+
+        return key
+
+
+# ---------------------------------------------------------------------------
+# Value-level encrypt / decrypt
+# ---------------------------------------------------------------------------
+
+def encrypt_value(plaintext: str) -> str:
+    """Encrypt a single string value → ``enc:v1:<fernet_token>``."""
+    if not plaintext or plaintext.startswith(ENCRYPTED_PREFIX):
+        return plaintext  # empty or already encrypted
+    key = EncryptionKeyManager.get_key()
+    token = Fernet(key).encrypt(plaintext.encode()).decode()
+    return f"{ENCRYPTED_PREFIX}{token}"
+
+
+def decrypt_value(stored: str) -> str:
+    """Decrypt a value.  Returns ``""`` on failure (tamper / wrong key).
+
+    Plaintext values (no ``enc:v1:`` prefix) pass through unchanged — this
+    provides backwards compatibility during migration.
+    """
+    if not stored or not stored.startswith(ENCRYPTED_PREFIX):
+        return stored  # plaintext pass-through
+    token = stored[len(ENCRYPTED_PREFIX):]
+    try:
+        key = EncryptionKeyManager.get_key()
+        return Fernet(key).decrypt(token.encode()).decode()
+    except (InvalidToken, Exception) as exc:
+        logger.warning("Failed to decrypt value (tampered or wrong key): %s", exc)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Dict-level helpers  (recursive for nested profile dicts)
+# ---------------------------------------------------------------------------
+
+def encrypt_dict(data: dict) -> dict:
+    """Return a shallow copy with sensitive string fields encrypted."""
+    result = {}
+    for k, v in data.items():
+        if k in SENSITIVE_FIELDS and isinstance(v, str):
+            result[k] = encrypt_value(v)
+        elif isinstance(v, dict):
+            result[k] = encrypt_dict(v)
+        else:
+            result[k] = v
+    return result
+
+
+def decrypt_dict(data: dict) -> dict:
+    """Return a shallow copy with sensitive string fields decrypted."""
+    result = {}
+    for k, v in data.items():
+        if k in SENSITIVE_FIELDS and isinstance(v, str):
+            result[k] = decrypt_value(v)
+        elif isinstance(v, dict):
+            result[k] = decrypt_dict(v)
+        else:
+            result[k] = v
+    return result
+
+
+def needs_migration(data: dict) -> bool:
+    """Return True if any sensitive field is still plaintext (not encrypted)."""
+    for k, v in data.items():
+        if k in SENSITIVE_FIELDS and isinstance(v, str) and v and not v.startswith(ENCRYPTED_PREFIX):
+            return True
+        if isinstance(v, dict) and needs_migration(v):
+            return True
+    return False

--- a/backend/core/encryption.py
+++ b/backend/core/encryption.py
@@ -16,7 +16,7 @@ import logging
 import os
 from pathlib import Path
 
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,7 @@ KEYCHAIN_ACCOUNT = "encryption-key"
 ENCRYPTED_PREFIX = "enc:v1:"
 
 # JSON keys whose values contain secrets and must be encrypted on disk.
+# When adding a new integration, add any secret field names here.
 SENSITIVE_FIELDS = frozenset({
     "key",              # API keys  (auth-profiles.json)
     "token",            # setup tokens (auth-profiles.json)
@@ -162,7 +163,7 @@ def decrypt_value(stored: str) -> str:
     try:
         key = EncryptionKeyManager.get_key()
         return Fernet(key).decrypt(token.encode()).decode()
-    except (InvalidToken, Exception) as exc:
+    except Exception as exc:
         logger.warning("Failed to decrypt value (tampered or wrong key): %s", exc)
         return ""
 
@@ -172,7 +173,7 @@ def decrypt_value(stored: str) -> str:
 # ---------------------------------------------------------------------------
 
 def encrypt_dict(data: dict) -> dict:
-    """Return a shallow copy with sensitive string fields encrypted."""
+    """Return a copy with sensitive string fields encrypted (recurses into nested dicts)."""
     result = {}
     for k, v in data.items():
         if k in SENSITIVE_FIELDS and isinstance(v, str):
@@ -185,7 +186,7 @@ def encrypt_dict(data: dict) -> dict:
 
 
 def decrypt_dict(data: dict) -> dict:
-    """Return a shallow copy with sensitive string fields decrypted."""
+    """Return a copy with sensitive string fields decrypted (recurses into nested dicts)."""
     result = {}
     for k, v in data.items():
         if k in SENSITIVE_FIELDS and isinstance(v, str):

--- a/backend/core/providers/credentials.py
+++ b/backend/core/providers/credentials.py
@@ -22,6 +22,8 @@ import logging
 import time
 from pathlib import Path
 
+from core.encryption import decrypt_dict, encrypt_dict, needs_migration
+
 logger = logging.getLogger(__name__)
 
 DATA_DIR = Path(__file__).parent.parent.parent / "data"
@@ -41,14 +43,22 @@ class CredentialStore:
     def _load(self) -> dict:
         if PROFILES_PATH.exists():
             try:
-                return json.loads(PROFILES_PATH.read_text())
+                raw = json.loads(PROFILES_PATH.read_text())
+                decrypted = decrypt_dict(raw)
+                # Auto-migrate plaintext credentials to encrypted on disk
+                if needs_migration(raw):
+                    logger.info("Migrating auth-profiles.json to encrypted storage")
+                    self.data = decrypted
+                    self._save()
+                return decrypted
             except Exception as e:
                 logger.error("Failed to load auth-profiles.json: %s", e)
         return {"active_provider": "", "active_model": "", "profiles": {}}
 
     def _save(self):
         DATA_DIR.mkdir(parents=True, exist_ok=True)
-        PROFILES_PATH.write_text(json.dumps(self.data, indent=2))
+        encrypted = encrypt_dict(self.data)
+        PROFILES_PATH.write_text(json.dumps(encrypted, indent=2))
 
     def get_active_profile(self, provider_override: str | None = None) -> tuple[str, dict | None]:
         """Return (profile_name, profile_dict) for the active (or overridden) provider."""

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -16,6 +16,8 @@ import json
 import logging
 from pathlib import Path
 
+from core.encryption import decrypt_dict, encrypt_dict, needs_migration
+
 logger = logging.getLogger(__name__)
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "integrations"
@@ -80,15 +82,22 @@ def get_credentials(name: str) -> dict:
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        decrypted = decrypt_dict(raw)
+        # Auto-migrate plaintext credentials to encrypted on disk
+        if needs_migration(raw):
+            logger.info("Migrating %s.json to encrypted storage", name)
+            save_credentials(name, decrypted)
+        return decrypted
     except Exception:
         return {}
 
 
 def save_credentials(name: str, data: dict) -> None:
-    """Save integration credentials."""
+    """Save integration credentials (sensitive fields encrypted at rest)."""
     ensure_dir()
-    _creds_path(name).write_text(json.dumps(data, indent=2), encoding="utf-8")
+    encrypted = encrypt_dict(data)
+    _creds_path(name).write_text(json.dumps(encrypted, indent=2), encoding="utf-8")
 
 
 def enable(name: str) -> None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,8 @@ google-auth
 google-auth-oauthlib
 google-api-python-client
 google-cloud-storage
+cryptography
+keyring
 anthropic
 openai
 google-generativeai

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -1,0 +1,461 @@
+"""Tests for core.encryption — keychain-backed credential encryption."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Generate a stable test key (never used outside tests)
+TEST_KEY = Fernet.generate_key()
+
+
+@pytest.fixture(autouse=True)
+def _reset_key_cache():
+    """Reset the cached encryption key between every test."""
+    from core.encryption import EncryptionKeyManager
+    EncryptionKeyManager.reset_cache()
+    yield
+    EncryptionKeyManager.reset_cache()
+
+
+@pytest.fixture()
+def env_key(monkeypatch):
+    """Set ENCRYPTION_KEY env var to TEST_KEY for the duration of a test."""
+    monkeypatch.setenv("ENCRYPTION_KEY", TEST_KEY.decode())
+    return TEST_KEY
+
+
+@pytest.fixture()
+def no_env_key(monkeypatch):
+    """Ensure ENCRYPTION_KEY is not set."""
+    monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# encrypt_value / decrypt_value
+# ---------------------------------------------------------------------------
+
+class TestEncryptDecryptValue:
+    def test_roundtrip(self, env_key):
+        from core.encryption import decrypt_value, encrypt_value
+
+        original = "sk-ant-api03-secret-key"
+        encrypted = encrypt_value(original)
+        assert encrypted.startswith("enc:v1:")
+        assert encrypted != original
+        assert decrypt_value(encrypted) == original
+
+    def test_plaintext_passthrough(self, env_key):
+        from core.encryption import decrypt_value
+
+        # Pre-migration: no prefix → return as-is
+        assert decrypt_value("sk-ant-plain") == "sk-ant-plain"
+
+    def test_empty_string_noop(self, env_key):
+        from core.encryption import decrypt_value, encrypt_value
+
+        assert encrypt_value("") == ""
+        assert decrypt_value("") == ""
+
+    def test_already_encrypted_idempotent(self, env_key):
+        from core.encryption import encrypt_value
+
+        first = encrypt_value("my-secret")
+        second = encrypt_value(first)
+        assert first == second  # no double-encryption
+
+    def test_tampered_ciphertext_returns_empty(self, env_key):
+        from core.encryption import decrypt_value, encrypt_value
+
+        encrypted = encrypt_value("real-secret")
+        # Corrupt a byte in the Fernet token portion
+        tampered = encrypted[:20] + "X" + encrypted[21:]
+        assert decrypt_value(tampered) == ""
+
+    def test_wrong_key_returns_empty(self, env_key):
+        from core.encryption import decrypt_value, encrypt_value
+
+        encrypted = encrypt_value("my-secret")
+
+        # Switch to a different key
+        from core.encryption import EncryptionKeyManager
+        EncryptionKeyManager.reset_cache()
+        other_key = Fernet.generate_key()
+        EncryptionKeyManager._cached_key = other_key
+
+        assert decrypt_value(encrypted) == ""
+
+
+# ---------------------------------------------------------------------------
+# encrypt_dict / decrypt_dict
+# ---------------------------------------------------------------------------
+
+class TestDictHelpers:
+    def test_only_sensitive_fields_encrypted(self, env_key):
+        from core.encryption import ENCRYPTED_PREFIX, encrypt_dict
+
+        data = {
+            "type": "api_key",
+            "key": "sk-ant-secret",
+            "active_provider": "anthropic",
+        }
+        result = encrypt_dict(data)
+        assert result["type"] == "api_key"  # unchanged
+        assert result["active_provider"] == "anthropic"  # unchanged
+        assert result["key"].startswith(ENCRYPTED_PREFIX)
+
+    def test_nested_dict_recursion(self, env_key):
+        from core.encryption import ENCRYPTED_PREFIX, decrypt_dict, encrypt_dict
+
+        data = {
+            "active_provider": "anthropic",
+            "profiles": {
+                "anthropic:default": {"type": "api_key", "key": "sk-ant-xxx"},
+                "google:default": {
+                    "type": "oauth",
+                    "access": "ya29.token",
+                    "refresh": "1//refresh",
+                    "expires": 9999999999,
+                },
+            },
+        }
+        encrypted = encrypt_dict(data)
+
+        # Top-level metadata untouched
+        assert encrypted["active_provider"] == "anthropic"
+        # Nested sensitive fields encrypted
+        assert encrypted["profiles"]["anthropic:default"]["key"].startswith(ENCRYPTED_PREFIX)
+        assert encrypted["profiles"]["google:default"]["access"].startswith(ENCRYPTED_PREFIX)
+        assert encrypted["profiles"]["google:default"]["refresh"].startswith(ENCRYPTED_PREFIX)
+        # Non-sensitive nested fields untouched
+        assert encrypted["profiles"]["anthropic:default"]["type"] == "api_key"
+        assert encrypted["profiles"]["google:default"]["expires"] == 9999999999
+
+        # Roundtrip
+        decrypted = decrypt_dict(encrypted)
+        assert decrypted == data
+
+    def test_integration_credentials(self, env_key):
+        from core.encryption import ENCRYPTED_PREFIX, decrypt_dict, encrypt_dict
+
+        data = {
+            "url": "https://myodoo.com",
+            "database": "prod",
+            "username": "admin",
+            "api_key": "odoo-secret-key",
+            "enabled": True,
+            "version": "17.0",
+        }
+        encrypted = encrypt_dict(data)
+        assert encrypted["api_key"].startswith(ENCRYPTED_PREFIX)
+        assert encrypted["url"] == "https://myodoo.com"
+        assert encrypted["enabled"] is True
+
+        decrypted = decrypt_dict(encrypted)
+        assert decrypted == data
+
+
+# ---------------------------------------------------------------------------
+# needs_migration
+# ---------------------------------------------------------------------------
+
+class TestNeedsMigration:
+    def test_plaintext_detected(self, env_key):
+        from core.encryption import needs_migration
+
+        data = {
+            "profiles": {
+                "anthropic:default": {"type": "api_key", "key": "sk-ant-plain"},
+            }
+        }
+        assert needs_migration(data) is True
+
+    def test_all_encrypted(self, env_key):
+        from core.encryption import encrypt_dict, needs_migration
+
+        data = {
+            "profiles": {
+                "anthropic:default": {"type": "api_key", "key": "sk-ant-plain"},
+            }
+        }
+        encrypted = encrypt_dict(data)
+        assert needs_migration(encrypted) is False
+
+    def test_empty_values_not_flagged(self, env_key):
+        from core.encryption import needs_migration
+
+        data = {"profiles": {"anthropic:default": {"type": "api_key", "key": ""}}}
+        assert needs_migration(data) is False
+
+    def test_no_sensitive_fields(self, env_key):
+        from core.encryption import needs_migration
+
+        data = {"active_provider": "anthropic", "active_model": "claude-opus-4-6"}
+        assert needs_migration(data) is False
+
+
+# ---------------------------------------------------------------------------
+# EncryptionKeyManager
+# ---------------------------------------------------------------------------
+
+class TestKeyManager:
+    def test_key_from_env_var(self, monkeypatch):
+        from core.encryption import EncryptionKeyManager
+
+        test_key = Fernet.generate_key()
+        monkeypatch.setenv("ENCRYPTION_KEY", test_key.decode())
+        assert EncryptionKeyManager.get_key() == test_key
+
+    def test_invalid_env_var_skipped(self, monkeypatch):
+        from core.encryption import EncryptionKeyManager
+
+        monkeypatch.setenv("ENCRYPTION_KEY", "not-a-valid-fernet-key")
+        # Should not raise — falls through to other sources
+        with patch.object(EncryptionKeyManager, "_try_keychain", return_value=None), \
+             patch.object(EncryptionKeyManager, "_try_file", return_value=None), \
+             patch.object(EncryptionKeyManager, "_generate_and_store", return_value=Fernet.generate_key()):
+            key = EncryptionKeyManager.get_key()
+            assert key is not None
+
+    def test_key_from_keychain(self, no_env_key):
+        from core.encryption import EncryptionKeyManager
+
+        test_key = Fernet.generate_key()
+        mock_keyring = MagicMock()
+        mock_keyring.get_password.return_value = test_key.decode()
+
+        with patch.dict("sys.modules", {"keyring": mock_keyring}):
+            EncryptionKeyManager.reset_cache()
+            result = EncryptionKeyManager._try_keychain()
+            assert result == test_key
+
+    def test_key_from_file(self, no_env_key, tmp_path, monkeypatch):
+        from core import encryption
+        from core.encryption import EncryptionKeyManager
+
+        test_key = Fernet.generate_key()
+        key_file = tmp_path / ".encryption-key"
+        key_file.write_text(test_key.decode())
+
+        monkeypatch.setattr(encryption, "KEY_FILE_PATH", key_file)
+        assert EncryptionKeyManager._try_file() == test_key
+
+    def test_generate_stores_to_keychain(self, no_env_key):
+        from core.encryption import EncryptionKeyManager
+
+        mock_keyring = MagicMock()
+        mock_keyring.set_password = MagicMock()
+
+        with patch.dict("sys.modules", {"keyring": mock_keyring}):
+            key = EncryptionKeyManager._generate_and_store()
+            assert key is not None
+            mock_keyring.set_password.assert_called_once()
+
+    def test_generate_falls_back_to_file(self, no_env_key, tmp_path, monkeypatch):
+        from core import encryption
+        from core.encryption import EncryptionKeyManager
+
+        key_file = tmp_path / ".encryption-key"
+        data_dir = tmp_path
+        monkeypatch.setattr(encryption, "KEY_FILE_PATH", key_file)
+        monkeypatch.setattr(encryption, "DATA_DIR", data_dir)
+
+        # Make keyring unavailable
+        with patch.dict("sys.modules", {"keyring": None}):
+            key = EncryptionKeyManager._generate_and_store()
+
+        assert key is not None
+        assert key_file.exists()
+        assert key_file.read_text().encode() == key
+
+    def test_key_is_cached(self, env_key):
+        from core.encryption import EncryptionKeyManager
+
+        key1 = EncryptionKeyManager.get_key()
+        key2 = EncryptionKeyManager.get_key()
+        assert key1 is key2  # same object, not just equal
+
+
+# ---------------------------------------------------------------------------
+# CredentialStore integration
+# ---------------------------------------------------------------------------
+
+class TestCredentialStoreIntegration:
+    @pytest.fixture()
+    def store_env(self, tmp_path, monkeypatch, env_key):
+        """Set up a temporary data dir and return a CredentialStore factory."""
+        from core import encryption
+        from core.providers import credentials
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        profiles_path = data_dir / "auth-profiles.json"
+
+        monkeypatch.setattr(credentials, "DATA_DIR", data_dir)
+        monkeypatch.setattr(credentials, "PROFILES_PATH", profiles_path)
+        monkeypatch.setattr(encryption, "DATA_DIR", data_dir)
+
+        return {"data_dir": data_dir, "profiles_path": profiles_path}
+
+    def test_save_encrypts_on_disk(self, store_env):
+        from core.encryption import ENCRYPTED_PREFIX
+        from core.providers.credentials import CredentialStore
+
+        store = CredentialStore()
+        store.set_api_key("anthropic", "sk-ant-my-secret-key", "claude-opus-4-6")
+
+        # Read raw file — key should be encrypted
+        raw = json.loads(store_env["profiles_path"].read_text())
+        raw_key = raw["profiles"]["anthropic:default"]["key"]
+        assert raw_key.startswith(ENCRYPTED_PREFIX)
+
+    def test_load_decrypts_in_memory(self, store_env):
+        from core.providers.credentials import CredentialStore
+
+        store = CredentialStore()
+        store.set_api_key("anthropic", "sk-ant-my-secret-key", "claude-opus-4-6")
+
+        # Reload from disk
+        store2 = CredentialStore()
+        _, profile = store2.get_active_profile()
+        assert profile["key"] == "sk-ant-my-secret-key"
+
+    def test_auto_migration(self, store_env):
+        from core.encryption import ENCRYPTED_PREFIX
+        from core.providers.credentials import CredentialStore
+
+        # Write plaintext directly (simulating pre-encryption data)
+        plaintext_data = {
+            "active_provider": "anthropic",
+            "active_model": "claude-opus-4-6",
+            "profiles": {
+                "anthropic:default": {"type": "api_key", "key": "sk-ant-plain-key"}
+            },
+        }
+        store_env["profiles_path"].write_text(json.dumps(plaintext_data))
+
+        # Loading should trigger migration
+        store = CredentialStore()
+        _, profile = store.get_active_profile()
+        assert profile["key"] == "sk-ant-plain-key"  # decrypted in memory
+
+        # File on disk should now be encrypted
+        raw = json.loads(store_env["profiles_path"].read_text())
+        assert raw["profiles"]["anthropic:default"]["key"].startswith(ENCRYPTED_PREFIX)
+
+    def test_corrupted_credential_treated_as_missing(self, store_env):
+        from core.encryption import ENCRYPTED_PREFIX
+        from core.providers.credentials import CredentialStore
+
+        # Write a corrupted encrypted value
+        data = {
+            "active_provider": "anthropic",
+            "active_model": "claude-opus-4-6",
+            "profiles": {
+                "anthropic:default": {
+                    "type": "api_key",
+                    "key": f"{ENCRYPTED_PREFIX}corrupted-garbage-token",
+                }
+            },
+        }
+        store_env["profiles_path"].write_text(json.dumps(data))
+
+        store = CredentialStore()
+        _, profile = store.get_active_profile()
+        assert profile["key"] == ""  # treated as missing
+
+    def test_to_dict_still_works(self, store_env):
+        from core.providers.credentials import CredentialStore
+
+        store = CredentialStore()
+        store.set_api_key("anthropic", "sk-ant-my-secret-key-1234", "claude-opus-4-6")
+
+        summary = store.to_dict()
+        assert summary["profiles"]["anthropic"]["configured"] is True
+        assert summary["profiles"]["anthropic"]["key_preview"] == "...1234"
+
+    def test_oauth_tokens_encrypted(self, store_env):
+        from core.encryption import ENCRYPTED_PREFIX
+        from core.providers.credentials import CredentialStore
+
+        store = CredentialStore()
+        store.set_oauth_tokens("google", "ya29.access", "1//refresh", 3600)
+
+        raw = json.loads(store_env["profiles_path"].read_text())
+        profile = raw["profiles"]["google:default"]
+        assert profile["access"].startswith(ENCRYPTED_PREFIX)
+        assert profile["refresh"].startswith(ENCRYPTED_PREFIX)
+        assert isinstance(profile["expires"], int)  # not encrypted
+
+
+# ---------------------------------------------------------------------------
+# Integration registry integration
+# ---------------------------------------------------------------------------
+
+class TestRegistryIntegration:
+    @pytest.fixture()
+    def registry_env(self, tmp_path, monkeypatch, env_key):
+        from core import encryption
+        from integrations import registry
+
+        data_dir = tmp_path / "integrations"
+        data_dir.mkdir()
+        monkeypatch.setattr(registry, "DATA_DIR", data_dir)
+        monkeypatch.setattr(encryption, "DATA_DIR", tmp_path)
+        return data_dir
+
+    def test_save_encrypts_get_decrypts(self, registry_env):
+        from core.encryption import ENCRYPTED_PREFIX
+        from integrations.registry import get_credentials, save_credentials
+
+        creds = {
+            "url": "https://myodoo.com",
+            "database": "prod",
+            "username": "admin",
+            "api_key": "odoo-secret",
+            "enabled": True,
+        }
+        save_credentials("odoo", creds)
+
+        # Raw file has encrypted api_key
+        raw = json.loads((registry_env / "odoo.json").read_text())
+        assert raw["api_key"].startswith(ENCRYPTED_PREFIX)
+        assert raw["url"] == "https://myodoo.com"  # not encrypted
+
+        # get_credentials returns decrypted
+        loaded = get_credentials("odoo")
+        assert loaded["api_key"] == "odoo-secret"
+
+    def test_migration_on_get(self, registry_env):
+        from core.encryption import ENCRYPTED_PREFIX
+        from integrations.registry import get_credentials
+
+        # Write plaintext directly
+        path = registry_env / "bamboohr.json"
+        path.write_text(json.dumps({
+            "subdomain": "myco",
+            "api_key": "bamboo-plain-key",
+            "enabled": True,
+        }))
+
+        loaded = get_credentials("bamboohr")
+        assert loaded["api_key"] == "bamboo-plain-key"
+
+        # File should now be encrypted
+        raw = json.loads(path.read_text())
+        assert raw["api_key"].startswith(ENCRYPTED_PREFIX)
+
+    def test_is_enabled_works(self, registry_env):
+        from integrations.registry import is_enabled, save_credentials
+
+        save_credentials("odoo", {"api_key": "secret", "enabled": True})
+        assert is_enabled("odoo") is True
+
+        save_credentials("odoo", {"api_key": "secret", "enabled": False})
+        assert is_enabled("odoo") is False


### PR DESCRIPTION
## Summary
- Encrypt API keys and OAuth tokens on disk using Fernet (AES-128-CBC), with encryption key sourced from `ENCRYPTION_KEY` env var (deployed/Railway), OS keychain via `keyring` (local), or file fallback
- Existing plaintext credentials auto-migrate on first load; tampered values treated as missing so users can re-enter from the UI
- Transparent to all consumers — no changes to CredentialStore public API, provider factories, routers, integration clients, or frontend

## Test plan
- [ ] Run `PYTHONPATH=. python -m pytest tests/test_encryption.py -v` (29 tests covering roundtrips, tamper detection, migration, key management, CredentialStore + registry integration)
- [ ] Start app with existing plaintext credentials, verify auto-migration encrypts on disk
- [ ] Confirm AI chat still works after migration
- [ ] Verify `to_dict()` still shows correct key preview in frontend
- [ ] On macOS: `security find-generic-password -s chatty -a encryption-key` confirms keychain storage
- [ ] Test deployed mode: set `ENCRYPTION_KEY` env var, verify it's used instead of keychain