### PR TITLE
Port WhatsApp integration from CAKE OS via Baileys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,11 @@ ENCRYPTION_KEY=
 # ─── WhatsApp ─────────────────────────────────────────────────────────────────
 # URL of the Baileys sidecar (whatsapp-bridge). Leave blank to disable.
 WHATSAPP_BRIDGE_URL=
-# Shared secret for sidecar ↔ backend auth (X-Api-Key header)
+# Shared secret for sidecar ↔ backend auth (X-Api-Key header).
+# Also used to verify inbound webhook calls from the sidecar.
+# Set the same value as API_KEY on the sidecar side.
 WHATSAPP_BRIDGE_API_KEY=
-# Secret for verifying inbound webhook calls from the sidecar
+# Optional: override webhook verification secret (defaults to WHATSAPP_BRIDGE_API_KEY)
 WHATSAPP_WEBHOOK_SECRET=
 
 # ─── Server ──────────────────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,14 @@ WEBBY_GITHUB_REPO=
 # Leave blank for local use (key stored in OS keychain automatically).
 ENCRYPTION_KEY=
 
+# ─── WhatsApp ─────────────────────────────────────────────────────────────────
+# URL of the Baileys sidecar (whatsapp-bridge). Leave blank to disable.
+WHATSAPP_BRIDGE_URL=
+# Shared secret for sidecar ↔ backend auth (X-Api-Key header)
+WHATSAPP_BRIDGE_API_KEY=
+# Secret for verifying inbound webhook calls from the sidecar
+WHATSAPP_WEBHOOK_SECRET=
+
 # ─── Server ──────────────────────────────────────────────────────────────────
 # CORS origins (comma-separated). Defaults to localhost dev servers.
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,5 @@ WORKDIR /app/backend
 EXPOSE 8000
 
 # Start WhatsApp bridge sidecar in background (if configured) alongside the Python backend
-CMD ["sh", "-c", "if [ -n \"$WHATSAPP_BRIDGE_URL\" ]; then node whatsapp-bridge/index.js & fi; gunicorn main:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT:-8000} --workers 1 --timeout 120"]
+# Sidecar PORT is pinned to 3001 to avoid conflicts with cloud platforms that set PORT
+CMD ["sh", "-c", "if [ -n \"$WHATSAPP_BRIDGE_URL\" ]; then PORT=3001 node whatsapp-bridge/index.js & fi; gunicorn main:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT:-8000} --workers 1 --timeout 120"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,35 @@ RUN npm ci
 COPY frontend/ .
 RUN npm run build
 
-# Stage 2: Python runtime
+# Stage 2: Install WhatsApp bridge dependencies
+FROM node:22-alpine AS bridge-deps
+WORKDIR /bridge
+COPY backend/whatsapp-bridge/package.json backend/whatsapp-bridge/package-lock.json* ./
+RUN npm ci --production
+
+# Stage 3: Python runtime
 FROM python:3.12-slim
 WORKDIR /app
+
+# Install Node.js runtime (for whatsapp-bridge sidecar)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    apt-get purge -y curl && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt gunicorn
 
 COPY backend/ ./backend/
 COPY --from=frontend-build /build/dist ./frontend/dist/
+COPY --from=bridge-deps /bridge/node_modules ./backend/whatsapp-bridge/node_modules/
 
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app/backend
 EXPOSE 8000
 
-CMD ["sh", "-c", "gunicorn main:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT:-8000} --workers 1 --timeout 120"]
+# Start WhatsApp bridge sidecar in background (if configured) alongside the Python backend
+CMD ["sh", "-c", "if [ -n \"$WHATSAPP_BRIDGE_URL\" ]; then node whatsapp-bridge/index.js & fi; gunicorn main:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT:-8000} --workers 1 --timeout 120"]

--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -62,6 +62,14 @@ def init_db() -> None:
             updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
         );
     """)
+    # Migration: add WhatsApp session ID column if not present
+    try:
+        _connection.execute(
+            "ALTER TABLE agents ADD COLUMN whatsapp_session_id TEXT NOT NULL DEFAULT ''"
+        )
+        _connection.commit()
+    except sqlite3.OperationalError:
+        pass  # Column already exists
     _connection.commit()
     logger.info("Agent registry DB initialized at %s", DB_PATH)
 
@@ -126,7 +134,7 @@ def list_agents() -> list[dict]:
 UPDATABLE_FIELDS = {
     "agent_name", "avatar_url", "personality",
     "onboarding_complete", "provider_override", "model_override",
-    "gmail_enabled", "calendar_enabled",
+    "gmail_enabled", "calendar_enabled", "whatsapp_session_id",
 }
 
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -46,12 +46,24 @@ class WebbySettings:
     github_repo: str = os.getenv("WEBBY_GITHUB_REPO", "")  # e.g. "owner/repo"
 
 
+class WhatsAppSettings:
+    def __init__(self):
+        self.bridge_url: str = os.getenv("WHATSAPP_BRIDGE_URL", "")
+        self.bridge_api_key: str = os.getenv("WHATSAPP_BRIDGE_API_KEY", "")
+        self.webhook_secret: str = os.getenv("WHATSAPP_WEBHOOK_SECRET", "")
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.bridge_url)
+
+
 class Settings:
     auth = AuthSettings()
     jwt = JWTSettings()
     google_oauth = GoogleOAuthSettings()
     openai_oauth = OpenAIOAuthSettings()
     webby = WebbySettings()
+    whatsapp = WhatsAppSettings()
 
     # GCS bucket for Phase 2 cloud deployment (no-ops if empty)
     gcs_bucket: str = os.getenv("CONFIG_BUCKET", "")

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -49,9 +49,9 @@ AVAILABLE_INTEGRATIONS = {
     },
     "whatsapp": {
         "name": "WhatsApp",
-        "description": "WhatsApp Business — send/receive messages (coming soon)",
+        "description": "WhatsApp — connect agents to WhatsApp via QR code scan",
         "icon": "💬",
-        "auth_type": "stub",
+        "auth_type": "qr_session",
     },
 }
 

--- a/backend/integrations/whatsapp/client.py
+++ b/backend/integrations/whatsapp/client.py
@@ -1,0 +1,198 @@
+"""Chatty — WhatsApp messaging client via Baileys sidecar.
+
+The sidecar is a small Node.js Express server that manages Baileys sessions
+and exposes a REST API for session CRUD, QR retrieval, and message sending.
+This module wraps those HTTP calls.
+
+Ported from CAKE OS messaging/whatsapp_client.py.
+"""
+
+import logging
+
+import httpx
+
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# WhatsApp text messages are limited to ~65536 chars, but readability
+# drops sharply past 4096.  Chunk on paragraph boundaries.
+MAX_CHUNK_LENGTH = 4000
+
+
+def _headers() -> dict[str, str]:
+    h: dict[str, str] = {}
+    if settings.whatsapp.bridge_api_key:
+        h["X-Api-Key"] = settings.whatsapp.bridge_api_key
+    return h
+
+
+def _base_url() -> str:
+    return settings.whatsapp.bridge_url.rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Session management
+# ---------------------------------------------------------------------------
+
+def create_session(session_id: str) -> dict:
+    """Create and start a new Baileys session on the sidecar."""
+    if not settings.whatsapp.is_configured:
+        return {"error": "WhatsApp bridge not configured"}
+    try:
+        resp = httpx.post(
+            f"{_base_url()}/sessions",
+            json={"session": session_id},
+            headers=_headers(),
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPError as e:
+        logger.error("Failed to create WhatsApp session %s: %s", session_id, e)
+        return {"error": str(e)}
+
+
+def delete_session(session_id: str) -> dict:
+    """Logout and delete a Baileys session."""
+    if not settings.whatsapp.is_configured:
+        return {"error": "WhatsApp bridge not configured"}
+    try:
+        resp = httpx.delete(
+            f"{_base_url()}/sessions/{session_id}",
+            headers=_headers(),
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPError as e:
+        logger.error("Failed to delete WhatsApp session %s: %s", session_id, e)
+        return {"error": str(e)}
+
+
+def get_status(session_id: str) -> dict:
+    """Get the status of a Baileys session.
+
+    Returns dict with ``status`` key: "scan_qr", "connecting", "connected",
+    "disconnected", or "not_configured".
+    """
+    if not settings.whatsapp.is_configured:
+        return {"status": "not_configured"}
+    try:
+        resp = httpx.get(
+            f"{_base_url()}/sessions/{session_id}",
+            headers=_headers(),
+            timeout=10,
+        )
+        if resp.status_code == 404:
+            return {"status": "disconnected"}
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPError as e:
+        logger.warning("WhatsApp status check failed for %s: %s", session_id, e)
+        return {"status": "disconnected", "error": str(e)}
+
+
+def get_qr(session_id: str) -> bytes | None:
+    """Fetch the QR code PNG for a session.
+
+    Returns raw PNG bytes when QR is available, or None otherwise.
+    """
+    if not settings.whatsapp.is_configured:
+        return None
+    try:
+        resp = httpx.get(
+            f"{_base_url()}/sessions/{session_id}/qr",
+            headers=_headers(),
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            return resp.content
+        return None
+    except httpx.HTTPError:
+        return None
+
+
+def list_sessions() -> list[dict]:
+    """List all sessions on the sidecar with their status."""
+    if not settings.whatsapp.is_configured:
+        return []
+    try:
+        resp = httpx.get(
+            f"{_base_url()}/sessions",
+            headers=_headers(),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPError as e:
+        logger.warning("Failed to list WhatsApp sessions: %s", e)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Message sending
+# ---------------------------------------------------------------------------
+
+def send_message(phone: str, text: str, session: str = "default") -> list[dict]:
+    """Send a text message via the sidecar.
+
+    Long messages are chunked into multiple sends.
+    Returns a list of response dicts (one per chunk).
+    """
+    if not settings.whatsapp.is_configured:
+        logger.warning("WhatsApp not configured — cannot send message")
+        return []
+
+    phone = phone.lstrip("+")
+    chunks = _chunk_text(text, MAX_CHUNK_LENGTH)
+    results = []
+    for chunk in chunks:
+        try:
+            resp = httpx.post(
+                f"{_base_url()}/sessions/{session}/send",
+                json={"phone": phone, "text": chunk},
+                headers=_headers(),
+                timeout=30,
+            )
+            resp.raise_for_status()
+            results.append(resp.json())
+        except httpx.HTTPError as e:
+            logger.error("WhatsApp send failed: %s", e)
+            results.append({"error": str(e)})
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Text chunking helper
+# ---------------------------------------------------------------------------
+
+def _chunk_text(text: str, max_length: int) -> list[str]:
+    """Split text into chunks on paragraph boundaries."""
+    if len(text) <= max_length:
+        return [text]
+
+    chunks = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= max_length:
+            chunks.append(remaining)
+            break
+
+        # Find the last paragraph break before the limit
+        split_at = remaining.rfind("\n\n", 0, max_length)
+        if split_at == -1:
+            # No paragraph break — try single newline
+            split_at = remaining.rfind("\n", 0, max_length)
+        if split_at == -1:
+            # No newline — try space
+            split_at = remaining.rfind(" ", 0, max_length)
+        if split_at == -1:
+            # No good break point — hard cut
+            split_at = max_length
+
+        chunks.append(remaining[:split_at].rstrip())
+        remaining = remaining[split_at:].lstrip()
+
+    return chunks

--- a/backend/integrations/whatsapp/connector.py
+++ b/backend/integrations/whatsapp/connector.py
@@ -1,13 +1,8 @@
-"""
-Chatty — WhatsApp Business connector stub.
+"""Chatty — WhatsApp connector availability check."""
 
-TODO: Phase 2 — implement WhatsApp Business API integration.
-"""
+from core.config import settings
 
 
 def is_available() -> bool:
-    return False
-
-
-def send_message(to: str, body: str) -> dict:
-    return {"error": "WhatsApp integration not yet implemented"}
+    """Check if the WhatsApp bridge sidecar is configured."""
+    return settings.whatsapp.is_configured

--- a/backend/integrations/whatsapp/lifecycle.py
+++ b/backend/integrations/whatsapp/lifecycle.py
@@ -1,0 +1,169 @@
+"""Chatty — WhatsApp session lifecycle management.
+
+Handles session creation/deletion on the Baileys sidecar, QR retrieval,
+and the time-limited auto-registration window that lets a user self-onboard
+by messaging the agent's WhatsApp within 10 minutes of connection.
+
+Ported from CAKE OS messaging/whatsapp_lifecycle.py.
+Adapted: agent_email → agent_slug, session IDs use wa-{slug} format.
+"""
+
+import logging
+
+from agents.db import get_agent_by_slug, list_agents, update_agent
+
+from . import state
+from . import client as whatsapp_client
+
+logger = logging.getLogger(__name__)
+
+
+def _session_id_for(agent_slug: str) -> str:
+    """Generate the sidecar session ID for an agent."""
+    return f"wa-{agent_slug}"
+
+
+def session_id_to_agent_slug(session_id: str) -> str | None:
+    """Resolve a sidecar session ID back to the agent slug.
+
+    Session IDs have the format "wa-{slug}".
+    Returns the slug if the agent exists, None otherwise.
+    """
+    if not session_id.startswith("wa-"):
+        return None
+    slug = session_id[3:]  # strip "wa-" prefix
+    agent = get_agent_by_slug(slug)
+    return slug if agent else None
+
+
+def start_session(agent_slug: str) -> dict:
+    """Start a WhatsApp session for an agent.
+
+    Creates the session on the sidecar, saves the session ID to the agent
+    registry, and opens a 10-minute registration window.
+
+    Returns dict with session_id, status, and registration window info.
+    """
+    agent = get_agent_by_slug(agent_slug)
+    if not agent:
+        raise ValueError(f"Agent not found: {agent_slug}")
+
+    session_id = _session_id_for(agent_slug)
+
+    result = whatsapp_client.create_session(session_id)
+    if "error" in result:
+        raise ValueError(f"Failed to create session: {result['error']}")
+
+    # Save session ID to agent DB
+    update_agent(agent["id"], whatsapp_session_id=session_id)
+
+    # Open registration window
+    window = state.open_registration_window(agent_slug)
+
+    return {
+        "session_id": session_id,
+        "status": result.get("status", "starting"),
+        "registration_expires_at": window["expires_at"],
+    }
+
+
+def stop_session(agent_slug: str) -> None:
+    """Disconnect WhatsApp for an agent.
+
+    Deletes the session from the sidecar and clears the session ID from the DB.
+    """
+    agent = get_agent_by_slug(agent_slug)
+    if not agent:
+        return
+
+    session_id = agent.get("whatsapp_session_id", "")
+    if session_id:
+        whatsapp_client.delete_session(session_id)
+
+    update_agent(agent["id"], whatsapp_session_id="")
+
+
+def get_session_status(agent_slug: str) -> dict:
+    """Get WhatsApp session status for an agent."""
+    agent = get_agent_by_slug(agent_slug)
+    if not agent:
+        return {"status": "not_found"}
+
+    session_id = agent.get("whatsapp_session_id", "")
+    if not session_id:
+        return {"status": "disconnected"}
+
+    return whatsapp_client.get_status(session_id)
+
+
+def get_session_qr(agent_slug: str) -> bytes | None:
+    """Get QR code PNG for an agent's WhatsApp session."""
+    agent = get_agent_by_slug(agent_slug)
+    if not agent:
+        return None
+
+    session_id = agent.get("whatsapp_session_id", "")
+    if not session_id:
+        return None
+
+    return whatsapp_client.get_qr(session_id)
+
+
+def reset_registration_window(agent_slug: str) -> dict:
+    """Reset (re-open) the WhatsApp registration window for an agent.
+
+    Returns the new window info.
+    Raises ValueError if the agent has no active WhatsApp session.
+    """
+    agent = get_agent_by_slug(agent_slug)
+    if not agent or not agent.get("whatsapp_session_id"):
+        raise ValueError("Agent has no WhatsApp session configured")
+
+    return state.open_registration_window(agent_slug)
+
+
+def reconnect_all_sessions() -> None:
+    """Log the status of all agents with WhatsApp sessions.
+
+    Sessions with saved credentials auto-reconnect on sidecar startup,
+    so this function just checks and logs their status.
+    """
+    agents = list_agents()
+    count = 0
+    for agent in agents:
+        session_id = agent.get("whatsapp_session_id", "")
+        if not session_id:
+            continue
+
+        try:
+            status = whatsapp_client.get_status(session_id)
+            session_status = status.get("status", "unknown")
+            if session_status in ("connected", "scan_qr", "connecting"):
+                count += 1
+            logger.info(
+                "WhatsApp session %s (%s): %s",
+                session_id, agent["agent_name"], session_status,
+            )
+        except Exception as e:
+            logger.warning(
+                "WhatsApp status check failed for %s: %s",
+                agent["agent_name"], e,
+            )
+
+    if count:
+        logger.info("Found %d active WhatsApp session(s)", count)
+
+
+def try_auto_register(
+    agent_slug: str, phone: str, sender_name: str,
+) -> bool:
+    """Try to auto-register a WhatsApp user during the registration window.
+
+    Returns True if registration succeeded, False if the window is closed.
+    """
+    if not state.is_registration_open(agent_slug):
+        return False
+
+    state.create_mapping("whatsapp", phone, agent_slug, sender_name)
+    state.close_registration_window(agent_slug, phone)
+    return True

--- a/backend/integrations/whatsapp/models.py
+++ b/backend/integrations/whatsapp/models.py
@@ -1,0 +1,11 @@
+"""Chatty — WhatsApp Pydantic request models."""
+
+from pydantic import BaseModel
+
+
+class StartSessionRequest(BaseModel):
+    agent_slug: str
+
+
+class ResetRegistrationRequest(BaseModel):
+    agent_slug: str

--- a/backend/integrations/whatsapp/router.py
+++ b/backend/integrations/whatsapp/router.py
@@ -35,14 +35,18 @@ _wa_token_warned = False
 
 
 def _verify_webhook(request: Request) -> None:
-    """Verify the webhook secret from the sidecar's X-Api-Key header."""
+    """Verify the webhook secret from the sidecar's X-Api-Key header.
+
+    Checks WHATSAPP_WEBHOOK_SECRET first; falls back to WHATSAPP_BRIDGE_API_KEY
+    so a single shared secret works for both sidecar auth and webhook verification.
+    """
     global _wa_token_warned
-    expected = settings.whatsapp.webhook_secret
+    expected = settings.whatsapp.webhook_secret or settings.whatsapp.bridge_api_key
     if not expected:
         if not _wa_token_warned:
             logger.warning(
-                "WHATSAPP_WEBHOOK_SECRET is not set — WhatsApp webhook is open. "
-                "Set the secret in production."
+                "No webhook secret configured — WhatsApp webhook is open. "
+                "Set WHATSAPP_BRIDGE_API_KEY or WHATSAPP_WEBHOOK_SECRET in production."
             )
             _wa_token_warned = True
         return

--- a/backend/integrations/whatsapp/router.py
+++ b/backend/integrations/whatsapp/router.py
@@ -1,0 +1,226 @@
+"""Chatty — WhatsApp messaging router.
+
+Handles inbound webhooks from the Baileys sidecar plus JWT-protected
+admin endpoints for managing per-agent WhatsApp sessions.
+
+Ported from CAKE OS messaging/router.py (WhatsApp endpoints only).
+"""
+
+import hmac
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response
+
+from core.auth import get_current_user
+from core.config import settings
+
+from . import state, service, lifecycle
+from . import client as whatsapp_client
+from .models import StartSessionRequest, ResetRegistrationRequest
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/whatsapp", tags=["whatsapp"])
+
+_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wa-webhook")
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp webhook (Baileys sidecar) — no JWT, token-verified
+# ---------------------------------------------------------------------------
+
+_wa_token_warned = False
+
+
+def _verify_webhook(request: Request) -> None:
+    """Verify the webhook secret from the sidecar's X-Api-Key header."""
+    global _wa_token_warned
+    expected = settings.whatsapp.webhook_secret
+    if not expected:
+        if not _wa_token_warned:
+            logger.warning(
+                "WHATSAPP_WEBHOOK_SECRET is not set — WhatsApp webhook is open. "
+                "Set the secret in production."
+            )
+            _wa_token_warned = True
+        return
+
+    token = request.headers.get("X-Api-Key", "")
+    if not hmac.compare_digest(token, expected):
+        raise HTTPException(status_code=401, detail="Invalid webhook token")
+
+
+@router.post("/webhook", status_code=200)
+async def whatsapp_webhook(request: Request):
+    """Receive inbound messages from the Baileys sidecar.
+
+    Payload: { session, phone, text, sender_name, message_id }
+    Returns 200 immediately; processes message and sends reply in background.
+    """
+    _verify_webhook(request)
+
+    try:
+        raw = await request.json()
+    except Exception:
+        logger.warning("WhatsApp webhook: unparseable body")
+        return {"status": "ok"}
+
+    session = raw.get("session", "")
+    phone = raw.get("phone", "")
+    text = raw.get("text", "")
+    sender_name = raw.get("sender_name", "")
+
+    if not phone or not text:
+        return {"status": "ok"}
+
+    logger.info(
+        "WhatsApp message: session=%s from=%s name=%s msg=%s",
+        session, phone, sender_name, text[:100],
+    )
+
+    _executor.submit(_safe_process_whatsapp, session, phone, sender_name, text)
+    return {"status": "ok"}
+
+
+def _try_auto_register(
+    agent_slug: str | None, phone: str, sender_name: str,
+) -> bool:
+    """Try to auto-register a WhatsApp user, checking agent-specific window first,
+    then falling back to any open window. Returns True if registered."""
+    if agent_slug and lifecycle.try_auto_register(agent_slug, phone, sender_name):
+        logger.info("Auto-registered WhatsApp user %s for agent %s", phone, agent_slug)
+        return True
+    # Fall back to any open window
+    window = state.get_any_open_window()
+    if window and lifecycle.try_auto_register(window["agent_slug"], phone, sender_name):
+        logger.info(
+            "Auto-registered WhatsApp user %s for agent %s (via open window)",
+            phone, window["agent_slug"],
+        )
+        return True
+    return False
+
+
+def _safe_process_whatsapp(
+    session: str, phone: str, sender_name: str, message: str,
+) -> None:
+    """Process WhatsApp message and send reply. Catches exceptions."""
+    try:
+        # Resolve session → agent slug
+        agent_slug = lifecycle.session_id_to_agent_slug(session)
+
+        # Check if sender has a mapping
+        mapping = state.get_mapping_by_sender("whatsapp", phone)
+        if not mapping:
+            if not _try_auto_register(agent_slug, phone, sender_name):
+                logger.debug(
+                    "WhatsApp: ignoring unregistered phone %s (no open window)", phone,
+                )
+                return
+            # Re-fetch the mapping after registration
+            mapping = state.get_mapping_by_sender("whatsapp", phone)
+            if not mapping:
+                return
+
+        target_slug = mapping["agent_slug"]
+        response = service.process_message(target_slug, phone, sender_name, message)
+        whatsapp_client.send_message(phone, response, session=session)
+    except Exception:
+        logger.exception("WhatsApp processing failed (phone=%s)", phone)
+        try:
+            whatsapp_client.send_message(
+                phone, "I had trouble processing that. Please try again.",
+                session=session,
+            )
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints — JWT protected
+# ---------------------------------------------------------------------------
+
+@router.get("/status")
+async def get_whatsapp_status(user=Depends(get_current_user)):
+    """Check if WhatsApp bridge is configured and healthy."""
+    if not settings.whatsapp.is_configured:
+        return {"configured": False, "status": "not_configured"}
+
+    sessions = whatsapp_client.list_sessions()
+    return {
+        "configured": True,
+        "bridge_url": settings.whatsapp.bridge_url,
+        "sessions": sessions,
+    }
+
+
+@router.post("/session")
+async def start_session(
+    req: StartSessionRequest, user=Depends(get_current_user),
+):
+    """Start a WhatsApp session for an agent.
+
+    Creates the Baileys session on the sidecar and opens a 10-minute
+    registration window.
+    """
+    try:
+        result = lifecycle.start_session(req.agent_slug)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.delete("/session/{agent_slug}")
+async def stop_session(
+    agent_slug: str, user=Depends(get_current_user),
+):
+    """Disconnect WhatsApp for an agent."""
+    lifecycle.stop_session(agent_slug)
+    return {"ok": True}
+
+
+@router.get("/session/status/{agent_slug}")
+async def get_session_status(
+    agent_slug: str, user=Depends(get_current_user),
+):
+    """Get the WhatsApp session status for an agent."""
+    return lifecycle.get_session_status(agent_slug)
+
+
+@router.get("/session/qr/{agent_slug}")
+async def get_session_qr(
+    agent_slug: str, user=Depends(get_current_user),
+):
+    """Get the QR code PNG for an agent's WhatsApp session."""
+    data = lifecycle.get_session_qr(agent_slug)
+    if data is None:
+        raise HTTPException(status_code=404, detail="QR not available")
+    return Response(content=data, media_type="image/png")
+
+
+@router.post("/session/reset-registration")
+async def reset_registration(
+    req: ResetRegistrationRequest, user=Depends(get_current_user),
+):
+    """Reset (re-open) the WhatsApp registration window for an agent."""
+    try:
+        window = lifecycle.reset_registration_window(req.agent_slug)
+        return window
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/registration-window/{agent_slug}")
+async def get_registration_window(
+    agent_slug: str, user=Depends(get_current_user),
+):
+    """Get the WhatsApp registration window status for an agent."""
+    window = state.get_registration_window(agent_slug)
+    if not window:
+        return {"open": False, "window": None}
+    return {
+        "open": state.is_registration_open(agent_slug),
+        "window": window,
+    }

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -1,0 +1,280 @@
+"""Chatty — WhatsApp message processing service.
+
+Routes inbound WhatsApp messages to the appropriate Chatty agent,
+runs the agent synchronously via background_runner, and returns
+the response text. The router handles sending the response back
+via the WhatsApp client.
+
+Ported from CAKE OS messaging/service.py.
+Adapted: uses Chatty's background_runner + agent engine instead of
+CAKE OS's run_sync + load_agent_components.
+"""
+
+import importlib
+import logging
+import uuid
+
+from agents.db import get_agent_by_slug
+from agents.engine import build_agent_config, get_context_manager, get_chat_service
+from core.agents.background_runner import run_background_turn
+from core.agents.tool_registry import ToolRegistry
+from core.agents.tool_definitions import get_tool_definitions
+from core.agents.tools.real_tools import load_all_real_tools
+from core.providers.credentials import CredentialStore
+from core.agents.reminders.tools import (
+    create_reminder_handler,
+    list_reminders_handler,
+    cancel_reminder_handler,
+)
+from core.agents.scheduled_actions.tools import (
+    create_scheduled_action_handler,
+    list_scheduled_actions_handler,
+    update_scheduled_action_handler,
+    delete_scheduled_action_handler,
+)
+
+from . import state
+
+logger = logging.getLogger(__name__)
+
+# Maximum recent messages to include for context
+MAX_CONTEXT_MESSAGES = 20
+
+# Integration module registry (same as agents/router.py)
+_INTEGRATION_MODULES = {
+    "crm_lite": ("integrations.crm_lite.tools", "CRM_LITE_TOOL_DEFS"),
+    "odoo": ("integrations.odoo.tools", "ODOO_TOOL_DEFS"),
+    "bamboohr": ("integrations.bamboohr.tools", "BAMBOOHR_TOOL_DEFS"),
+    "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
+}
+
+
+def _load_integration_tools() -> tuple[list[dict], dict]:
+    """Load tool definitions and executors from all enabled integrations."""
+    from integrations.registry import is_enabled
+
+    tool_defs: list[dict] = []
+    executors: dict = {}
+
+    for name, (module_path, defs_attr) in _INTEGRATION_MODULES.items():
+        if not is_enabled(name):
+            continue
+        try:
+            if name == "crm_lite":
+                from integrations.crm_lite.db import init_db, _connection
+                if _connection is None:
+                    init_db()
+
+            mod = importlib.import_module(module_path)
+            defs = getattr(mod, defs_attr, [])
+            execs = getattr(mod, "TOOL_EXECUTORS", {})
+            tool_defs.extend(defs)
+            executors.update(execs)
+        except Exception as e:
+            logger.warning("Failed to load integration %s: %s", name, e)
+
+    return tool_defs, executors
+
+
+def process_message(
+    agent_slug: str,
+    phone: str,
+    sender_name: str,
+    message_text: str,
+) -> str:
+    """Route an inbound WhatsApp message to the agent and return the response.
+
+    Args:
+        agent_slug: The agent's slug identifier
+        phone: Sender's phone number
+        sender_name: Display name from WhatsApp
+        message_text: The message content
+
+    Returns:
+        The agent's response text.
+    """
+    # 1. Load agent
+    agent = get_agent_by_slug(agent_slug)
+    if not agent:
+        return "I had trouble starting up. Please try again."
+
+    # 2. Build agent components
+    config = build_agent_config(agent)
+    ctx_manager = get_context_manager(agent_slug)
+    chat_service = get_chat_service(agent_slug)
+
+    # 3. Get/create conversation for multi-turn context
+    conv = state.get_or_create_conversation(phone, agent_slug, "whatsapp")
+
+    # 4. Resolve or create Chatty chat history conversation
+    chatty_conv_id = conv.get("chatty_conversation_id")
+    if not chatty_conv_id and chat_service:
+        try:
+            new_conv = chat_service.create_conversation()
+            chatty_conv_id = new_conv["id"]
+            state.set_chatty_conversation_id(conv["id"], chatty_conv_id)
+        except Exception as e:
+            logger.warning("Failed to create chat history conversation: %s", e)
+
+    # 5. Save the user message to chat history
+    if chat_service and chatty_conv_id:
+        try:
+            chat_service.save_message(
+                conversation_id=chatty_conv_id,
+                msg_id=str(uuid.uuid4()),
+                role="user",
+                content=message_text,
+            )
+        except Exception as e:
+            logger.warning("Failed to save user message to chat history: %s", e)
+
+    # 6. Build system prompt
+    system_prompt = _build_system_prompt(config, ctx_manager)
+
+    # 7. Load recent messages for context
+    messages_for_context = _load_recent_messages(chat_service, chatty_conv_id)
+    # If no history, just use the current message
+    user_message = message_text
+    if messages_for_context:
+        # background_runner takes a single user_message, not a full messages array.
+        # We'll include recent context in the system prompt instead.
+        context_lines = []
+        for msg in messages_for_context[:-1]:  # exclude the most recent (current) message
+            role = msg["role"]
+            content = msg["content"][:500]
+            context_lines.append(f"[{role}]: {content}")
+        if context_lines:
+            system_prompt += "\n\n# Recent Conversation Context\n\n" + "\n".join(context_lines)
+
+    # 8. Build tool registry
+    store = CredentialStore()
+    google_token = ""
+    if config.gmail_enabled or config.calendar_enabled:
+        google_token = store.get_google_token() or ""
+
+    integration_tool_defs, integration_executors = _load_integration_tools()
+
+    reminder_handlers = {
+        "create_reminder": lambda **kw: create_reminder_handler(agent_slug, **kw),
+        "list_reminders": lambda **kw: list_reminders_handler(agent_slug, **kw),
+        "cancel_reminder": lambda **kw: cancel_reminder_handler(agent_slug, **kw),
+    }
+    sa_handlers = {
+        "create_scheduled_action": lambda **kw: create_scheduled_action_handler(agent_slug, **kw),
+        "list_scheduled_actions": lambda **kw: list_scheduled_actions_handler(agent_slug, **kw),
+        "update_scheduled_action": lambda **kw: update_scheduled_action_handler(agent_slug, **kw),
+        "delete_scheduled_action": lambda **kw: delete_scheduled_action_handler(agent_slug, **kw),
+    }
+
+    registry = ToolRegistry(
+        context_dir=config.context_dir,
+        google_access_token=google_token,
+        integration_executors=integration_executors,
+        agent_slug=agent_slug,
+        reminder_handlers=reminder_handlers,
+        scheduled_action_handlers=sa_handlers,
+    )
+
+    # 9. Build tool definitions
+    dynamic_real_tools = load_all_real_tools(agent_slug)
+    tool_defs = get_tool_definitions(
+        gmail_enabled=config.gmail_enabled,
+        calendar_enabled=config.calendar_enabled,
+        integration_tools=integration_tool_defs or None,
+        dynamic_real_tools=dynamic_real_tools or None,
+    )
+
+    # 10. Run the agent
+    result = run_background_turn(
+        system_prompt=system_prompt,
+        user_message=user_message,
+        tool_defs=tool_defs,
+        registry=registry,
+        max_iterations=5,
+        model_override=config.model_override or None,
+    )
+
+    response_text = result.text
+
+    # 11. Save assistant response to chat history
+    if chat_service and chatty_conv_id and response_text:
+        try:
+            chat_service.save_message(
+                conversation_id=chatty_conv_id,
+                msg_id=str(uuid.uuid4()),
+                role="assistant",
+                content=response_text,
+            )
+        except Exception as e:
+            logger.warning("Failed to save assistant message to chat history: %s", e)
+
+    return response_text or "I had trouble generating a response. Please try again."
+
+
+def _build_system_prompt(config, ctx_manager) -> str:
+    """Build a system prompt for WhatsApp message processing.
+
+    Mirrors ai_service._build_system_prompt but without training mode.
+    """
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    ct_tz = ZoneInfo("America/Chicago")
+    now_ct = datetime.now(ct_tz)
+    date_str = now_ct.strftime("%A, %B %d, %Y")
+    time_str = now_ct.strftime("%I:%M %p CT")
+
+    context = ctx_manager.load_all_context()
+
+    personality = config.personality or (
+        f"You are {config.agent_name}, a helpful personal AI assistant."
+    )
+
+    parts = [
+        personality,
+        "",
+        "# Your Knowledge (Long-Term Memory)",
+        "",
+        "These are your persistent memory files. They carry forward across all conversations. "
+        "Read them carefully — this is what you know. Update them actively when you learn new things.",
+        "",
+        context if context else "(No knowledge files yet. Create them using write_context_file.)",
+        "",
+        "# Current Session",
+        "",
+        f"- Date: {date_str}",
+        f"- Time: {time_str}",
+        f"- Channel: WhatsApp (messages are from a phone, keep responses concise)",
+        "",
+        "# Instructions",
+        "",
+        f"- You are {config.agent_name}. Be helpful, concise, and proactive.",
+        "- Use your knowledge files to personalize every response.",
+        "- When you learn something new, save it immediately.",
+        "- Keep responses brief and mobile-friendly — this is a WhatsApp conversation.",
+        "",
+    ]
+
+    return "\n".join(parts)
+
+
+def _load_recent_messages(chat_service, conversation_id: str | None) -> list[dict]:
+    """Load recent messages from chat history for conversation context."""
+    if not chat_service or not conversation_id:
+        return []
+
+    try:
+        conv = chat_service.get_conversation(conversation_id)
+        if not conv or "messages" not in conv:
+            return []
+
+        messages = []
+        for msg in conv["messages"][-MAX_CONTEXT_MESSAGES:]:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            if role in ("user", "assistant") and content:
+                messages.append({"role": role, "content": content})
+        return messages
+    except Exception as e:
+        logger.warning("Failed to load chat history messages: %s", e)
+        return []

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -12,6 +12,7 @@ CAKE OS's run_sync + load_agent_components.
 
 import importlib
 import logging
+import threading
 import uuid
 
 from agents.db import get_agent_by_slug
@@ -39,6 +40,18 @@ logger = logging.getLogger(__name__)
 
 # Maximum recent messages to include for context
 MAX_CONTEXT_MESSAGES = 20
+
+# Per-agent lock to prevent concurrent AI turns from corrupting context files
+_agent_locks: dict[str, threading.Lock] = {}
+_agent_locks_guard = threading.Lock()
+
+
+def _get_agent_lock(agent_slug: str) -> threading.Lock:
+    """Get or create a lock for a specific agent."""
+    with _agent_locks_guard:
+        if agent_slug not in _agent_locks:
+            _agent_locks[agent_slug] = threading.Lock()
+        return _agent_locks[agent_slug]
 
 # Integration module registry (same as agents/router.py)
 _INTEGRATION_MODULES = {
@@ -84,6 +97,9 @@ def process_message(
 ) -> str:
     """Route an inbound WhatsApp message to the agent and return the response.
 
+    Uses a per-agent lock to prevent concurrent AI turns from corrupting
+    context files when multiple messages arrive simultaneously.
+
     Args:
         agent_slug: The agent's slug identifier
         phone: Sender's phone number
@@ -93,6 +109,18 @@ def process_message(
     Returns:
         The agent's response text.
     """
+    lock = _get_agent_lock(agent_slug)
+    with lock:
+        return _process_message_locked(agent_slug, phone, sender_name, message_text)
+
+
+def _process_message_locked(
+    agent_slug: str,
+    phone: str,
+    sender_name: str,
+    message_text: str,
+) -> str:
+    """Internal: process message with agent lock held."""
     # 1. Load agent
     agent = get_agent_by_slug(agent_slug)
     if not agent:

--- a/backend/integrations/whatsapp/state.py
+++ b/backend/integrations/whatsapp/state.py
@@ -1,0 +1,272 @@
+"""Chatty — WhatsApp messaging persistent state (SQLite).
+
+Stores phone→agent mappings, registration windows, and conversation
+state for multi-turn WhatsApp context.
+
+Adapted from CAKE OS messaging/state.py for Chatty's single-user,
+multi-agent architecture (agent_slug replaces agent_email).
+"""
+
+import logging
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "whatsapp"
+DB_PATH = DATA_DIR / "whatsapp.db"
+
+_write_lock = threading.Lock()
+
+
+def _get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def init_db() -> None:
+    """Create tables if they don't exist."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    conn = _get_conn()
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS user_mappings (
+            id TEXT PRIMARY KEY,
+            platform TEXT NOT NULL,
+            platform_user_id TEXT NOT NULL,
+            agent_slug TEXT NOT NULL,
+            sender_name TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            UNIQUE(platform, platform_user_id)
+        )
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS whatsapp_registration_windows (
+            agent_slug TEXT PRIMARY KEY,
+            opened_at   TEXT NOT NULL,
+            expires_at  TEXT NOT NULL,
+            registered_phone TEXT
+        )
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS conversations (
+            id TEXT PRIMARY KEY,
+            platform TEXT NOT NULL,
+            sender_id TEXT NOT NULL,
+            agent_slug TEXT NOT NULL,
+            chatty_conversation_id TEXT,
+            last_active TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(platform, sender_id, agent_slug)
+        )
+    """)
+
+    conn.commit()
+    conn.close()
+    logger.info("WhatsApp state DB initialized at %s", DB_PATH)
+
+
+# ---------------------------------------------------------------------------
+# User mappings
+# ---------------------------------------------------------------------------
+
+def get_mapping_by_sender(platform: str, platform_user_id: str) -> dict | None:
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT id, platform, platform_user_id, agent_slug, sender_name "
+            "FROM user_mappings WHERE platform = ? AND platform_user_id = ?",
+            (platform, platform_user_id),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def create_mapping(
+    platform: str, platform_user_id: str, agent_slug: str,
+    sender_name: str = "",
+) -> dict:
+    now = datetime.now(timezone.utc).isoformat()
+    mapping_id = str(uuid.uuid4())
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO user_mappings
+                   (id, platform, platform_user_id, agent_slug, sender_name, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(platform, platform_user_id)
+                   DO UPDATE SET agent_slug = excluded.agent_slug,
+                                 sender_name = excluded.sender_name""",
+                (mapping_id, platform, platform_user_id, agent_slug, sender_name, now),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    return {
+        "id": mapping_id, "platform": platform,
+        "platform_user_id": platform_user_id,
+        "agent_slug": agent_slug,
+    }
+
+
+def delete_mapping(mapping_id: str) -> bool:
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            cursor = conn.execute(
+                "DELETE FROM user_mappings WHERE id = ?", (mapping_id,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp registration windows
+# ---------------------------------------------------------------------------
+
+def open_registration_window(agent_slug: str, minutes: int = 10) -> dict:
+    """Open (or re-open) a WhatsApp registration window for an agent."""
+    now = datetime.now(timezone.utc)
+    expires = now + timedelta(minutes=minutes)
+    now_iso = now.isoformat()
+    expires_iso = expires.isoformat()
+
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO whatsapp_registration_windows
+                   (agent_slug, opened_at, expires_at, registered_phone)
+                   VALUES (?, ?, ?, NULL)
+                   ON CONFLICT(agent_slug)
+                   DO UPDATE SET opened_at = excluded.opened_at,
+                                 expires_at = excluded.expires_at,
+                                 registered_phone = NULL""",
+                (agent_slug, now_iso, expires_iso),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    return {"agent_slug": agent_slug, "opened_at": now_iso, "expires_at": expires_iso}
+
+
+def get_registration_window(agent_slug: str) -> dict | None:
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT * FROM whatsapp_registration_windows WHERE agent_slug = ?",
+            (agent_slug,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def get_any_open_window() -> dict | None:
+    """Find any currently active (not expired, not used) registration window."""
+    now = datetime.now(timezone.utc).isoformat()
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            """SELECT * FROM whatsapp_registration_windows
+               WHERE registered_phone IS NULL AND expires_at > ?
+               ORDER BY opened_at DESC LIMIT 1""",
+            (now,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def close_registration_window(agent_slug: str, phone: str) -> None:
+    """Close a registration window by recording the registered phone."""
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                "UPDATE whatsapp_registration_windows SET registered_phone = ? WHERE agent_slug = ?",
+                (phone, agent_slug),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def is_registration_open(agent_slug: str) -> bool:
+    """Check if a registration window is currently open."""
+    window = get_registration_window(agent_slug)
+    if not window:
+        return False
+    if window.get("registered_phone"):
+        return False
+    now = datetime.now(timezone.utc).isoformat()
+    return now < window["expires_at"]
+
+
+# ---------------------------------------------------------------------------
+# Conversation state
+# ---------------------------------------------------------------------------
+
+def get_or_create_conversation(
+    sender_id: str, agent_slug: str, platform: str,
+) -> dict:
+    """Look up an existing conversation or create a new one."""
+    now = datetime.now(timezone.utc).isoformat()
+
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            row = conn.execute(
+                """SELECT id, chatty_conversation_id FROM conversations
+                   WHERE platform = ? AND sender_id = ? AND agent_slug = ?""",
+                (platform, sender_id, agent_slug),
+            ).fetchone()
+
+            if row:
+                conn.execute(
+                    "UPDATE conversations SET last_active = ? WHERE id = ?",
+                    (now, row["id"]),
+                )
+                conn.commit()
+                return {
+                    "id": row["id"],
+                    "chatty_conversation_id": row["chatty_conversation_id"],
+                    "is_new": False,
+                }
+
+            conv_id = str(uuid.uuid4())
+            conn.execute(
+                """INSERT INTO conversations
+                   (id, platform, sender_id, agent_slug, last_active, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (conv_id, platform, sender_id, agent_slug, now, now),
+            )
+            conn.commit()
+            return {"id": conv_id, "chatty_conversation_id": None, "is_new": True}
+        finally:
+            conn.close()
+
+
+def set_chatty_conversation_id(conv_id: str, chatty_conversation_id: str) -> None:
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                "UPDATE conversations SET chatty_conversation_id = ? WHERE id = ?",
+                (chatty_conversation_id, conv_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from agents.router import router as agents_router
 from branding.router import router as branding_router
 from integrations.router import router as integrations_router
 from integrations.crm_lite.router import router as crm_router
+from integrations.whatsapp.router import router as whatsapp_router
 from webby.router import router as webby_router
 from core.agents.scheduled_actions.router import router as scheduled_actions_router
 from setup.router import router as setup_router
@@ -38,7 +39,7 @@ async def lifespan(app: FastAPI):
 
     # Ensure data directories exist
     data_root = Path(__file__).resolve().parent / "data"
-    for subdir in ("agents", "branding", "integrations", "reminders"):
+    for subdir in ("agents", "branding", "integrations", "reminders", "whatsapp"):
         (data_root / subdir).mkdir(parents=True, exist_ok=True)
 
     # Initialize agent registry DB
@@ -50,6 +51,12 @@ async def lifespan(app: FastAPI):
     if integration_enabled("crm_lite"):
         from integrations.crm_lite.db import init_db as init_crm_db
         init_crm_db()
+
+    # Initialize WhatsApp state DB if bridge is configured
+    if settings.whatsapp.is_configured:
+        from integrations.whatsapp.state import init_db as init_whatsapp_db
+        init_whatsapp_db()
+        logger.info("WhatsApp bridge configured at %s", settings.whatsapp.bridge_url)
 
     # Initialize reminders + scheduled actions DB
     from core.agents.reminders.db import init_db as init_reminders_db
@@ -66,6 +73,14 @@ async def lifespan(app: FastAPI):
     _scheduler.add_job(process_due_actions, "interval", seconds=60, id="scheduled_actions_processor")
     _scheduler.start()
     logger.info("APScheduler started (reminder heartbeat + scheduled actions processor)")
+
+    # Log WhatsApp session status on startup
+    if settings.whatsapp.is_configured:
+        try:
+            from integrations.whatsapp.lifecycle import reconnect_all_sessions
+            reconnect_all_sessions()
+        except Exception as e:
+            logger.warning("WhatsApp session reconnect check failed: %s", e)
 
     logger.info("Chatty backend started. Data dir: %s", data_root)
     yield
@@ -100,6 +115,7 @@ app.include_router(providers_router, prefix="/api/providers", tags=["providers"]
 app.include_router(agents_router, prefix="/api/agents", tags=["agents"])
 app.include_router(branding_router, prefix="/api/branding", tags=["branding"])
 app.include_router(integrations_router, prefix="/api/integrations", tags=["integrations"])
+app.include_router(whatsapp_router, prefix="/api/messaging", tags=["messaging"])
 app.include_router(crm_router, prefix="/api/crm", tags=["crm"])
 app.include_router(webby_router, tags=["webby"])
 app.include_router(scheduled_actions_router, prefix="/api/scheduled-actions", tags=["scheduled-actions"])

--- a/backend/whatsapp-bridge/.gitignore
+++ b/backend/whatsapp-bridge/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+sessions/

--- a/backend/whatsapp-bridge/index.js
+++ b/backend/whatsapp-bridge/index.js
@@ -1,0 +1,408 @@
+/**
+ * WhatsApp Bridge — Baileys sidecar for CAKE OS / Chatty.
+ *
+ * Thin Express server that manages WhatsApp Web sessions via Baileys.
+ * Each session gets its own multi-file auth state on disk.  Incoming
+ * messages are forwarded to the CAKE/Chatty webhook; outbound messages
+ * are sent via REST.
+ *
+ * Environment:
+ *   WEBHOOK_URL   – where to POST inbound messages  (default: http://localhost:8000/api/messaging/whatsapp/webhook)
+ *   API_KEY       – shared secret for X-Api-Key header auth (optional)
+ *   PORT          – listen port (default: 3001)
+ *   SESSIONS_DIR  – directory for per-session auth state (default: ./sessions)
+ */
+
+import makeWASocket, {
+  useMultiFileAuthState,
+  DisconnectReason,
+  fetchLatestBaileysVersion,
+} from '@whiskeysockets/baileys';
+import express from 'express';
+import QRCode from 'qrcode';
+import pino from 'pino';
+import fs from 'fs';
+import path from 'path';
+
+const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
+
+const WEBHOOK_URL =
+  process.env.WEBHOOK_URL ||
+  'http://localhost:8000/api/messaging/whatsapp/webhook';
+const API_KEY = process.env.API_KEY || '';
+const PORT = parseInt(process.env.PORT || '3001', 10);
+const SESSIONS_DIR = process.env.SESSIONS_DIR || './sessions';
+
+// In-memory session map: sessionId → { sock, status, qr, jid }
+const sessions = new Map();
+
+// LID → full JID mapping (WhatsApp multi-device uses LIDs instead of phone JIDs)
+const lidToJid = new Map();
+
+// -----------------------------------------------------------------------
+// Validation & helpers
+// -----------------------------------------------------------------------
+
+const SAFE_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
+
+function validateSessionId(sessionId) {
+  if (!sessionId || !SAFE_SESSION_ID.test(sessionId)) {
+    throw new Error(`Invalid session ID: ${sessionId}`);
+  }
+}
+
+// Reconnect backoff state per session
+const reconnectAttempts = new Map();
+const MAX_RECONNECT_DELAY_MS = 60_000;
+
+function getReconnectDelay(sessionId) {
+  const attempts = reconnectAttempts.get(sessionId) || 0;
+  reconnectAttempts.set(sessionId, attempts + 1);
+  return Math.min(1000 * 2 ** attempts, MAX_RECONNECT_DELAY_MS);
+}
+
+function resetReconnectAttempts(sessionId) {
+  reconnectAttempts.delete(sessionId);
+}
+
+// -----------------------------------------------------------------------
+// Baileys session helpers
+// -----------------------------------------------------------------------
+
+async function startSession(sessionId) {
+  validateSessionId(sessionId);
+  const sessionDir = path.join(SESSIONS_DIR, sessionId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  const { state, saveCreds } = await useMultiFileAuthState(sessionDir);
+  const { version } = await fetchLatestBaileysVersion();
+
+  const entry = { sock: null, status: 'connecting', qr: null, jid: null };
+  sessions.set(sessionId, entry);
+
+  // Message cache for retry decryption (required by Baileys multi-device)
+  const msgCache = new Map();
+
+  const sock = makeWASocket({
+    version,
+    auth: state,
+    logger: pino({ level: 'warn' }),
+    printQRInTerminal: false,
+    syncFullHistory: false,
+    markOnlineOnConnect: true,
+    getMessage: async (key) => {
+      const cached = msgCache.get(key.id);
+      return cached?.message || undefined;
+    },
+  });
+
+  entry.sock = sock;
+
+  // Persist credentials whenever they change
+  sock.ev.on('creds.update', saveCreds);
+
+  // Connection lifecycle
+  sock.ev.on('connection.update', (update) => {
+    const { connection, lastDisconnect, qr: qrString } = update;
+
+    if (qrString) {
+      entry.qr = qrString;
+      entry.status = 'scan_qr';
+      logger.info({ sessionId }, 'QR code available — waiting for scan');
+    }
+
+    if (connection === 'open') {
+      entry.status = 'connected';
+      entry.qr = null;
+      entry.jid = sock.user?.id || null;
+      resetReconnectAttempts(sessionId);
+      logger.info({ sessionId, jid: entry.jid }, 'Session connected');
+    }
+
+    if (connection === 'close') {
+      const statusCode =
+        lastDisconnect?.error?.output?.statusCode;
+      const shouldReconnect =
+        statusCode !== DisconnectReason.loggedOut;
+
+      logger.info(
+        { sessionId, statusCode, shouldReconnect },
+        'Session disconnected',
+      );
+
+      if (shouldReconnect) {
+        const delay = getReconnectDelay(sessionId);
+        logger.info({ sessionId, delay }, 'Reconnecting after delay');
+        setTimeout(() => {
+          startSession(sessionId).catch((err) =>
+            logger.error({ err, sessionId }, 'Reconnect failed'),
+          );
+        }, delay);
+      } else {
+        entry.status = 'disconnected';
+        entry.sock = null;
+      }
+    }
+  });
+
+  // Forward incoming messages to webhook
+  sock.ev.on('messages.upsert', async ({ messages: msgs, type }) => {
+    logger.info({ sessionId, count: msgs.length, type }, 'messages.upsert event');
+    for (const msg of msgs) {
+      // Cache for getMessage retries
+      if (msg.key.id && msg.message) {
+        msgCache.set(msg.key.id, msg);
+        // Evict old entries to prevent unbounded growth
+        if (msgCache.size > 500) {
+          const firstKey = msgCache.keys().next().value;
+          msgCache.delete(firstKey);
+        }
+      }
+      logger.info({ sessionId, fromMe: msg.key.fromMe, remoteJid: msg.key.remoteJid, hasMessage: !!msg.message }, 'Processing message');
+      if (msg.key.fromMe) continue;
+
+      const remoteJid = msg.key.remoteJid || '';
+      // Handle personal chats — both traditional (@s.whatsapp.net) and
+      // linked identity (@lid) formats. Skip groups (@g.us).
+      if (remoteJid.endsWith('@g.us')) continue;
+
+      // Extract phone number or LID as the sender identifier
+      const phone = remoteJid.includes('@')
+        ? remoteJid.split('@')[0]
+        : remoteJid;
+
+      // Cache the LID→JID mapping so we can reply using the correct JID
+      if (remoteJid.endsWith('@lid')) {
+        lidToJid.set(phone, remoteJid);
+        logger.info({ phone, jid: remoteJid }, 'Cached LID→JID mapping');
+      }
+
+      // Also try to get the real phone from the participant field (for LID messages)
+      const senderPhone = msg.key.participant
+        ? msg.key.participant.split('@')[0]
+        : phone;
+      const text =
+        msg.message?.conversation ||
+        msg.message?.extendedTextMessage?.text ||
+        '';
+      if (!text) continue;
+
+      logger.info({ sessionId, phone, senderPhone, remoteJid, text: text.substring(0, 50) }, 'Forwarding message to webhook');
+
+      const payload = {
+        session: sessionId,
+        phone: senderPhone,
+        text,
+        sender_name: msg.pushName || '',
+        message_id: msg.key.id,
+      };
+
+      try {
+        const headers = { 'Content-Type': 'application/json' };
+        if (API_KEY) headers['X-Api-Key'] = API_KEY;
+
+        await fetch(WEBHOOK_URL, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(payload),
+        });
+      } catch (err) {
+        logger.error({ err, sessionId, phone }, 'Webhook delivery failed');
+      }
+    }
+  });
+
+  return entry;
+}
+
+// -----------------------------------------------------------------------
+// Express app
+// -----------------------------------------------------------------------
+
+const app = express();
+app.use(express.json());
+
+// API key middleware (skip if no API_KEY configured)
+app.use((req, res, next) => {
+  if (!API_KEY) return next();
+  const provided = req.headers['x-api-key'] || '';
+  if (provided !== API_KEY) {
+    return res.status(401).json({ error: 'Invalid API key' });
+  }
+  next();
+});
+
+// POST /sessions — Create and start a new session
+app.post('/sessions', async (req, res) => {
+  const sessionId = req.body.session;
+  if (!sessionId) {
+    return res.status(400).json({ error: 'Missing "session" in body' });
+  }
+  if (!SAFE_SESSION_ID.test(sessionId)) {
+    return res.status(400).json({ error: 'Invalid session ID format' });
+  }
+  if (sessions.has(sessionId)) {
+    const existing = sessions.get(sessionId);
+    return res.json({ status: existing.status, jid: existing.jid });
+  }
+
+  try {
+    await startSession(sessionId);
+    res.json({ status: 'starting' });
+  } catch (err) {
+    logger.error({ err, sessionId }, 'Failed to start session');
+    res.status(500).json({ error: 'Failed to start session' });
+  }
+});
+
+// GET /sessions — List all sessions
+app.get('/sessions', (_req, res) => {
+  const list = [];
+  for (const [id, entry] of sessions) {
+    list.push({
+      session: id,
+      status: entry.status,
+      jid: entry.jid,
+    });
+  }
+  res.json(list);
+});
+
+// GET /sessions/:id — Get session status
+app.get('/sessions/:id', (req, res) => {
+  if (!SAFE_SESSION_ID.test(req.params.id)) {
+    return res.status(400).json({ error: 'Invalid session ID format' });
+  }
+  const entry = sessions.get(req.params.id);
+  if (!entry) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+  res.json({
+    status: entry.status,
+    jid: entry.jid,
+    qr_available: !!entry.qr,
+  });
+});
+
+// GET /sessions/:id/qr — Get QR code as PNG
+app.get('/sessions/:id/qr', async (req, res) => {
+  if (!SAFE_SESSION_ID.test(req.params.id)) {
+    return res.status(400).json({ error: 'Invalid session ID format' });
+  }
+  const entry = sessions.get(req.params.id);
+  if (!entry || !entry.qr) {
+    return res.status(404).json({ error: 'QR not available' });
+  }
+  try {
+    const png = await QRCode.toBuffer(entry.qr, { type: 'png', width: 300 });
+    res.set('Content-Type', 'image/png');
+    res.send(png);
+  } catch (err) {
+    logger.error({ err }, 'QR render failed');
+    res.status(500).json({ error: 'QR render failed' });
+  }
+});
+
+// POST /sessions/:id/send — Send a text message
+app.post('/sessions/:id/send', async (req, res) => {
+  if (!SAFE_SESSION_ID.test(req.params.id)) {
+    return res.status(400).json({ error: 'Invalid session ID format' });
+  }
+  const entry = sessions.get(req.params.id);
+  if (!entry || !entry.sock) {
+    return res.status(404).json({ error: 'Session not found or not connected' });
+  }
+  if (entry.status !== 'connected') {
+    return res.status(400).json({ error: `Session not connected (status: ${entry.status})` });
+  }
+
+  const { phone, text } = req.body;
+  if (!phone || !text) {
+    return res.status(400).json({ error: 'Missing "phone" or "text"' });
+  }
+
+  // Try LID format first (if the phone looks like a LID), then fall back to standard JID
+  const cleanPhone = phone.replace(/^\+/, '');
+  const jid = lidToJid.has(cleanPhone)
+    ? lidToJid.get(cleanPhone)
+    : `${cleanPhone}@s.whatsapp.net`;
+  logger.info({ phone: cleanPhone, jid }, 'Sending message');
+  try {
+    const result = await entry.sock.sendMessage(jid, { text });
+    res.json({ ok: true, id: result?.key?.id });
+  } catch (err) {
+    logger.error({ err, phone }, 'Send failed');
+    res.status(500).json({ error: 'Send failed' });
+  }
+});
+
+// DELETE /sessions/:id — Logout and delete session
+app.delete('/sessions/:id', async (req, res) => {
+  const sessionId = req.params.id;
+  if (!SAFE_SESSION_ID.test(sessionId)) {
+    return res.status(400).json({ error: 'Invalid session ID format' });
+  }
+  const entry = sessions.get(sessionId);
+
+  if (entry?.sock) {
+    try {
+      await entry.sock.logout();
+    } catch {
+      // Already disconnected — ignore
+    }
+    entry.sock = null;
+  }
+  sessions.delete(sessionId);
+
+  // Remove auth state from disk
+  const sessionDir = path.join(SESSIONS_DIR, sessionId);
+  try {
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  } catch {
+    // Directory may not exist — ignore
+  }
+
+  res.json({ ok: true });
+});
+
+// -----------------------------------------------------------------------
+// Startup: reconnect saved sessions
+// -----------------------------------------------------------------------
+
+async function reconnectSavedSessions() {
+  if (!fs.existsSync(SESSIONS_DIR)) return;
+
+  const dirs = fs
+    .readdirSync(SESSIONS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  for (const sessionId of dirs) {
+    const credsPath = path.join(SESSIONS_DIR, sessionId, 'creds.json');
+    if (!fs.existsSync(credsPath)) continue;
+
+    logger.info({ sessionId }, 'Reconnecting saved session');
+    try {
+      await startSession(sessionId);
+    } catch (err) {
+      logger.error({ err, sessionId }, 'Failed to reconnect session');
+    }
+  }
+}
+
+// -----------------------------------------------------------------------
+// Boot
+// -----------------------------------------------------------------------
+
+await reconnectSavedSessions();
+
+if (!API_KEY) {
+  logger.warn(
+    'No API_KEY set — sidecar is running without authentication. ' +
+    'Set the API_KEY environment variable in production.',
+  );
+}
+
+app.listen(PORT, () => {
+  logger.info({ port: PORT, webhook: WEBHOOK_URL }, 'WhatsApp bridge started');
+});

--- a/backend/whatsapp-bridge/index.js
+++ b/backend/whatsapp-bridge/index.js
@@ -23,6 +23,7 @@ import QRCode from 'qrcode';
 import pino from 'pino';
 import fs from 'fs';
 import path from 'path';
+import crypto from 'crypto';
 
 const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
 
@@ -226,7 +227,10 @@ app.use(express.json());
 app.use((req, res, next) => {
   if (!API_KEY) return next();
   const provided = req.headers['x-api-key'] || '';
-  if (provided !== API_KEY) {
+  // Timing-safe comparison to prevent side-channel attacks
+  const a = Buffer.from(provided);
+  const b = Buffer.from(API_KEY);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
     return res.status(401).json({ error: 'Invalid API key' });
   }
   next();

--- a/backend/whatsapp-bridge/package.json
+++ b/backend/whatsapp-bridge/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "whatsapp-bridge",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@whiskeysockets/baileys": "^7.0.0-rc.9",
+    "express": "^4.21.0",
+    "pino": "^9.0.0",
+    "qrcode": "^1.5.4"
+  }
+}

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -11,6 +11,7 @@ export interface Agent {
   model_override: string;
   gmail_enabled: boolean;
   calendar_enabled: boolean;
+  whatsapp_session_id?: string;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { api } from '../core/api/client';
-import type { Integration } from '../core/types';
+import { getToken } from '../core/auth/AuthContext';
+import type { Integration, Agent } from '../core/types';
 
 export function IntegrationsTab() {
   const [integrations, setIntegrations] = useState<Integration[]>([]);
@@ -17,11 +18,134 @@ export function IntegrationsTab() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
+  // WhatsApp state
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [waSelectedAgent, setWaSelectedAgent] = useState<string>('');
+  const [waConnecting, setWaConnecting] = useState<Record<string, boolean>>({});
+  const [waQrUrls, setWaQrUrls] = useState<Record<string, string>>({});
+  const [waStatuses, setWaStatuses] = useState<Record<string, string>>({});
+  const [waErrors, setWaErrors] = useState<Record<string, string>>({});
+  const [waExpanded, setWaExpanded] = useState(false);
+  const pollTimers = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+
   useEffect(() => {
     api<{ integrations: Integration[] }>('/api/integrations')
       .then(data => setIntegrations(data.integrations))
       .finally(() => setLoading(false));
   }, []);
+
+  // Load agents when WhatsApp panel is expanded
+  useEffect(() => {
+    if (waExpanded) {
+      api<{ agents: Agent[] }>('/api/agents')
+        .then(data => {
+          setAgents(data.agents);
+          // Initialize statuses for agents with active sessions
+          const statuses: Record<string, string> = {};
+          for (const a of data.agents) {
+            if (a.whatsapp_session_id) {
+              statuses[a.slug] = 'checking...';
+              // Fetch actual status
+              api<{ status: string }>(`/api/messaging/whatsapp/session/status/${a.slug}`)
+                .then(s => setWaStatuses(prev => ({ ...prev, [a.slug]: s.status })))
+                .catch(() => setWaStatuses(prev => ({ ...prev, [a.slug]: 'unknown' })));
+            }
+          }
+          setWaStatuses(statuses);
+        });
+    }
+  }, [waExpanded]);
+
+  // Cleanup poll timers on unmount
+  useEffect(() => {
+    return () => {
+      Object.values(pollTimers.current).forEach(clearInterval);
+    };
+  }, []);
+
+  const startQrPolling = useCallback((slug: string) => {
+    // Clear existing timer for this slug
+    if (pollTimers.current[slug]) clearInterval(pollTimers.current[slug]);
+
+    pollTimers.current[slug] = setInterval(async () => {
+      try {
+        // Check status
+        const status = await api<{ status: string }>(`/api/messaging/whatsapp/session/status/${slug}`);
+        setWaStatuses(prev => ({ ...prev, [slug]: status.status }));
+
+        if (status.status === 'connected') {
+          // Connected! Stop polling, refresh agents
+          clearInterval(pollTimers.current[slug]);
+          delete pollTimers.current[slug];
+          setWaConnecting(prev => ({ ...prev, [slug]: false }));
+          setWaQrUrls(prev => { const n = { ...prev }; delete n[slug]; return n; });
+          // Refresh agent list to get updated whatsapp_session_id
+          const data = await api<{ agents: Agent[] }>('/api/agents');
+          setAgents(data.agents);
+          return;
+        }
+
+        if (status.status === 'scan_qr') {
+          // Fetch QR code as binary
+          const token = getToken();
+          const resp = await fetch(`/api/messaging/whatsapp/session/qr/${slug}`, {
+            headers: token ? { 'Authorization': `Bearer ${token}` } : {},
+          });
+          if (resp.ok) {
+            const blob = await resp.blob();
+            const url = URL.createObjectURL(blob);
+            setWaQrUrls(prev => {
+              // Revoke old URL to prevent memory leak
+              if (prev[slug]) URL.revokeObjectURL(prev[slug]);
+              return { ...prev, [slug]: url };
+            });
+          }
+        }
+      } catch {
+        // Ignore polling errors
+      }
+    }, 3000);
+  }, []);
+
+  async function connectWhatsApp(slug: string) {
+    setWaConnecting(prev => ({ ...prev, [slug]: true }));
+    setWaErrors(prev => { const n = { ...prev }; delete n[slug]; return n; });
+    try {
+      await api('/api/messaging/whatsapp/session', {
+        method: 'POST',
+        body: JSON.stringify({ agent_slug: slug }),
+      });
+      setWaStatuses(prev => ({ ...prev, [slug]: 'scan_qr' }));
+      startQrPolling(slug);
+    } catch (err: unknown) {
+      setWaConnecting(prev => ({ ...prev, [slug]: false }));
+      setWaErrors(prev => ({
+        ...prev,
+        [slug]: err instanceof Error ? err.message : 'Connection failed',
+      }));
+    }
+  }
+
+  async function disconnectWhatsApp(slug: string) {
+    try {
+      await api(`/api/messaging/whatsapp/session/${slug}`, { method: 'DELETE' });
+      if (pollTimers.current[slug]) {
+        clearInterval(pollTimers.current[slug]);
+        delete pollTimers.current[slug];
+      }
+      setWaConnecting(prev => ({ ...prev, [slug]: false }));
+      setWaStatuses(prev => ({ ...prev, [slug]: 'disconnected' }));
+      setWaQrUrls(prev => {
+        if (prev[slug]) URL.revokeObjectURL(prev[slug]);
+        const n = { ...prev }; delete n[slug]; return n;
+      });
+      // Refresh agents
+      const data = await api<{ agents: Agent[] }>('/api/agents');
+      setAgents(data.agents);
+    } catch {
+      // Ignore disconnect errors
+    }
+  }
 
   async function toggleEnable(id: string, enabled: boolean) {
     const endpoint = enabled ? 'disable' : 'enable';
@@ -79,7 +203,7 @@ export function IntegrationsTab() {
             </div>
 
             <div className="flex items-center gap-2">
-              {integration.auth_type !== 'stub' && (
+              {integration.auth_type !== 'stub' && integration.auth_type !== 'qr_session' && (
                 <>
                   {!integration.configured && (
                     <button
@@ -102,13 +226,141 @@ export function IntegrationsTab() {
                   )}
                 </>
               )}
+              {integration.auth_type === 'qr_session' && (
+                <button
+                  onClick={() => setWaExpanded(prev => !prev)}
+                  className="text-xs px-3 py-1.5 rounded-lg bg-green-700/30 text-green-300 hover:bg-green-700/50 transition"
+                >
+                  {waExpanded ? 'Close' : 'Manage'}
+                </button>
+              )}
               {integration.auth_type === 'stub' && (
                 <span className="text-xs text-gray-500 bg-gray-700/50 px-2 py-1 rounded">Coming soon</span>
               )}
             </div>
           </div>
 
-          {/* Setup forms */}
+          {/* WhatsApp QR session panel */}
+          {integration.auth_type === 'qr_session' && waExpanded && (
+            <div className="mt-4 pt-4 border-t border-gray-700 space-y-4">
+              {agents.length === 0 ? (
+                <p className="text-gray-400 text-sm">No agents created yet. Create an agent first.</p>
+              ) : (
+                <>
+                  {/* Agent selector */}
+                  <div>
+                    <label className="block text-gray-400 text-xs mb-1.5">Select agent to connect</label>
+                    <select
+                      value={waSelectedAgent}
+                      onChange={e => setWaSelectedAgent(e.target.value)}
+                      className="w-full bg-gray-700 border border-gray-600 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-indigo-500"
+                    >
+                      <option value="">Choose an agent...</option>
+                      {agents.map(a => (
+                        <option key={a.id} value={a.slug}>
+                          {a.agent_name} {a.whatsapp_session_id ? '(connected)' : ''}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* Per-agent status when selected */}
+                  {waSelectedAgent && (() => {
+                    const agent = agents.find(a => a.slug === waSelectedAgent);
+                    if (!agent) return null;
+                    const slug = agent.slug;
+                    const status = waStatuses[slug] || 'disconnected';
+                    const isConnecting = waConnecting[slug];
+                    const qrUrl = waQrUrls[slug];
+                    const errMsg = waErrors[slug];
+
+                    return (
+                      <div className="bg-gray-900/50 rounded-lg p-4 space-y-3">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <span className="text-white text-sm font-medium">{agent.agent_name}</span>
+                            <span className={`inline-block w-2 h-2 rounded-full ${
+                              status === 'connected' ? 'bg-green-400' :
+                              status === 'scan_qr' || status === 'connecting' ? 'bg-yellow-400 animate-pulse' :
+                              'bg-gray-500'
+                            }`} />
+                            <span className="text-gray-400 text-xs capitalize">{status.replace('_', ' ')}</span>
+                          </div>
+
+                          {status === 'connected' && (
+                            <button
+                              onClick={() => disconnectWhatsApp(slug)}
+                              className="text-xs px-3 py-1.5 rounded-lg bg-red-700/30 text-red-300 hover:bg-red-700/50 transition"
+                            >
+                              Disconnect
+                            </button>
+                          )}
+                          {status === 'disconnected' && !isConnecting && (
+                            <button
+                              onClick={() => connectWhatsApp(slug)}
+                              className="text-xs px-3 py-1.5 rounded-lg bg-green-700/30 text-green-300 hover:bg-green-700/50 transition"
+                            >
+                              Connect WhatsApp
+                            </button>
+                          )}
+                        </div>
+
+                        {errMsg && <p className="text-red-400 text-xs">{errMsg}</p>}
+
+                        {/* QR Code display */}
+                        {(isConnecting || status === 'scan_qr') && (
+                          <div className="flex flex-col items-center gap-3 py-2">
+                            {qrUrl ? (
+                              <img src={qrUrl} alt="WhatsApp QR Code" className="w-48 h-48 rounded-lg bg-white p-2" />
+                            ) : (
+                              <div className="w-48 h-48 rounded-lg bg-gray-700 flex items-center justify-center">
+                                <div className="w-6 h-6 border-2 border-green-400 border-t-transparent rounded-full animate-spin" />
+                              </div>
+                            )}
+                            <div className="text-center">
+                              <p className="text-gray-300 text-sm">Scan with WhatsApp</p>
+                              <p className="text-gray-500 text-xs mt-1">
+                                Open WhatsApp &rarr; Settings &rarr; Linked Devices &rarr; Link a Device
+                              </p>
+                            </div>
+                          </div>
+                        )}
+
+                        {status === 'connected' && (
+                          <p className="text-green-400/80 text-xs">
+                            Messages to this WhatsApp number will be handled by {agent.agent_name}.
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })()}
+
+                  {/* Connected agents summary */}
+                  {agents.filter(a => a.whatsapp_session_id).length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-gray-400 text-xs font-medium">Connected agents</p>
+                      {agents.filter(a => a.whatsapp_session_id).map(a => (
+                        <div key={a.id} className="flex items-center justify-between bg-gray-900/30 rounded-lg px-3 py-2">
+                          <div className="flex items-center gap-2">
+                            <span className="inline-block w-2 h-2 rounded-full bg-green-400" />
+                            <span className="text-white text-sm">{a.agent_name}</span>
+                          </div>
+                          <button
+                            onClick={() => { setWaSelectedAgent(a.slug); }}
+                            className="text-xs text-gray-400 hover:text-white transition"
+                          >
+                            Manage
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Standard setup forms */}
           {setupFor === integration.id && (
             <div className="mt-4 pt-4 border-t border-gray-700 space-y-3">
               {error && <p className="text-red-400 text-xs">{error}</p>}

--- a/run.py
+++ b/run.py
@@ -120,6 +120,9 @@ def install_deps():
     (VENV / "deps_installed").touch()
 
 
+WA_BRIDGE = BACKEND / "whatsapp-bridge"
+
+
 def setup_frontend():
     if not (FRONTEND / "node_modules").exists():
         print("  Installing frontend dependencies...")
@@ -131,22 +134,56 @@ def setup_frontend():
     subprocess.run(["npm", "run", "build"], cwd=str(FRONTEND), check=True)
 
 
+def setup_whatsapp_bridge():
+    """Install WhatsApp bridge sidecar dependencies if needed."""
+    if not WA_BRIDGE.exists():
+        return
+    if not (WA_BRIDGE / "node_modules").exists():
+        print("  Installing WhatsApp bridge dependencies...")
+        subprocess.run(["npm", "ci"], cwd=str(WA_BRIDGE), check=True)
+    else:
+        print("  WhatsApp bridge dependencies already installed.")
+
+
+def start_whatsapp_bridge() -> subprocess.Popen | None:
+    """Start the WhatsApp bridge sidecar if configured."""
+    if not WA_BRIDGE.exists() or not (WA_BRIDGE / "node_modules").exists():
+        return None
+    # Only start if WHATSAPP_BRIDGE_URL is configured
+    if not os.environ.get("WHATSAPP_BRIDGE_URL"):
+        return None
+    print("  Starting WhatsApp bridge sidecar on port 3001...")
+    return subprocess.Popen(
+        ["node", "index.js"],
+        cwd=str(WA_BRIDGE),
+        env={**os.environ, "PORT": "3001"},
+    )
+
+
 def start_server():
+    wa_proc = start_whatsapp_bridge()
     print()
     print("=" * 50)
     print("  Chatty is running at http://localhost:8000")
+    if wa_proc:
+        print("  WhatsApp bridge running on port 3001")
     print("  Press Ctrl+C to stop.")
     print("=" * 50)
     print()
-    subprocess.run(
-        [
-            _python(), "-m", "uvicorn",
-            "main:app",
-            "--host", "127.0.0.1",
-            "--port", "8000",
-        ],
-        cwd=str(BACKEND),
-    )
+    try:
+        subprocess.run(
+            [
+                _python(), "-m", "uvicorn",
+                "main:app",
+                "--host", "127.0.0.1",
+                "--port", "8000",
+            ],
+            cwd=str(BACKEND),
+        )
+    finally:
+        if wa_proc:
+            wa_proc.terminate()
+            wa_proc.wait(timeout=5)
 
 
 def main():
@@ -167,6 +204,9 @@ def main():
 
     print("\nSetting up frontend...")
     setup_frontend()
+
+    print("\nSetting up WhatsApp bridge...")
+    setup_whatsapp_bridge()
 
     start_server()
 


### PR DESCRIPTION
## Summary
- Replaces the WhatsApp stub with a full Baileys-based integration ported from the CAKE OS `whatsapp-upgrade` branch
- Adds a Node.js sidecar (`whatsapp-bridge/`) that manages WhatsApp Web sessions, with the LID fix for multi-device protocol support
- Implements Python backend (client, lifecycle, state DB, message service, router) that routes inbound WhatsApp messages through Chatty's AI engine with full tool access
- Frontend QR code setup panel in IntegrationsTab with per-agent connect/disconnect and 3-second polling

## Test plan
- [ ] Set `WHATSAPP_BRIDGE_URL=http://localhost:3001` and `WHATSAPP_BRIDGE_API_KEY` in `.env`
- [ ] Start sidecar with `cd backend/whatsapp-bridge && node index.js` — verify it starts on port 3001
- [ ] Start backend — verify "WhatsApp bridge configured" log message appears
- [ ] Open Integrations tab — verify WhatsApp shows "Manage" button instead of "Coming soon"
- [ ] Click Manage → select an agent → click "Connect WhatsApp" → verify QR code appears
- [ ] Scan QR with WhatsApp → verify status changes to "connected"
- [ ] Send a WhatsApp message to the connected number → verify agent processes and responds
- [ ] Test disconnect flow — verify session clears and agent shows as disconnected