### PR TITLE
Add API key helper links to provider setup cards

### DIFF
--- a/frontend/src/setup/ApiKeyEntry.tsx
+++ b/frontend/src/setup/ApiKeyEntry.tsx
@@ -6,6 +6,12 @@ interface Props {
   onConnected: () => void;
 }
 
+const API_KEY_LINKS: Record<string, { url: string; label: string }> = {
+  anthropic: { url: 'https://console.anthropic.com/settings/keys', label: 'Get your API key at console.anthropic.com' },
+  openai: { url: 'https://platform.openai.com/api-keys', label: 'Get your API key at platform.openai.com' },
+  google: { url: 'https://aistudio.google.com/apikey', label: 'Get your API key at aistudio.google.com' },
+};
+
 export function ApiKeyEntry({ provider, onConnected }: Props) {
   const [key, setKey] = useState('');
   const [loading, setLoading] = useState(false);
@@ -42,6 +48,16 @@ export function ApiKeyEntry({ provider, onConnected }: Props) {
         className="w-full bg-gray-700 border border-gray-600 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-indigo-500"
       />
       {error && <p className="text-red-400 text-xs">{error}</p>}
+      {API_KEY_LINKS[provider] && (
+        <a
+          href={API_KEY_LINKS[provider].url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block text-xs text-indigo-400 hover:text-indigo-300 transition"
+        >
+          {API_KEY_LINKS[provider].label} &rarr;
+        </a>
+      )}
       <button
         onClick={connect}
         disabled={loading || !key.trim()}


### PR DESCRIPTION
## Summary
- Adds "Get your API key" links below the input field on each provider's connect card
- Links point to console.anthropic.com, platform.openai.com, and aistudio.google.com respectively
- These existed in the onboarding wizard but were missing from the main settings/provider setup screen

## Test plan
- [ ] Open Settings > AI Providers with no providers connected
- [ ] Verify each card shows the correct helper link below the API key input
- [ ] Click each link and confirm it opens the correct page in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)