### PR TITLE
Port Cake OS immersive chat + tool mode selector

### DIFF
--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -156,6 +156,13 @@ class ChatRequest(BaseModel):
     messages: list[dict]
     conversation_id: str | None = None
     training_mode: bool = False
+    tool_mode: str = "normal"
+    approved_tool: dict | None = None
+
+
+class ToolExecuteRequest(BaseModel):
+    tool: str
+    args: dict
 
 
 class ContextWriteRequest(BaseModel):
@@ -350,7 +357,8 @@ async def get_avatar(agent_id: str, user=Depends(get_current_user)):
 
 # ── Per-agent: Chat (shared helper) ──────────────────────────────────────────
 
-def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_id: str | None):
+def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_id: str | None,
+                  tool_mode: str = "normal", approved_tool: dict | None = None):
     """Build provider, registry, and return a StreamingResponse for agent chat."""
     config = build_agent_config(agent)
     ctx_manager = get_context_manager(agent["slug"])
@@ -395,6 +403,8 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
             chat_service=chat_service,
             anthropic_api_key=anthropic_api_key,
             integration_tool_defs=integration_tool_defs or None,
+            tool_mode=tool_mode,
+            approved_tool=approved_tool,
         ):
             yield event
 
@@ -413,7 +423,8 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
 async def agent_chat(agent_id: str, req: ChatRequest, user=Depends(get_current_user)):
     """Stream a chat response for a specific agent."""
     agent = _get_agent_or_404(agent_id)
-    return _stream_chat(agent, req.messages, req.training_mode, req.conversation_id)
+    return _stream_chat(agent, req.messages, req.training_mode, req.conversation_id,
+                        tool_mode=req.tool_mode, approved_tool=req.approved_tool)
 
 
 # ── Per-agent: Onboarding progress ───────────────────────────────────────────
@@ -613,7 +624,57 @@ async def agent_chat_upload(
         prefix = "\n\n".join(file_texts)
         last_msg["content"] = prefix + "\n\n" + (last_msg.get("content") or "")
 
-    return _stream_chat(agent, messages, body.get("training_mode", False), body.get("conversation_id"))
+    return _stream_chat(
+        agent, messages, body.get("training_mode", False), body.get("conversation_id"),
+        tool_mode=body.get("tool_mode", "normal"), approved_tool=body.get("approved_tool"),
+    )
+
+
+# ── Per-agent: Tool execute (confirmation approval) ─────────────────────────
+
+@router.post("/{agent_id}/tool/execute")
+async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_current_user)):
+    """Execute a write tool after user approval (confirmation flow)."""
+    agent = _get_agent_or_404(agent_id)
+    config = build_agent_config(agent)
+
+    store = CredentialStore()
+    google_token = ""
+    if config.gmail_enabled or config.calendar_enabled:
+        google_token = store.get_google_token() or ""
+
+    integration_tool_defs, integration_executors = _load_integration_tools()
+    reminder_handlers, sa_handlers = _build_agent_handlers(agent["slug"])
+
+    registry = ToolRegistry(
+        context_dir=config.context_dir,
+        google_access_token=google_token,
+        integration_executors=integration_executors,
+        agent_slug=agent["slug"],
+        reminder_handlers=reminder_handlers,
+        scheduled_action_handlers=sa_handlers,
+    )
+
+    from core.agents.tool_definitions import get_tool_definitions, build_writes_map
+    tool_defs = get_tool_definitions(
+        gmail_enabled=config.gmail_enabled,
+        calendar_enabled=config.calendar_enabled,
+        integration_tools=integration_tool_defs,
+    )
+    writes_map = build_writes_map(tool_defs)
+    if not writes_map.get(req.tool, False):
+        raise HTTPException(status_code=400, detail="Tool is not a write operation")
+
+    kind_map = {t["name"]: t.get("kind", "context") for t in tool_defs}
+    kind = kind_map.get(req.tool, "context")
+    result = await registry.execute_tool(req.tool, req.args, kind)
+
+    # Sync context files to GCS after write
+    ctx_manager = get_context_manager(agent["slug"])
+    from core.agents.ai_service import _sync_context_after_tool
+    _sync_context_after_tool(req.tool, result, ctx_manager)
+
+    return result
 
 
 # ── Per-agent: Reports ───────────────────────────────────────────────────────

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -31,7 +31,7 @@ from core.providers.base import AIProvider, _sse
 from .config import AgentConfig
 from .context_manager import ContextManager
 from .tool_registry import ToolRegistry
-from .tool_definitions import get_tool_definitions, get_report_instructions, get_scheduling_instructions
+from .tool_definitions import get_tool_definitions, get_report_instructions, get_scheduling_instructions, build_writes_map, build_context_memory_map
 from .tools.real_tools import load_all_real_tools
 
 logger = logging.getLogger(__name__)
@@ -256,6 +256,8 @@ async def chat(
     chat_service=None,
     anthropic_api_key: str = "",
     integration_tool_defs: list[dict] | None = None,
+    tool_mode: str = "normal",
+    approved_tool: dict | None = None,
 ) -> AsyncGenerator[str, None]:
     """Stream a chat response as SSE events.
 
@@ -272,7 +274,12 @@ async def chat(
         chat_service: Optional ChatHistoryService for persistence
         anthropic_api_key: For smart title generation (uses haiku, optional)
         integration_tool_defs: Extra tool definitions from enabled integrations
+        tool_mode: 'read-only', 'normal', or 'power'
+        approved_tool: Previously confirmed tool execution result to reconstruct
     """
+    # Training mode forces power (no confirmations needed during onboarding)
+    if training_mode:
+        tool_mode = "power"
     persist = not training_mode and chat_service is not None
 
     # ── Get tool definitions ──────────────────────────────────────────
@@ -287,9 +294,19 @@ async def chat(
         dynamic_real_tools=dynamic_real_tools or None,
     )
     kind_map = _build_kind_map(tool_defs)
+    writes_map = build_writes_map(tool_defs)
+    cm_map = build_context_memory_map(tool_defs)
 
-    # Strip internal 'kind' field before sending to provider
-    provider_tools = [{k: v for k, v in t.items() if k != "kind"} for t in tool_defs]
+    # ── Read-only mode: filter out write tools (except context_memory) ──
+    if tool_mode == "read-only":
+        tool_defs = [
+            t for t in tool_defs
+            if not t.get("writes", False) or t.get("context_memory", False)
+        ]
+
+    # Strip internal fields before sending to provider
+    _internal_fields = {"kind", "writes", "context_memory"}
+    provider_tools = [{k: v for k, v in t.items() if k not in _internal_fields} for t in tool_defs]
 
     # ── Chat history persistence ──────────────────────────────────────
     if persist:
@@ -355,6 +372,29 @@ async def chat(
             )
 
     accumulated_text = ""
+
+    # ── Reconstruct approved tool in message history ──────────────────
+    if approved_tool:
+        at_tool = approved_tool.get("tool", "")
+        at_args = approved_tool.get("args", {})
+        at_id = approved_tool.get("toolUseId", str(uuid.uuid4()))
+        at_result = approved_tool.get("result", {})
+
+        # Build fake tool_calls and results for provider reconstruction
+        fake_tc = [{"name": at_tool, "id": at_id, "args": at_args}]
+        fake_results = [{
+            "tool_use_id": at_id,
+            "tool_name": at_tool,
+            "content": json.dumps(at_result),
+        }]
+
+        # Remove the "[Approved]" user message (last in the list) since the
+        # provider needs tool_use/tool_result blocks instead
+        if current_messages and current_messages[-1].get("role") == "user":
+            current_messages = current_messages[:-1]
+
+        # Reconstruct via provider abstraction
+        current_messages = provider.add_tool_results(current_messages, fake_tc, fake_results)
 
     # ── Tool execution loop ───────────────────────────────────────────
     max_iterations = 20
@@ -429,11 +469,42 @@ async def chat(
             return
 
         results = []
+        has_pending_confirmation = False
+
         for tc in tool_calls_this_turn:
             tool_name = tc.get("name", "")
             tool_use_id = tc.get("id", "")
             tool_args = tc.get("args", {})
             kind = kind_map.get(tool_name, "context")
+
+            # ── Normal mode: intercept write tools (not context_memory) ──
+            is_write = writes_map.get(tool_name, False)
+            is_cm = cm_map.get(tool_name, False)
+
+            if tool_mode == "normal" and is_write and not is_cm:
+                # Get human-readable description
+                tool_desc = next(
+                    (t.get("description", tool_name) for t in tool_defs if t["name"] == tool_name),
+                    tool_name,
+                )
+                yield _sse({
+                    "type": "confirm",
+                    "tool": tool_name,
+                    "args": tool_args,
+                    "tool_use_id": tool_use_id,
+                    "description": tool_desc,
+                })
+
+                # Feed pending result to provider so it can describe the action
+                result = {"status": "pending_user_approval", "message": f"Waiting for user to approve: {tool_name}"}
+                result_str = json.dumps(result)
+                results.append({
+                    "tool_use_id": tool_use_id,
+                    "tool_name": tool_name,
+                    "content": result_str,
+                })
+                has_pending_confirmation = True
+                continue
 
             t_start = time.time()
             result = await registry.execute_tool(tool_name, tool_args, kind)
@@ -459,6 +530,19 @@ async def chat(
 
         # Append tool results to messages for next turn
         current_messages = provider.add_tool_results(current_messages, tool_calls_this_turn, results)
+
+        # If we have a pending confirmation, do one more streaming turn
+        # to let the AI describe the pending action, then stop
+        if has_pending_confirmation:
+            async for event in provider.stream_turn(current_messages, provider_tools, system_prompt):
+                etype = event.get("type")
+                if etype == "text":
+                    accumulated_text += event["text"]
+                    yield _sse({"type": "text", "text": event["text"]})
+                elif etype == "_turn_complete":
+                    break
+            yield _sse({"type": "done"})
+            return
 
     # Exceeded max iterations
     yield _sse({"type": "error", "error": "Tool loop exceeded maximum iterations"})

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -277,6 +277,10 @@ async def chat(
         tool_mode: 'read-only', 'normal', or 'power'
         approved_tool: Previously confirmed tool execution result to reconstruct
     """
+    # Validate tool_mode
+    if tool_mode not in ("read-only", "normal", "power"):
+        tool_mode = "normal"
+
     # Training mode forces power (no confirmations needed during onboarding)
     if training_mode:
         tool_mode = "power"
@@ -390,7 +394,9 @@ async def chat(
 
         # Remove the "[Approved]" user message (last in the list) since the
         # provider needs tool_use/tool_result blocks instead
-        if current_messages and current_messages[-1].get("role") == "user":
+        if (current_messages
+            and current_messages[-1].get("role") == "user"
+            and str(current_messages[-1].get("content", "")).startswith("[Approved]")):
             current_messages = current_messages[:-1]
 
         # Reconstruct via provider abstraction

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -17,6 +17,8 @@ CONTEXT_TOOLS = [
             "required": [],
         },
         "kind": "context",
+        "writes": False,
+        "context_memory": True,
     },
     {
         "name": "read_context_file",
@@ -32,6 +34,8 @@ CONTEXT_TOOLS = [
             "required": ["filename"],
         },
         "kind": "context",
+        "writes": False,
+        "context_memory": True,
     },
     {
         "name": "write_context_file",
@@ -51,6 +55,8 @@ CONTEXT_TOOLS = [
             "required": ["filename", "content"],
         },
         "kind": "context",
+        "writes": True,
+        "context_memory": True,
     },
     {
         "name": "append_to_context_file",
@@ -70,6 +76,8 @@ CONTEXT_TOOLS = [
             "required": ["filename", "content"],
         },
         "kind": "context",
+        "writes": True,
+        "context_memory": True,
     },
     {
         "name": "delete_context_file",
@@ -85,6 +93,8 @@ CONTEXT_TOOLS = [
             "required": ["filename"],
         },
         "kind": "context",
+        "writes": True,
+        "context_memory": True,
     },
 ]
 
@@ -110,6 +120,7 @@ GMAIL_TOOLS = [
             "required": ["query"],
         },
         "kind": "gmail",
+        "writes": False,
     },
     {
         "name": "get_email",
@@ -125,6 +136,7 @@ GMAIL_TOOLS = [
             "required": ["message_id"],
         },
         "kind": "gmail",
+        "writes": False,
     },
     {
         "name": "get_email_thread",
@@ -140,6 +152,7 @@ GMAIL_TOOLS = [
             "required": ["thread_id"],
         },
         "kind": "gmail",
+        "writes": False,
     },
 ]
 
@@ -174,6 +187,7 @@ CALENDAR_TOOLS = [
             "required": [],
         },
         "kind": "calendar",
+        "writes": False,
     },
     {
         "name": "get_calendar_event",
@@ -194,6 +208,7 @@ CALENDAR_TOOLS = [
             "required": ["event_id"],
         },
         "kind": "calendar",
+        "writes": False,
     },
     {
         "name": "search_calendar_events",
@@ -219,6 +234,7 @@ CALENDAR_TOOLS = [
             "required": ["query"],
         },
         "kind": "calendar",
+        "writes": False,
     },
 ]
 
@@ -244,6 +260,7 @@ WEB_TOOLS = [
             "required": ["query"],
         },
         "kind": "web",
+        "writes": False,
     },
     {
         "name": "web_fetch",
@@ -263,6 +280,7 @@ WEB_TOOLS = [
             "required": ["url"],
         },
         "kind": "web",
+        "writes": False,
     },
 ]
 
@@ -282,6 +300,8 @@ REAL_TOOL_DEFS = [
             "required": ["name", "definition"],
         },
         "kind": "real_tool",
+        "writes": True,
+        "context_memory": True,
     },
     {
         "name": "update_real_tool",
@@ -295,6 +315,8 @@ REAL_TOOL_DEFS = [
             "required": ["name", "definition"],
         },
         "kind": "real_tool",
+        "writes": True,
+        "context_memory": True,
     },
     {
         "name": "delete_real_tool",
@@ -307,6 +329,8 @@ REAL_TOOL_DEFS = [
             "required": ["name"],
         },
         "kind": "real_tool",
+        "writes": True,
+        "context_memory": True,
     },
     {
         "name": "list_real_tools",
@@ -317,6 +341,8 @@ REAL_TOOL_DEFS = [
             "required": [],
         },
         "kind": "real_tool",
+        "writes": False,
+        "context_memory": True,
     },
     {
         "name": "test_real_tool",
@@ -330,6 +356,8 @@ REAL_TOOL_DEFS = [
             "required": ["definition"],
         },
         "kind": "real_tool",
+        "writes": False,
+        "context_memory": True,
     },
 ]
 
@@ -375,6 +403,8 @@ REPORT_TOOLS = [
             "required": ["title", "sections"],
         },
         "kind": "report",
+        "writes": True,
+        "context_memory": True,
     },
 ]
 
@@ -394,6 +424,7 @@ REMINDER_TOOLS = [
             "required": ["message", "due_at"],
         },
         "kind": "reminder",
+        "writes": True,
     },
     {
         "name": "list_reminders",
@@ -406,6 +437,7 @@ REMINDER_TOOLS = [
             "required": [],
         },
         "kind": "reminder",
+        "writes": False,
     },
     {
         "name": "cancel_reminder",
@@ -418,6 +450,7 @@ REMINDER_TOOLS = [
             "required": ["reminder_id"],
         },
         "kind": "reminder",
+        "writes": True,
     },
 ]
 
@@ -443,6 +476,7 @@ SCHEDULED_ACTION_TOOLS = [
             "required": ["name", "prompt", "schedule_type"],
         },
         "kind": "scheduled_action",
+        "writes": True,
     },
     {
         "name": "list_scheduled_actions",
@@ -453,6 +487,7 @@ SCHEDULED_ACTION_TOOLS = [
             "required": [],
         },
         "kind": "scheduled_action",
+        "writes": False,
     },
     {
         "name": "update_scheduled_action",
@@ -471,6 +506,7 @@ SCHEDULED_ACTION_TOOLS = [
             "required": ["action_id"],
         },
         "kind": "scheduled_action",
+        "writes": True,
     },
     {
         "name": "delete_scheduled_action",
@@ -483,6 +519,7 @@ SCHEDULED_ACTION_TOOLS = [
             "required": ["action_id"],
         },
         "kind": "scheduled_action",
+        "writes": True,
     },
 ]
 
@@ -522,6 +559,18 @@ Guidelines:
 - Set reasonable active hours to avoid running during off-hours
 - Prefer cron expressions for recurring tasks, 'once' for one-time future tasks
 """
+
+
+# ── Helper maps for tool mode ────────────────────────────────────────────────
+
+def build_writes_map(tool_defs: list[dict]) -> dict[str, bool]:
+    """Map tool name → whether it performs write operations."""
+    return {t["name"]: t.get("writes", False) for t in tool_defs}
+
+
+def build_context_memory_map(tool_defs: list[dict]) -> dict[str, bool]:
+    """Map tool name → whether it's a context/memory tool (always allowed)."""
+    return {t["name"]: t.get("context_memory", False) for t in tool_defs}
 
 
 def get_tool_definitions(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,15 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "highlight.js": "^11.11.1",
         "html2pdf.js": "^0.14.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.2",
-        "recharts": "^3.8.1"
+        "recharts": "^3.8.1",
+        "rehype-highlight": "^7.0.2",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1256,18 +1260,59 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1297,7 +1342,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1319,6 +1363,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -1621,6 +1671,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -1709,6 +1765,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1835,6 +1901,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1850,6 +1926,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/clsx": {
@@ -1880,6 +1996,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1948,7 +2074,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2076,7 +2201,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2096,12 +2220,34 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2111,6 +2257,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dompurify": {
@@ -2350,6 +2509,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2364,6 +2533,12 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -2541,6 +2716,75 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -2556,6 +2800,25 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/html2canvas": {
@@ -2629,6 +2892,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2643,6 +2912,40 @@
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
       "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
       "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2665,6 +2968,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3076,6 +3401,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3096,6 +3446,861 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3113,7 +4318,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3218,6 +4422,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3304,6 +4533,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3351,6 +4590,33 @@
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -3464,6 +4730,89 @@
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -3587,6 +4936,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -3595,6 +4954,20 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.14"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3608,6 +4981,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -3684,6 +5075,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3765,6 +5176,107 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3822,6 +5334,34 @@
       "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -3991,6 +5531,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,11 +10,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "highlight.js": "^11.11.1",
     "html2pdf.js": "^0.14.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.2",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "rehype-highlight": "^7.0.2",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -1,13 +1,15 @@
 /**
  * Chatty — AgentPage.
- * Chat + Knowledge tabs with collapsible sidebar.
+ * Immersive chat with auto-hiding top bar, tool mode selector,
+ * collapsible sidebar, and Chat/Knowledge/Reports tabs.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../core/api/client';
-import { useAgentChat } from './hooks/useAgentChat';
+import { useAgentChat, type ToolMode } from './hooks/useAgentChat';
 import { useConversations } from './hooks/useConversations';
+import { useScrollDirection } from './hooks/useScrollDirection';
 import { AgentChatPanel } from './components/AgentChatPanel';
 import { AgentContextEditor } from './components/AgentContextEditor';
 import ReportsPanel from './reports/ReportsPanel';
@@ -25,6 +27,12 @@ interface AgentRow {
 }
 
 type Tab = 'chat' | 'knowledge' | 'reports';
+
+const TOOL_MODES: { key: ToolMode; label: string; activeClass: string }[] = [
+  { key: 'read-only', label: 'Read Only', activeClass: 'bg-gray-600' },
+  { key: 'normal', label: 'Normal', activeClass: 'bg-indigo-600' },
+  { key: 'power', label: 'Power', activeClass: 'bg-amber-600' },
+];
 
 export function AgentPage() {
   const { id: agentId } = useParams<{ id: string }>();
@@ -46,6 +54,10 @@ export function AgentPage() {
   }, [convs]);
 
   const chat = useAgentChat(apiPrefix, { onTitleUpdate: handleTitleUpdate });
+
+  // Scroll direction for auto-hiding top bar
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const topBarVisible = useScrollDirection(scrollRef);
 
   // Load agent details
   useEffect(() => {
@@ -100,9 +112,15 @@ export function AgentPage() {
     chat.setTrainingMode(true);
   }
 
+  function handleToolModeChange(mode: ToolMode) {
+    if (mode === 'power') {
+      if (!window.confirm(`Enable Power mode? ${agent?.agent_name || 'This agent'} will be able to read and write without asking for confirmation.`)) return;
+    }
+    chat.setToolMode(mode);
+  }
+
   function handleAvatarComplete() {
     setShowAvatarPicker(false);
-    // Reload agent to get updated avatar_url
     if (agentId) {
       api<AgentRow>(`/api/agents/${agentId}`).then(setAgent).catch(() => {});
     }
@@ -123,10 +141,15 @@ export function AgentPage() {
     .toUpperCase()
     .slice(0, 2);
 
+  // Only auto-hide on chat tab; always visible on other tabs
+  const showTopBar = activeTab !== 'chat' || topBarVisible;
+
   return (
     <div className="flex flex-col h-screen bg-gray-950 text-white overflow-hidden">
-      {/* Top bar */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-800 bg-gray-950 flex-shrink-0">
+      {/* Top bar — auto-hides on scroll in chat tab */}
+      <div className={`flex items-center gap-3 px-4 py-3 border-b border-gray-800 bg-gray-950/95 backdrop-blur-sm flex-shrink-0 z-30 transition-all duration-300 ${
+        showTopBar ? 'translate-y-0 opacity-100' : '-translate-y-full opacity-0 pointer-events-none'
+      }`}>
         <button
           onClick={() => navigate('/')}
           className="text-gray-400 hover:text-white transition p-1.5 rounded-lg hover:bg-gray-800 text-sm"
@@ -169,6 +192,25 @@ export function AgentPage() {
           </span>
         )}
 
+        {/* Tool mode selector — hidden on mobile, hidden during training */}
+        {!chat.trainingMode && (
+          <div className="hidden sm:flex items-center bg-gray-800 rounded-full p-0.5 gap-0.5">
+            {TOOL_MODES.map(m => (
+              <button
+                key={m.key}
+                onClick={() => handleToolModeChange(m.key)}
+                className={`px-2 py-0.5 text-xs font-medium rounded-full transition-all ${
+                  chat.toolMode === m.key
+                    ? `${m.activeClass} text-white`
+                    : 'text-gray-400 hover:text-white'
+                }`}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+        )}
+
         {/* Tab switcher */}
         <div className="ml-auto flex items-center bg-gray-800 rounded-lg p-0.5 gap-0.5">
           {(['chat', 'knowledge', 'reports'] as Tab[]).map(tab => (
@@ -186,6 +228,14 @@ export function AgentPage() {
           ))}
         </div>
       </div>
+
+      {/* Power mode warning banner */}
+      {chat.toolMode === 'power' && !chat.trainingMode && (
+        <div className="px-3 py-1.5 bg-amber-900/30 border-b border-amber-700/40 flex items-center gap-2 flex-shrink-0">
+          <span className="text-amber-400 text-xs font-semibold">POWER MODE</span>
+          <span className="text-xs text-amber-300">{agent.agent_name} can read and write without confirmation.</span>
+        </div>
+      )}
 
       {/* Body */}
       <div className="flex flex-1 overflow-hidden">
@@ -210,6 +260,9 @@ export function AgentPage() {
               isStreaming={chat.isStreaming}
               onSend={chat.sendMessage}
               onStop={chat.stop}
+              onApprove={chat.approveAction}
+              onDeny={chat.denyAction}
+              scrollRef={scrollRef}
             />
           </>
         ) : activeTab === 'knowledge' ? (

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -132,8 +132,7 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprov
 
   // Click on messages area refocuses input (unless clicking interactive elements)
   function handleMessagesClick(e: MouseEvent) {
-    const tag = (e.target as HTMLElement).tagName;
-    if (['BUTTON', 'A', 'INPUT', 'TEXTAREA', 'PRE', 'CODE'].includes(tag)) return;
+    if ((e.target as HTMLElement).closest?.('button, a, input, textarea, pre, code')) return;
     textareaRef.current?.focus();
   }
 

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -1,9 +1,10 @@
 /**
  * Chatty — AgentChatPanel.
- * Floating pill input with send/stop controls, file upload (paperclip + drag-and-drop).
+ * Centered reading column with floating pill input and gradient fade.
+ * File upload via paperclip + drag-and-drop.
  */
 
-import { useState, useRef, useEffect, useCallback, type KeyboardEvent, type DragEvent } from 'react';
+import { useState, useRef, useEffect, useCallback, type RefObject, type KeyboardEvent, type DragEvent, type MouseEvent } from 'react';
 import type { ChatMessage } from '../hooks/useAgentChat';
 import { AgentMessageBubble } from './AgentMessageBubble';
 
@@ -20,20 +21,31 @@ interface Props {
   isStreaming: boolean;
   onSend: (text: string, files?: File[]) => void;
   onStop: () => void;
+  onApprove?: (msgId: string) => void;
+  onDeny?: (msgId: string) => void;
+  scrollRef?: RefObject<HTMLDivElement | null>;
 }
 
-export function AgentChatPanel({ messages, isStreaming, onSend, onStop }: Props) {
+export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprove, onDeny, scrollRef: externalScrollRef }: Props) {
   const [input, setInput] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [dragOver, setDragOver] = useState(false);
   const [fileError, setFileError] = useState<string | null>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const internalScrollRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = externalScrollRef || internalScrollRef;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Auto-scroll to bottom on new messages
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+    const el = scrollContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, scrollContainerRef]);
+
+  // Auto-focus textarea on mount and after streaming stops
+  useEffect(() => {
+    if (!isStreaming) textareaRef.current?.focus();
+  }, [isStreaming]);
 
   // Auto-dismiss file error
   useEffect(() => {
@@ -118,7 +130,15 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop }: Props)
     e.target.style.height = Math.min(e.target.scrollHeight, 200) + 'px';
   }
 
+  // Click on messages area refocuses input (unless clicking interactive elements)
+  function handleMessagesClick(e: MouseEvent) {
+    const tag = (e.target as HTMLElement).tagName;
+    if (['BUTTON', 'A', 'INPUT', 'TEXTAREA', 'PRE', 'CODE'].includes(tag)) return;
+    textareaRef.current?.focus();
+  }
+
   const isEmpty = messages.length === 0;
+  const isMultiLine = input.includes('\n') || (textareaRef.current && textareaRef.current.scrollHeight > 44);
 
   return (
     <div
@@ -134,21 +154,29 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop }: Props)
         </div>
       )}
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-6 py-4">
+      {/* Messages — centered reading column */}
+      <div
+        ref={scrollContainerRef}
+        className="flex-1 overflow-y-auto pb-40 sm:pb-48"
+        onClick={handleMessagesClick}
+      >
         {isEmpty && !isStreaming ? (
-          <div className="flex flex-col items-center justify-center h-full text-center">
+          <div className="flex flex-col items-center justify-center min-h-[60vh] text-center">
             <div className="text-5xl mb-4">💬</div>
-            <p className="text-gray-400">Start a conversation</p>
-            <p className="text-gray-600 text-sm mt-1">Type a message below</p>
+            <p className="text-gray-400 text-sm font-medium">Start a conversation</p>
+            <p className="text-gray-600 text-xs mt-1">Type a message below</p>
           </div>
         ) : (
-          <>
+          <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
             {messages.map(msg => (
-              <AgentMessageBubble key={msg.id} message={msg} />
+              <AgentMessageBubble
+                key={msg.id}
+                message={msg}
+                onApprove={onApprove}
+                onDeny={onDeny}
+              />
             ))}
-            <div ref={bottomRef} />
-          </>
+          </div>
         )}
       </div>
 
@@ -159,80 +187,86 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop }: Props)
         </div>
       )}
 
-      {/* Floating pill input */}
-      <div className="px-4 pb-4 pt-2">
-        {/* Pending file chips */}
-        {pendingFiles.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mb-2 px-1">
-            {pendingFiles.map((f, i) => (
-              <span key={i} className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-gray-700 border border-gray-600 rounded-lg text-xs text-gray-300">
-                <svg className="w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
-                {f.name}
-                <button onClick={() => removeFile(i)} className="text-gray-500 hover:text-gray-300 ml-0.5">&times;</button>
-              </span>
-            ))}
-          </div>
-        )}
+      {/* Floating input with gradient fade */}
+      <div className="absolute bottom-0 inset-x-0 pointer-events-none z-20">
+        <div className="h-12 bg-gradient-to-t from-gray-950 to-transparent" />
 
-        <div className="bg-gray-800 border border-gray-700 rounded-2xl shadow-xl focus-within:border-indigo-500/60 transition">
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={autoResize}
-            onKeyDown={handleKeyDown}
-            placeholder="Message..."
-            disabled={isStreaming}
-            rows={1}
-            className="w-full bg-transparent text-white placeholder-gray-500 text-sm px-4 pt-3 pb-0 resize-none focus:outline-none disabled:opacity-50"
-          />
+        <div className="bg-gray-950 px-3 sm:px-4 pb-3 sm:pb-4 pointer-events-auto">
+          <div className="mx-auto max-w-2xl">
+            {/* Pending file chips */}
+            {pendingFiles.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-2 px-1">
+                {pendingFiles.map((f, i) => (
+                  <span key={i} className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-gray-700 border border-gray-600 rounded-lg text-xs text-gray-300">
+                    <svg className="w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+                    {f.name}
+                    <button onClick={() => removeFile(i)} className="text-gray-500 hover:text-gray-300 ml-0.5">&times;</button>
+                  </span>
+                ))}
+              </div>
+            )}
 
-          <div className="flex items-center justify-between px-3 pb-2 pt-1">
-            {/* Paperclip */}
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isStreaming}
-              title="Attach files (CSV, XLSX, MD, TXT)"
-              className="text-gray-500 hover:text-gray-300 disabled:opacity-30 transition p-1"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              accept=".csv,.xlsx,.md,.txt"
-              className="hidden"
-              onChange={e => {
-                if (e.target.files?.length) {
-                  validateAndAddFiles(Array.from(e.target.files));
-                  e.target.value = '';
-                }
-              }}
-            />
+            <div className={`bg-gray-800 border border-gray-700 ${isMultiLine ? 'rounded-3xl' : 'rounded-full'} shadow-lg focus-within:shadow-xl focus-within:border-indigo-500/60 transition`}>
+              <textarea
+                ref={textareaRef}
+                value={input}
+                onChange={autoResize}
+                onKeyDown={handleKeyDown}
+                placeholder="Message..."
+                disabled={isStreaming}
+                rows={1}
+                className="w-full bg-transparent text-white placeholder-gray-500 text-sm px-4 pt-3 pb-0 resize-none focus:outline-none disabled:opacity-50"
+              />
 
-            <div className="flex gap-2">
-              {isStreaming ? (
+              <div className="flex items-center justify-between px-3 pb-2 pt-1">
+                {/* Paperclip */}
                 <button
-                  onClick={onStop}
-                  className="text-xs text-red-400 border border-red-500/30 rounded-lg px-3 py-1.5 hover:bg-red-500/10 transition"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isStreaming}
+                  title="Attach files (CSV, XLSX, MD, TXT)"
+                  className="text-gray-500 hover:text-gray-300 disabled:opacity-30 transition p-1"
                 >
-                  Stop
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
                 </button>
-              ) : (
-                <button
-                  onClick={handleSend}
-                  disabled={!input.trim() && pendingFiles.length === 0}
-                  className="bg-brand text-white text-xs font-semibold px-4 py-1.5 rounded-lg hover:opacity-90 transition disabled:opacity-30 disabled:cursor-not-allowed"
-                >
-                  Send
-                </button>
-              )}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  accept=".csv,.xlsx,.md,.txt"
+                  className="hidden"
+                  onChange={e => {
+                    if (e.target.files?.length) {
+                      validateAndAddFiles(Array.from(e.target.files));
+                      e.target.value = '';
+                    }
+                  }}
+                />
+
+                <div className="flex gap-2">
+                  {isStreaming ? (
+                    <button
+                      onClick={onStop}
+                      className="text-xs text-red-400 border border-red-500/30 rounded-lg px-3 py-1.5 hover:bg-red-500/10 transition"
+                    >
+                      Stop
+                    </button>
+                  ) : (
+                    <button
+                      onClick={handleSend}
+                      disabled={!input.trim() && pendingFiles.length === 0}
+                      className="bg-brand text-white text-xs font-semibold px-4 py-1.5 rounded-lg hover:opacity-90 transition disabled:opacity-30 disabled:cursor-not-allowed"
+                    >
+                      Send
+                    </button>
+                  )}
+                </div>
+              </div>
             </div>
+            <p className="text-center text-gray-700 text-xs mt-2">
+              Enter to send · Shift+Enter for new line · Drop or clip files to attach
+            </p>
           </div>
         </div>
-        <p className="text-center text-gray-700 text-xs mt-2">
-          Enter to send · Shift+Enter for new line · Drop or clip files to attach
-        </p>
       </div>
     </div>
   );

--- a/frontend/src/agent/components/AgentMessageBubble.tsx
+++ b/frontend/src/agent/components/AgentMessageBubble.tsx
@@ -1,13 +1,17 @@
 /**
  * Chatty — AgentMessageBubble.
- * Expandable tool pills with elapsed timer. No voice, no confirm flow.
+ * Claude-style: flat assistant messages with markdown, branded user bubbles.
+ * Expandable tool pills with elapsed timer. Confirmation cards for write ops.
  */
 
 import { useState, useEffect } from 'react';
-import type { ChatMessage, ToolCallInfo } from '../hooks/useAgentChat';
+import type { ChatMessage, ToolCallInfo, PendingConfirmation } from '../hooks/useAgentChat';
+import MarkdownContent from './MarkdownContent';
 
 interface Props {
   message: ChatMessage;
+  onApprove?: (msgId: string) => void;
+  onDeny?: (msgId: string) => void;
 }
 
 const HUNG_THRESHOLD_SEC = 30;
@@ -86,47 +90,125 @@ function ToolPill({ tc }: { tc: ToolCallInfo }) {
   );
 }
 
-export function AgentMessageBubble({ message }: Props) {
-  const isUser = message.role === 'user';
+function ConfirmationCard({ confirm, onApprove, onDeny }: {
+  confirm: PendingConfirmation;
+  onApprove?: () => void;
+  onDeny?: () => void;
+}) {
+  const borderColor = confirm.status === 'approved'
+    ? 'border-green-700/40 bg-green-900/20'
+    : confirm.status === 'denied'
+    ? 'border-red-700/40 bg-red-900/20'
+    : 'border-amber-700/40 bg-amber-900/20';
+
+  const dotColor = confirm.status === 'approved'
+    ? 'bg-green-500'
+    : confirm.status === 'denied'
+    ? 'bg-red-500'
+    : 'bg-amber-400 animate-pulse';
+
+  const statusLabel = confirm.status === 'approved'
+    ? 'Approved'
+    : confirm.status === 'denied'
+    ? 'Denied'
+    : 'Awaiting approval';
 
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-4`}>
-      <div className={`max-w-[85%] ${isUser ? 'max-w-[70%]' : ''}`}>
-        {/* Tool pills (assistant only) */}
-        {!isUser && message.toolCalls && message.toolCalls.length > 0 && (
-          <div className="mb-2">
-            {message.toolCalls.map(tc => (
-              <ToolPill key={tc.toolUseId} tc={tc} />
-            ))}
-          </div>
-        )}
-
-        {/* File attachments (user messages) */}
-        {isUser && message.attachments && message.attachments.length > 0 && (
-          <div className="mb-1.5 flex flex-wrap gap-1">
-            {message.attachments.map((att, i) => (
-              <span key={i} className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-500/30 border border-indigo-500/40 rounded text-xs text-indigo-200">
-                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
-                {att.name}
-              </span>
-            ))}
-          </div>
-        )}
-
-        {/* Message bubble */}
-        {(message.content || (isUser)) && (
-          <div className={`rounded-2xl px-4 py-3 text-sm leading-relaxed whitespace-pre-wrap ${
-            isUser
-              ? 'bg-indigo-600 text-white rounded-br-sm'
-              : 'bg-gray-800 text-gray-100 rounded-bl-sm'
-          }`}>
-            {message.content}
-            {message.isStreaming && !message.content && (
-              <span className="inline-block w-2 h-4 bg-gray-400 animate-pulse rounded-sm" />
-            )}
-          </div>
-        )}
+    <div className={`mt-3 rounded-xl border p-3 ${borderColor}`}>
+      <div className="flex items-center gap-2 mb-1">
+        <span className={`w-2 h-2 rounded-full ${dotColor}`} />
+        <span className="text-xs font-semibold text-gray-200">{statusLabel}</span>
       </div>
+      <p className="text-xs text-gray-400 mb-2">
+        {confirm.description || `Execute ${confirm.tool}`}
+      </p>
+      {confirm.status === 'pending' && (
+        <div className="flex gap-2">
+          <button
+            onClick={onApprove}
+            className="px-3 py-1 text-xs font-medium rounded-lg bg-green-700/50 text-green-200 hover:bg-green-700/70 transition"
+          >
+            Approve
+          </button>
+          <button
+            onClick={onDeny}
+            className="px-3 py-1 text-xs font-medium rounded-lg bg-red-700/50 text-red-200 hover:bg-red-700/70 transition"
+          >
+            Deny
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BouncingDots() {
+  return (
+    <div className="flex items-center gap-1 py-1">
+      {[0, 1, 2].map(i => (
+        <span
+          key={i}
+          className="w-1.5 h-1.5 rounded-full bg-gray-500 animate-bounce"
+          style={{ animationDelay: `${i * 0.15}s` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function AgentMessageBubble({ message, onApprove, onDeny }: Props) {
+  const isUser = message.role === 'user';
+
+  // ── User message: branded right-aligned bubble ──
+  if (isUser) {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[85%] sm:max-w-[75%]">
+          {message.attachments && message.attachments.length > 0 && (
+            <div className="mb-1.5 flex flex-wrap gap-1 justify-end">
+              {message.attachments.map((att, i) => (
+                <span key={i} className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-500/30 border border-indigo-500/40 rounded text-xs text-indigo-200">
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+                  {att.name}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="bg-indigo-600 text-white rounded-2xl rounded-br-sm px-4 py-3 text-sm leading-relaxed whitespace-pre-wrap break-words">
+            {message.content}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Assistant message: flat, no bubble, markdown rendered ──
+  return (
+    <div className="w-full">
+      {/* Tool pills */}
+      {message.toolCalls && message.toolCalls.length > 0 && (
+        <div className="mb-2">
+          {message.toolCalls.map(tc => (
+            <ToolPill key={tc.toolUseId} tc={tc} />
+          ))}
+        </div>
+      )}
+
+      {/* Message content */}
+      {message.content ? (
+        <MarkdownContent content={message.content} />
+      ) : message.isStreaming ? (
+        <BouncingDots />
+      ) : null}
+
+      {/* Confirmation card */}
+      {message.pendingConfirm && (
+        <ConfirmationCard
+          confirm={message.pendingConfirm}
+          onApprove={() => onApprove?.(message.id)}
+          onDeny={() => onDeny?.(message.id)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/agent/components/MarkdownContent.tsx
+++ b/frontend/src/agent/components/MarkdownContent.tsx
@@ -1,0 +1,94 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+
+interface Props {
+  content: string;
+}
+
+export default function MarkdownContent({ content }: Props) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeHighlight]}
+      components={{
+        h1: ({ children }) => (
+          <h1 className="text-xl font-bold text-gray-100 mt-4 mb-2">{children}</h1>
+        ),
+        h2: ({ children }) => (
+          <h2 className="text-lg font-semibold text-gray-100 mt-3 mb-2">{children}</h2>
+        ),
+        h3: ({ children }) => (
+          <h3 className="text-base font-semibold text-gray-100 mt-3 mb-1">{children}</h3>
+        ),
+        p: ({ children }) => (
+          <p className="text-sm leading-relaxed text-gray-200 mb-3 last:mb-0">{children}</p>
+        ),
+        ul: ({ children }) => (
+          <ul className="list-disc ml-4 text-sm text-gray-200 mb-3 space-y-1">{children}</ul>
+        ),
+        ol: ({ children }) => (
+          <ol className="list-decimal ml-4 text-sm text-gray-200 mb-3 space-y-1">{children}</ol>
+        ),
+        li: ({ children }) => (
+          <li className="leading-relaxed">{children}</li>
+        ),
+        a: ({ href, children }) => (
+          <a
+            href={href}
+            className="text-indigo-400 underline hover:text-indigo-300 transition-colors"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {children}
+          </a>
+        ),
+        blockquote: ({ children }) => (
+          <blockquote className="border-l-2 border-indigo-500/30 pl-4 italic text-gray-400 my-3">
+            {children}
+          </blockquote>
+        ),
+        code: ({ className, children, ...props }) => {
+          const hasLang = className?.includes('language-') || className?.includes('hljs');
+          const hasNewlines = typeof children === 'string' && children.includes('\n');
+          if (hasLang || hasNewlines) {
+            return <code className={className} {...props}>{children}</code>;
+          }
+          return (
+            <code className="bg-gray-800 px-1.5 py-0.5 rounded text-sm font-mono text-gray-200" {...props}>
+              {children}
+            </code>
+          );
+        },
+        pre: ({ children }) => (
+          <pre className="bg-gray-900 text-green-200 rounded-xl p-4 overflow-x-auto text-sm my-3 shadow-inner">
+            {children}
+          </pre>
+        ),
+        table: ({ children }) => (
+          <div className="overflow-x-auto my-3">
+            <table className="min-w-full text-sm border-collapse border border-gray-700 rounded-lg overflow-hidden">
+              {children}
+            </table>
+          </div>
+        ),
+        thead: ({ children }) => (
+          <thead className="bg-gray-800">{children}</thead>
+        ),
+        th: ({ children }) => (
+          <th className="px-3 py-2 text-left text-xs font-semibold text-gray-200 border border-gray-700">
+            {children}
+          </th>
+        ),
+        td: ({ children }) => (
+          <td className="px-3 py-2 text-sm text-gray-300 border border-gray-700">{children}</td>
+        ),
+        hr: () => <hr className="border-gray-700 my-4" />,
+        strong: ({ children }) => <strong className="font-semibold text-gray-100">{children}</strong>,
+        em: ({ children }) => <em className="italic">{children}</em>,
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -2,13 +2,15 @@
  * Chatty — useAgentChat hook.
  *
  * Streams chat responses via SSE. Handles text, tool_start, tool_args,
- * tool_end, title_update, done, error events.
+ * tool_end, confirm, title_update, done, error events.
  *
- * Adapted from CAKE OS — voice tab, confirm flow, and DIMM/report events removed.
+ * Supports 3-tier tool mode (read-only / normal / power) with confirmation flow.
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { getToken } from '../../core/auth/AuthContext';
+
+export type ToolMode = 'read-only' | 'normal' | 'power';
 
 export interface ToolCallInfo {
   tool: string;
@@ -20,6 +22,14 @@ export interface ToolCallInfo {
   startedAt: number;
 }
 
+export interface PendingConfirmation {
+  tool: string;
+  args: Record<string, unknown>;
+  toolUseId: string;
+  status: 'pending' | 'approved' | 'denied';
+  description?: string;
+}
+
 export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant';
@@ -28,6 +38,7 @@ export interface ChatMessage {
   toolCalls?: ToolCallInfo[];
   isStreaming?: boolean;
   attachments?: { name: string; size: number }[];
+  pendingConfirm?: PendingConfirmation;
 }
 
 interface Options {
@@ -39,10 +50,16 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
   const [isStreaming, setIsStreaming] = useState(false);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [trainingMode, setTrainingModeState] = useState(false);
+  const [toolMode, setToolMode] = useState<ToolMode>('normal');
   const abortRef = useRef<AbortController | null>(null);
   const trainingKickoffRef = useRef(false);
 
-  const sendMessage = useCallback(async (text: string, files?: File[]) => {
+  const sendMessage = useCallback(async (text: string, files?: File[], approvedTool?: {
+    tool: string;
+    args: Record<string, unknown>;
+    toolUseId: string;
+    result: unknown;
+  }) => {
     const userMsg: ChatMessage = {
       id: crypto.randomUUID(),
       role: 'user',
@@ -64,20 +81,27 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
 
     const history = [...messages, userMsg].map(m => ({ role: m.role, content: m.content }));
 
+    // Effective tool mode: training forces power
+    const effectiveMode = trainingMode ? 'power' : toolMode;
+
     abortRef.current = new AbortController();
 
     try {
       const token = getToken();
       const hasFiles = files && files.length > 0;
 
+      const payload: Record<string, unknown> = {
+        messages: history,
+        training_mode: trainingMode,
+        conversation_id: conversationId,
+        tool_mode: effectiveMode,
+      };
+      if (approvedTool) payload.approved_tool = approvedTool;
+
       let res: Response;
       if (hasFiles) {
         const formData = new FormData();
-        formData.append('payload', JSON.stringify({
-          messages: history,
-          training_mode: trainingMode,
-          conversation_id: conversationId,
-        }));
+        formData.append('payload', JSON.stringify(payload));
         for (const f of files) {
           formData.append('files', f);
         }
@@ -96,11 +120,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
             'Content-Type': 'application/json',
             ...(token ? { Authorization: `Bearer ${token}` } : {}),
           },
-          body: JSON.stringify({
-            messages: history,
-            training_mode: trainingMode,
-            conversation_id: conversationId,
-          }),
+          body: JSON.stringify(payload),
           signal: abortRef.current.signal,
         });
       }
@@ -191,6 +211,24 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
                 }
                 return updated;
               });
+            } else if (event.type === 'confirm' && event.tool) {
+              setMessages(prev => {
+                const updated = [...prev];
+                const last = updated[updated.length - 1];
+                if (last?.role === 'assistant') {
+                  updated[updated.length - 1] = {
+                    ...last,
+                    pendingConfirm: {
+                      tool: event.tool,
+                      args: event.args || {},
+                      toolUseId: event.tool_use_id || '',
+                      status: 'pending',
+                      description: event.description,
+                    },
+                  };
+                }
+                return updated;
+              });
             } else if (event.type === 'conversation_id' && event.id) {
               setConversationId(event.id);
             } else if (event.type === 'title_update' && event.title && event.conversation_id) {
@@ -202,7 +240,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
                 if (last?.role === 'assistant') {
                   updated[updated.length - 1] = {
                     ...last,
-                    content: last.content + `\n\n⚠️ ${event.error}`,
+                    content: last.content + `\n\n**Error:** ${event.error}`,
                   };
                 }
                 return updated;
@@ -226,7 +264,55 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
       setMessages(prev => prev.map(m => m.isStreaming ? { ...m, isStreaming: false } : m));
       abortRef.current = null;
     }
-  }, [messages, trainingMode, conversationId, apiPrefix, options]);
+  }, [messages, trainingMode, toolMode, conversationId, apiPrefix, options]);
+
+  // ── Approve a pending confirmation ──
+  const approveAction = useCallback(async (msgId: string) => {
+    // Find the message with the pending confirm
+    const msg = messages.find(m => m.id === msgId);
+    if (!msg?.pendingConfirm || msg.pendingConfirm.status !== 'pending') return;
+
+    const { tool, args, toolUseId } = msg.pendingConfirm;
+
+    // Mark as approved
+    setMessages(prev => prev.map(m =>
+      m.id === msgId && m.pendingConfirm
+        ? { ...m, pendingConfirm: { ...m.pendingConfirm, status: 'approved' as const } }
+        : m
+    ));
+
+    try {
+      const token = getToken();
+      const res = await fetch(`${apiPrefix}/tool/execute`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ tool, args }),
+      });
+
+      if (!res.ok) throw new Error(`Execute failed: ${res.status}`);
+      const result = await res.json();
+
+      // Send follow-up message with approved_tool metadata
+      sendMessage(`[Approved] ${tool}`, undefined, { tool, args, toolUseId, result });
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : 'Unknown error';
+      sendMessage(`[Action failed] ${tool}: ${errMsg}`, undefined, {
+        tool, args, toolUseId, result: { error: errMsg },
+      });
+    }
+  }, [messages, apiPrefix, sendMessage]);
+
+  // ── Deny a pending confirmation ──
+  const denyAction = useCallback((msgId: string) => {
+    setMessages(prev => prev.map(m =>
+      m.id === msgId && m.pendingConfirm
+        ? { ...m, pendingConfirm: { ...m.pendingConfirm, status: 'denied' as const } }
+        : m
+    ));
+  }, []);
 
   const setTrainingMode = useCallback((on: boolean) => {
     if (on) {
@@ -265,8 +351,12 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
     isStreaming,
     conversationId,
     trainingMode,
+    toolMode,
+    setToolMode,
     setTrainingMode,
     sendMessage,
+    approveAction,
+    denyAction,
     stop,
     clear,
     loadMessages,

--- a/frontend/src/agent/hooks/useScrollDirection.ts
+++ b/frontend/src/agent/hooks/useScrollDirection.ts
@@ -1,0 +1,39 @@
+import { useState, useRef, useEffect, type RefObject } from 'react';
+
+/**
+ * Detects scroll direction on a scrollable element and returns whether the
+ * top bar should be visible. Hides on scroll down, shows on scroll up.
+ */
+export function useScrollDirection(scrollRef: RefObject<HTMLElement | null>) {
+  const [isVisible, setIsVisible] = useState(true);
+  const lastScrollTop = useRef(0);
+  const ticking = useRef(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      if (ticking.current) return;
+      ticking.current = true;
+
+      requestAnimationFrame(() => {
+        const st = el.scrollTop;
+        if (st <= 10) {
+          setIsVisible(true);
+        } else if (st > lastScrollTop.current + 5) {
+          setIsVisible(false);
+        } else if (st < lastScrollTop.current - 5) {
+          setIsVisible(true);
+        }
+        lastScrollTop.current = st;
+        ticking.current = false;
+      });
+    };
+
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [scrollRef]);
+
+  return isVisible;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "highlight.js/styles/github-dark.css";
 
 :root {
   --brand-color: #393c74;


### PR DESCRIPTION
## Summary
- **Immersive chat layout**: Claude-style flat assistant messages with markdown rendering, branded user bubbles with clipped corners, centered max-w-2xl reading column, floating input with gradient fade, auto-hiding top bar on scroll
- **Markdown rendering**: New `MarkdownContent` component using react-markdown + remark-gfm + rehype-highlight for syntax-highlighted code blocks, styled tables, blockquotes, and inline code — all adapted for dark theme
- **Tool mode selector**: 3-tier permission toggle (Read Only / Normal / Power) with confirmation cards for write operations. Backend intercepts write tools in Normal mode, emits `confirm` SSE events, and provides a `tool/execute` endpoint for approved actions. Context/memory tools always execute without confirmation.

## Test plan
- [ ] Navigate to an agent — verify assistant messages render as flat markdown (no bubble) with syntax highlighting
- [ ] Verify user messages appear as right-aligned indigo bubble with clipped bottom-right corner
- [ ] Scroll down in a long conversation — top bar should auto-hide. Scroll up — it reappears
- [ ] Toggle between Read Only / Normal / Power in the top bar tool mode selector
- [ ] In Normal mode, trigger a write tool (e.g. create a reminder) — confirm card should appear with Approve/Deny
- [ ] In Power mode, verify amber warning banner and tools execute without confirmation
- [ ] Verify file upload, conversation sidebar, Knowledge tab, and Reports tab still work
- [ ] Check mobile view — tool mode selector should be hidden on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)