### PR TITLE
Fix OpenAI and Gemini provider failures

### DIFF
--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -361,10 +361,38 @@ REPORT_TOOLS = [
                                 "description": "Data object. For bar/line/area/pie/donut: {labels: [str], datasets: [{name: str, values: [number]}]}. For table: {headers: [str], rows: [[value]]}. For metric: {metrics: [{label: str, value: number, change?: str, unit?: str}]}.",
                                 "properties": {
                                     "labels": {"type": "array", "items": {"type": "string"}, "description": "Category labels (bar/line/pie charts)"},
-                                    "datasets": {"type": "array", "description": "Data series. Each: {name: str, values: [number]}"},
+                                    "datasets": {
+                                        "type": "array",
+                                        "description": "Data series. Each: {name: str, values: [number]}",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {"type": "string"},
+                                                "values": {"type": "array", "items": {"type": "number"}},
+                                            },
+                                            "required": ["name", "values"],
+                                        },
+                                    },
                                     "headers": {"type": "array", "items": {"type": "string"}, "description": "Column headers (table only)"},
-                                    "rows": {"type": "array", "description": "Table rows, each an array of values"},
-                                    "metrics": {"type": "array", "description": "Metric cards: [{label, value, change?, unit?}]"},
+                                    "rows": {
+                                        "type": "array",
+                                        "description": "Table rows, each an array of values",
+                                        "items": {"type": "array", "items": {}},
+                                    },
+                                    "metrics": {
+                                        "type": "array",
+                                        "description": "Metric cards: [{label, value, change?, unit?}]",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "label": {"type": "string"},
+                                                "value": {"type": "number"},
+                                                "change": {"type": "string"},
+                                                "unit": {"type": "string"},
+                                            },
+                                            "required": ["label", "value"],
+                                        },
+                                    },
                                 },
                             },
                         },

--- a/backend/core/providers/google_provider.py
+++ b/backend/core/providers/google_provider.py
@@ -13,16 +13,35 @@ from core.providers.base import AIProvider
 
 logger = logging.getLogger(__name__)
 
+# Fields not supported by Gemini's Schema protobuf
+_UNSUPPORTED_SCHEMA_FIELDS = {"default", "examples", "additionalProperties"}
+
+
+def _clean_schema(schema: dict) -> dict:
+    """Recursively strip fields that Gemini's FunctionDeclaration doesn't support."""
+    if not isinstance(schema, dict):
+        return schema
+    result = {k: v for k, v in schema.items() if k not in _UNSUPPORTED_SCHEMA_FIELDS}
+    if "properties" in result:
+        result["properties"] = {
+            k: _clean_schema(v) for k, v in result["properties"].items()
+        }
+    if "items" in result and isinstance(result["items"], dict):
+        result["items"] = _clean_schema(result["items"])
+    return result
+
 GOOGLE_MODELS = [
-    "gemini-2.0-flash-exp",
-    "gemini-2.0-pro-exp",
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
     "gemini-1.5-pro",
     "gemini-1.5-flash",
 ]
 
 
 class GoogleProvider(AIProvider):
-    def __init__(self, access_token: str = "", api_key: str = "", model: str = "gemini-2.0-flash-exp"):
+    def __init__(self, access_token: str = "", api_key: str = "", model: str = "gemini-2.0-flash"):
         super().__init__(model=model)
         self.access_token = access_token
         self.api_key = api_key
@@ -41,7 +60,7 @@ class GoogleProvider(AIProvider):
 
         declarations = []
         for t in tools:
-            schema = t.get("input_schema", {})
+            schema = _clean_schema(t.get("input_schema", {}))
             declarations.append(FunctionDeclaration(
                 name=t["name"],
                 description=t.get("description", ""),
@@ -60,6 +79,7 @@ class GoogleProvider(AIProvider):
     ) -> AsyncGenerator[dict, None]:
         try:
             import google.generativeai as genai
+            from google.generativeai import protos
             from google.oauth2.credentials import Credentials
         except ImportError:
             yield {"type": "error", "error": "google-generativeai package not installed"}
@@ -78,10 +98,38 @@ class GoogleProvider(AIProvider):
         # Build Gemini history (all but last user message)
         history = []
         for m in messages[:-1]:
-            role = "user" if m["role"] == "user" else "model"
+            role = m.get("role", "user")
             content = m.get("content", "")
-            if isinstance(content, str) and content:
-                history.append({"role": role, "parts": [content]})
+
+            if isinstance(content, list):
+                # Structured parts: function calls or function responses
+                parts = []
+                for part_data in content:
+                    if not isinstance(part_data, dict):
+                        continue
+                    if part_data.get("_type") == "function_call":
+                        parts.append(protos.Part(
+                            function_call=protos.FunctionCall(
+                                name=part_data["name"],
+                                args=part_data.get("args", {}),
+                            )
+                        ))
+                    elif part_data.get("_type") == "function_response":
+                        parts.append(protos.Part(
+                            function_response=protos.FunctionResponse(
+                                name=part_data["name"],
+                                response=part_data.get("response", {}),
+                            )
+                        ))
+                if parts:
+                    gemini_role = "model" if role == "assistant" else "user"
+                    history.append(protos.Content(role=gemini_role, parts=parts))
+            elif isinstance(content, str) and content:
+                gemini_role = "model" if role != "user" else "user"
+                history.append(protos.Content(
+                    role=gemini_role,
+                    parts=[protos.Part(text=content)],
+                ))
 
         model_kwargs = {
             "model_name": self.model,
@@ -95,6 +143,8 @@ class GoogleProvider(AIProvider):
 
         # Last user message
         last_msg = messages[-1].get("content", "") if messages else ""
+        if not isinstance(last_msg, str):
+            last_msg = str(last_msg)
 
         full_text = ""
         tool_calls = []
@@ -147,19 +197,34 @@ class GoogleProvider(AIProvider):
         tool_calls: list[dict],
         results: list[dict],
     ) -> list[dict]:
-        """Append function call + function response to messages."""
-        # For Gemini we store these as special message entries that get
-        # converted to Parts in the next stream_turn() call.
-        # We use a simplified approach: store as tool_result role entries.
-        tool_result_msgs = []
-        for r in results:
-            tool_result_msgs.append({
-                "role": "tool",
-                "tool_use_id": r["tool_use_id"],
-                "tool_name": r.get("tool_name", ""),
-                "content": str(r["content"]),
+        """Append model function calls + user function responses to messages.
+
+        Gemini requires the conversation history to contain:
+        1. A model message with FunctionCall parts
+        2. A user message with FunctionResponse parts
+        These are stored as structured dicts and converted to protos in stream_turn().
+        """
+        # Model's function calls
+        fc_parts = []
+        for tc in tool_calls:
+            fc_parts.append({
+                "_type": "function_call",
+                "name": tc["name"],
+                "args": tc.get("args", {}),
             })
-        return messages + tool_result_msgs
+        assistant_msg = {"role": "assistant", "content": fc_parts}
+
+        # User's function responses
+        fr_parts = []
+        for r in results:
+            fr_parts.append({
+                "_type": "function_response",
+                "name": r.get("tool_name", ""),
+                "response": {"result": str(r["content"])},
+            })
+        user_msg = {"role": "user", "content": fr_parts}
+
+        return messages + [assistant_msg, user_msg]
 
     async def list_models(self) -> list[str]:
         return GOOGLE_MODELS

--- a/backend/core/providers/google_provider.py
+++ b/backend/core/providers/google_provider.py
@@ -141,16 +141,28 @@ class GoogleProvider(AIProvider):
         model = genai.GenerativeModel(**model_kwargs)
         chat = model.start_chat(history=history)
 
-        # Last user message
-        last_msg = messages[-1].get("content", "") if messages else ""
-        if not isinstance(last_msg, str):
-            last_msg = str(last_msg)
+        # Last user message — may be plain text or structured function responses
+        last_content = messages[-1].get("content", "") if messages else ""
+        if isinstance(last_content, list):
+            # Structured parts (function responses after tool execution)
+            parts = []
+            for part_data in last_content:
+                if isinstance(part_data, dict) and part_data.get("_type") == "function_response":
+                    parts.append(protos.Part(
+                        function_response=protos.FunctionResponse(
+                            name=part_data["name"],
+                            response=part_data.get("response", {}),
+                        )
+                    ))
+            send_msg = protos.Content(role="user", parts=parts) if parts else ""
+        else:
+            send_msg = last_content
 
         full_text = ""
         tool_calls = []
 
         try:
-            response = await chat.send_message_async(last_msg, stream=True)
+            response = await chat.send_message_async(send_msg, stream=True)
 
             async for chunk in response:
                 # Text chunks

--- a/backend/core/providers/openai_provider.py
+++ b/backend/core/providers/openai_provider.py
@@ -108,8 +108,8 @@ class OpenAIProvider(AIProvider):
         tool_calls: list[dict] = []
 
         try:
-            # Newer models (o-series, gpt-5.4+) require max_completion_tokens
-            uses_completion_tokens = self.model.startswith(("o", "gpt-5"))
+            # Newer models (o-series, gpt-5.x) require max_completion_tokens
+            uses_completion_tokens = self.model.startswith(("o1", "o3", "o4", "gpt-5"))
             token_param = "max_completion_tokens" if uses_completion_tokens else "max_tokens"
             kwargs = {
                 "model": self.model,

--- a/backend/core/providers/openai_provider.py
+++ b/backend/core/providers/openai_provider.py
@@ -14,6 +14,22 @@ from core.providers.base import AIProvider
 
 logger = logging.getLogger(__name__)
 
+
+def _ensure_array_items(schema: dict) -> dict:
+    """Recursively ensure all array types have an items field (OpenAI requirement)."""
+    if not isinstance(schema, dict):
+        return schema
+    result = dict(schema)
+    if result.get("type") == "array" and "items" not in result:
+        result["items"] = {}
+    if "properties" in result:
+        result["properties"] = {
+            k: _ensure_array_items(v) for k, v in result["properties"].items()
+        }
+    if "items" in result and isinstance(result["items"], dict):
+        result["items"] = _ensure_array_items(result["items"])
+    return result
+
 OPENAI_MODELS = [
     "gpt-5.4",
     "gpt-5.4-mini",
@@ -51,7 +67,9 @@ class OpenAIProvider(AIProvider):
                 "function": {
                     "name": t["name"],
                     "description": t.get("description", ""),
-                    "parameters": t.get("input_schema", {"type": "object", "properties": {}}),
+                    "parameters": _ensure_array_items(
+                        t.get("input_schema", {"type": "object", "properties": {}})
+                    ),
                 },
             }
             for t in tools
@@ -69,18 +87,35 @@ class OpenAIProvider(AIProvider):
         # Build messages with system prompt prepended
         api_messages = [{"role": "system", "content": system_prompt}]
         for m in messages:
-            if m.get("role") in ("user", "assistant") and m.get("content"):
-                api_messages.append({"role": m["role"], "content": m["content"]})
+            role = m.get("role")
+            if role == "user":
+                api_messages.append({"role": "user", "content": m.get("content", "")})
+            elif role == "assistant":
+                msg: dict = {"role": "assistant"}
+                if m.get("content") is not None:
+                    msg["content"] = m["content"]
+                if m.get("tool_calls"):
+                    msg["tool_calls"] = m["tool_calls"]
+                api_messages.append(msg)
+            elif role == "tool":
+                api_messages.append({
+                    "role": "tool",
+                    "tool_call_id": m.get("tool_call_id", ""),
+                    "content": m.get("content", ""),
+                })
 
         full_text = ""
         tool_calls: list[dict] = []
 
         try:
+            # Newer models (o-series, gpt-5.4+) require max_completion_tokens
+            uses_completion_tokens = self.model.startswith(("o", "gpt-5"))
+            token_param = "max_completion_tokens" if uses_completion_tokens else "max_tokens"
             kwargs = {
                 "model": self.model,
                 "messages": api_messages,
                 "stream": True,
-                "max_tokens": 16384,
+                token_param: 16384,
             }
             if openai_tools:
                 kwargs["tools"] = openai_tools

--- a/backend/integrations/odoo/tools/core_tools.py
+++ b/backend/integrations/odoo/tools/core_tools.py
@@ -35,6 +35,7 @@ CORE_TOOL_DEFS = [
                 "domain": {
                     "type": "array",
                     "description": "Odoo domain filter (list of [field, op, value] tuples)",
+                    "items": {"type": "array", "items": {}},
                     "default": [],
                 },
                 "fields": {
@@ -97,6 +98,7 @@ CORE_TOOL_DEFS = [
                 "domain": {
                     "type": "array",
                     "description": "Odoo domain filter",
+                    "items": {"type": "array", "items": {}},
                     "default": [],
                 },
                 "fields": {


### PR DESCRIPTION
## Summary
- **OpenAI**: Fix tool schema validation errors (missing `items` on array types), broken message filtering that dropped tool results on multi-turn conversations, and `max_tokens` → `max_completion_tokens` for newer models
- **Gemini**: Fix hanging on tool use by properly converting tool call/response messages to Gemini `FunctionCall`/`FunctionResponse` protos, strip unsupported schema fields (`default`, `examples`), update model list to current GA names
- **Defense-in-depth**: Added recursive `_ensure_array_items()` sanitizer in OpenAI provider and `_clean_schema()` in Gemini provider to catch future tool definition issues

## Test plan
- [ ] Start conversation with OpenAI provider — verify no schema errors
- [ ] Trigger a tool call with OpenAI (e.g. "list my context files") — verify multi-turn works
- [ ] Start conversation with Gemini provider — verify response streams back
- [ ] Trigger a tool call with Gemini — verify it completes without hanging
- [ ] Start conversation with Anthropic — verify no regression