### PR TITLE
Port Telegram bot integration from CAKE OS

### DIFF
--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -58,10 +58,25 @@ def init_db() -> None:
             model_override      TEXT NOT NULL DEFAULT '',
             gmail_enabled       INTEGER NOT NULL DEFAULT 0,
             calendar_enabled    INTEGER NOT NULL DEFAULT 0,
+            telegram_enabled    INTEGER NOT NULL DEFAULT 0,
+            telegram_bot_token  TEXT NOT NULL DEFAULT '',
+            telegram_bot_username TEXT NOT NULL DEFAULT '',
             created_at          TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
         );
     """)
+
+    # Migrations for existing databases
+    for col, typedef in [
+        ("telegram_enabled", "INTEGER NOT NULL DEFAULT 0"),
+        ("telegram_bot_token", "TEXT NOT NULL DEFAULT ''"),
+        ("telegram_bot_username", "TEXT NOT NULL DEFAULT ''"),
+    ]:
+        try:
+            _connection.execute(f"ALTER TABLE agents ADD COLUMN {col} {typedef}")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
     _connection.commit()
     logger.info("Agent registry DB initialized at %s", DB_PATH)
 
@@ -126,7 +141,8 @@ def list_agents() -> list[dict]:
 UPDATABLE_FIELDS = {
     "agent_name", "avatar_url", "personality",
     "onboarding_complete", "provider_override", "model_override",
-    "gmail_enabled", "calendar_enabled",
+    "gmail_enabled", "calendar_enabled", "telegram_enabled",
+    "telegram_bot_token", "telegram_bot_username",
 }
 
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -150,6 +150,7 @@ class UpdateAgentRequest(BaseModel):
     model_override: str | None = None
     gmail_enabled: bool | None = None
     calendar_enabled: bool | None = None
+    telegram_enabled: bool | None = None
 
 
 class ChatRequest(BaseModel):
@@ -206,7 +207,7 @@ async def update_agent(agent_id: str, body: UpdateAgentRequest, user=Depends(get
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
-    for field in ("onboarding_complete", "gmail_enabled", "calendar_enabled"):
+    for field in ("onboarding_complete", "gmail_enabled", "calendar_enabled", "telegram_enabled"):
         if field in updates:
             updates[field] = int(updates[field])
     agent = agent_db.update_agent(agent_id, **updates)

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -552,3 +552,140 @@ async def chat(
 
     # Exceeded max iterations
     yield _sse({"type": "error", "error": "Tool loop exceeded maximum iterations"})
+
+
+# ── Non-streaming sync execution (for Telegram / messaging channels) ──────────
+
+async def run_sync(
+    config: AgentConfig,
+    provider: AIProvider,
+    registry: ToolRegistry,
+    ctx_manager: ContextManager,
+    messages: list[dict],
+    chat_service=None,
+    conversation_id: str | None = None,
+    integration_tool_defs: list[dict] | None = None,
+) -> str:
+    """Run an agent synchronously, returning the final text response.
+
+    This is the non-streaming counterpart to ``chat()``.  Used by inbound
+    messaging integrations (Telegram) where the caller needs a single text
+    response rather than an SSE stream.
+
+    Works with any AIProvider (Anthropic, OpenAI, Google Gemini).
+    Supports full multi-turn tool execution loop.
+    """
+    # Build tool definitions (same as streaming path)
+    real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
+    dynamic_real_tools = load_all_real_tools(real_tools_dir)
+
+    tool_defs = get_tool_definitions(
+        gmail_enabled=config.gmail_enabled,
+        calendar_enabled=config.calendar_enabled,
+        integration_tools=integration_tool_defs,
+        dynamic_real_tools=dynamic_real_tools or None,
+    )
+    kind_map = _build_kind_map(tool_defs)
+
+    # Strip internal fields before sending to provider
+    _internal_fields = {"kind", "writes", "context_memory"}
+    provider_tools = [{k: v for k, v in t.items() if k not in _internal_fields} for t in tool_defs]
+
+    # Build system prompt
+    system_prompt = _build_system_prompt(config, ctx_manager)
+
+    # Append integration-specific instructions (same as chat())
+    if integration_tool_defs:
+        odoo_tools = [t for t in integration_tool_defs if t.get("name", "").startswith("odoo_")]
+        if odoo_tools:
+            system_prompt += (
+                "\n\n# Odoo ERP Tools Available\n\n"
+                "You have Odoo tools for CRM, helpdesk, sales, purchasing, contacts, projects, "
+                "and timesheets. Use them when the user asks about business operations."
+            )
+
+    # Chat history — save user message
+    persist = chat_service is not None
+    if persist:
+        try:
+            if not conversation_id:
+                conv = chat_service.create_conversation()
+                conversation_id = conv["id"]
+
+            last_user = next((m for m in reversed(messages) if m.get("role") == "user"), None)
+            if last_user:
+                chat_service.save_message(
+                    conversation_id=conversation_id,
+                    msg_id=str(uuid.uuid4()),
+                    role="user",
+                    content=last_user.get("content", ""),
+                )
+        except Exception as e:
+            logger.warning("run_sync: chat history save (user msg) failed: %s", e)
+
+    current_messages = list(messages)
+    accumulated_text = ""
+    max_iterations = 20
+
+    for iteration in range(max_iterations):
+        tool_calls_this_turn: list[dict] = []
+        turn_text = ""
+        stop_reason = "stop"
+
+        # Stream one turn, collecting all events
+        async for event in provider.stream_turn(current_messages, provider_tools, system_prompt):
+            etype = event.get("type")
+
+            if etype == "text":
+                turn_text += event["text"]
+                accumulated_text += event["text"]
+
+            elif etype == "_turn_complete":
+                tool_calls_this_turn = event.get("tool_calls", [])
+                stop_reason = event.get("stop_reason", "stop")
+
+            elif etype == "error":
+                logger.error("run_sync: provider error: %s", event.get("error"))
+                return accumulated_text or "I encountered an error. Please try again."
+
+        # Save assistant turn to history
+        if persist and turn_text and conversation_id:
+            try:
+                chat_service.save_message(
+                    conversation_id=conversation_id,
+                    msg_id=str(uuid.uuid4()),
+                    role="assistant",
+                    content=turn_text,
+                )
+            except Exception as e:
+                logger.warning("run_sync: chat history save (assistant) failed: %s", e)
+
+        # If no tool calls, we're done
+        if stop_reason != "tool_use" or not tool_calls_this_turn:
+            break
+
+        # Execute tool calls (power mode — no confirmation flow for messaging)
+        results = []
+        for tc in tool_calls_this_turn:
+            tool_name = tc.get("name", "")
+            tool_args = tc.get("args", {})
+            tool_use_id = tc.get("id", "")
+            kind = kind_map.get(tool_name, "context")
+
+            try:
+                result = await registry.execute_tool(tool_name, tool_args, kind)
+                _sync_context_after_tool(tool_name, result, ctx_manager)
+            except Exception as e:
+                logger.error("run_sync: tool %s failed: %s", tool_name, e)
+                result = {"error": str(e)}
+
+            results.append({
+                "tool_use_id": tool_use_id,
+                "tool_name": tool_name,
+                "content": json.dumps(result),
+            })
+
+        # Append tool results for next turn
+        current_messages = provider.add_tool_results(current_messages, tool_calls_this_turn, results)
+
+    return accumulated_text or "I had trouble generating a response. Please try again."

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -47,6 +47,12 @@ AVAILABLE_INTEGRATIONS = {
         "icon": "📋",
         "auth_type": "none",
     },
+    "telegram": {
+        "name": "Telegram",
+        "description": "Telegram Bot — connect your agent to a Telegram bot",
+        "icon": "✈️",
+        "auth_type": "per_agent",
+    },
     "whatsapp": {
         "name": "WhatsApp",
         "description": "WhatsApp Business — send/receive messages (coming soon)",

--- a/backend/integrations/telegram/client.py
+++ b/backend/integrations/telegram/client.py
@@ -1,0 +1,155 @@
+"""Telegram Bot API client.
+
+Handles outbound messages and webhook registration.  Every function requires
+an explicit ``bot_token`` — there is no global fallback.  Telegram's Bot API
+is HTTP/webhook-based so no persistent connections are needed.
+"""
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+MAX_CHUNK_LENGTH = 4096  # Telegram's message limit
+
+
+def _base_url(bot_token: str) -> str:
+    return f"https://api.telegram.org/bot{bot_token}"
+
+
+def send_message(chat_id: int | str, text: str, bot_token: str) -> list[dict]:
+    """Send a text message to a Telegram chat.
+
+    Long messages are chunked.  Returns a list of Telegram response dicts.
+    """
+    if not bot_token:
+        logger.warning("No Telegram bot token — cannot send message")
+        return []
+
+    chunks = _chunk_text(text, MAX_CHUNK_LENGTH)
+    results = []
+    for chunk in chunks:
+        try:
+            resp = httpx.post(
+                f"{_base_url(bot_token)}/sendMessage",
+                json={
+                    "chat_id": chat_id,
+                    "text": chunk,
+                    "parse_mode": "Markdown",
+                },
+                timeout=30,
+            )
+            # If Markdown parse fails, retry without parse_mode
+            if resp.status_code == 400 and "parse" in resp.text.lower():
+                resp = httpx.post(
+                    f"{_base_url(bot_token)}/sendMessage",
+                    json={"chat_id": chat_id, "text": chunk},
+                    timeout=30,
+                )
+            resp.raise_for_status()
+            results.append(resp.json())
+        except httpx.HTTPError as e:
+            logger.error("Telegram send failed: %s", e)
+            results.append({"error": str(e)})
+
+    return results
+
+
+def set_webhook(url: str, bot_token: str, secret_token: str | None = None) -> dict:
+    """Register a webhook URL with Telegram.
+
+    Telegram will POST updates to this URL.  The optional ``secret_token``
+    is sent in the ``X-Telegram-Bot-Api-Secret-Token`` header on every
+    webhook delivery so we can verify authenticity.
+    """
+    if not bot_token:
+        return {"ok": False, "error": "No bot token provided"}
+
+    payload: dict = {"url": url}
+    if secret_token:
+        payload["secret_token"] = secret_token
+
+    try:
+        resp = httpx.post(
+            f"{_base_url(bot_token)}/setWebhook",
+            json=payload,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPError as e:
+        logger.error("Telegram setWebhook failed: %s", e)
+        return {"ok": False, "error": str(e)}
+
+
+def delete_webhook(bot_token: str) -> dict:
+    """Remove the webhook for this bot token."""
+    if not bot_token:
+        return {"ok": False, "error": "No bot token provided"}
+
+    try:
+        resp = httpx.post(
+            f"{_base_url(bot_token)}/deleteWebhook",
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPError as e:
+        logger.error("Telegram deleteWebhook failed: %s", e)
+        return {"ok": False, "error": str(e)}
+
+
+def get_me(bot_token: str) -> dict:
+    """Get bot info (username, name) for status display."""
+    if not bot_token:
+        return {"ok": False, "error": "No bot token provided"}
+
+    try:
+        resp = httpx.get(f"{_base_url(bot_token)}/getMe", timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPError as e:
+        logger.warning("Telegram getMe failed: %s", e)
+        return {"ok": False, "error": str(e)}
+
+
+def validate_token(bot_token: str) -> dict | None:
+    """Validate a bot token by calling getMe.
+
+    Returns the ``result`` dict (with ``id``, ``username``, ``first_name``, etc.)
+    on success, or ``None`` if the token is invalid or the call fails.
+    """
+    if not bot_token:
+        return None
+
+    result = get_me(bot_token)
+    if result.get("ok") and "result" in result:
+        return result["result"]
+    return None
+
+
+def _chunk_text(text: str, max_length: int) -> list[str]:
+    """Split text into chunks on paragraph boundaries."""
+    if len(text) <= max_length:
+        return [text]
+
+    chunks = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= max_length:
+            chunks.append(remaining)
+            break
+
+        split_at = remaining.rfind("\n\n", 0, max_length)
+        if split_at == -1:
+            split_at = remaining.rfind("\n", 0, max_length)
+        if split_at == -1:
+            split_at = remaining.rfind(" ", 0, max_length)
+        if split_at == -1:
+            split_at = max_length
+
+        chunks.append(remaining[:split_at].rstrip())
+        remaining = remaining[split_at:].lstrip()
+
+    return chunks

--- a/backend/integrations/telegram/lifecycle.py
+++ b/backend/integrations/telegram/lifecycle.py
@@ -53,10 +53,11 @@ def validate_and_save_token(agent_id: str, bot_token: str) -> dict:
     # Save token + username
     update_agent(agent_id, telegram_bot_token=bot_token, telegram_bot_username=bot_username)
 
-    # Register webhook
+    # Generate webhook secret and register webhook
+    secret = state.get_or_create_webhook_secret(agent_id)
     slug = existing["slug"]
     webhook_url = f"{settings.backend_url}/api/telegram/webhook/{slug}"
-    webhook_result = set_webhook(webhook_url, bot_token)
+    webhook_result = set_webhook(webhook_url, bot_token, secret_token=secret)
 
     if not webhook_result.get("ok"):
         logger.warning(
@@ -94,6 +95,7 @@ def remove_token(agent_id: str) -> None:
         delete_webhook(token)
 
     update_agent(agent_id, telegram_bot_token="", telegram_bot_username="", telegram_enabled=0)
+    state.delete_webhook_secret(agent_id)
 
 
 def reset_registration_window(agent_id: str) -> dict:
@@ -123,9 +125,10 @@ def register_all_webhooks() -> None:
 
         slug = agent["slug"]
         webhook_url = f"{settings.backend_url}/api/telegram/webhook/{slug}"
+        secret = state.get_or_create_webhook_secret(agent["id"])
 
         try:
-            result = set_webhook(webhook_url, token)
+            result = set_webhook(webhook_url, token, secret_token=secret)
             if result.get("ok"):
                 count += 1
             else:

--- a/backend/integrations/telegram/lifecycle.py
+++ b/backend/integrations/telegram/lifecycle.py
@@ -1,0 +1,155 @@
+"""Telegram bot lifecycle management.
+
+Handles token validation, webhook registration/deregistration, and the
+time-limited auto-registration window that lets a user self-onboard by
+messaging their agent's Telegram bot within 10 minutes of setup.
+"""
+
+import logging
+
+from core.config import settings
+from agents.db import get_agent, list_agents, update_agent
+
+from . import state
+from .client import validate_token, set_webhook, delete_webhook
+
+logger = logging.getLogger(__name__)
+
+
+def validate_and_save_token(agent_id: str, bot_token: str) -> dict:
+    """Validate a Telegram bot token and save it for an agent.
+
+    1. Calls getMe to verify the token
+    2. Checks no other agent uses the same token
+    3. Deregisters the old webhook if replacing a token
+    4. Saves to DB + registers webhook + opens registration window
+
+    Returns dict with bot_username, webhook_url, registration info.
+    Raises ValueError on validation failure.
+    """
+    bot_info = validate_token(bot_token)
+    if not bot_info:
+        raise ValueError("Invalid Telegram bot token — getMe failed")
+
+    bot_username = bot_info.get("username", "")
+
+    # Check for duplicate tokens across agents
+    for agent in list_agents():
+        if agent["id"] == agent_id:
+            continue
+        if agent.get("telegram_bot_token") == bot_token:
+            raise ValueError(
+                f"This token is already in use by {agent.get('agent_name', 'another agent')}"
+            )
+
+    # If agent already has a different token, deregister old webhook
+    existing = get_agent(agent_id)
+    if not existing:
+        raise ValueError("Agent not found")
+
+    if existing.get("telegram_bot_token") and existing["telegram_bot_token"] != bot_token:
+        delete_webhook(existing["telegram_bot_token"])
+
+    # Save token + username
+    update_agent(agent_id, telegram_bot_token=bot_token, telegram_bot_username=bot_username)
+
+    # Register webhook
+    slug = existing["slug"]
+    webhook_url = f"{settings.backend_url}/api/telegram/webhook/{slug}"
+    webhook_result = set_webhook(webhook_url, bot_token)
+
+    if not webhook_result.get("ok"):
+        logger.warning(
+            "Webhook registration failed for agent %s: %s",
+            agent_id, webhook_result.get("error", "unknown"),
+        )
+
+    # Open registration window
+    window = state.open_registration_window(agent_id)
+
+    # Auto-enable Telegram on first token setup
+    if not existing.get("telegram_enabled"):
+        update_agent(agent_id, telegram_enabled=1)
+
+    return {
+        "bot_username": bot_username,
+        "bot_id": bot_info.get("id"),
+        "webhook_url": webhook_url,
+        "webhook_ok": webhook_result.get("ok", False),
+        "registration_expires_at": window["expires_at"],
+    }
+
+
+def remove_token(agent_id: str) -> None:
+    """Remove a Telegram bot token from an agent.
+
+    Deregisters the webhook and clears the token from the DB.
+    """
+    agent = get_agent(agent_id)
+    if not agent:
+        return
+
+    token = agent.get("telegram_bot_token", "")
+    if token:
+        delete_webhook(token)
+
+    update_agent(agent_id, telegram_bot_token="", telegram_bot_username="", telegram_enabled=0)
+
+
+def reset_registration_window(agent_id: str) -> dict:
+    """Reset (re-open) the registration window for an agent.
+
+    Returns the new window info.
+    Raises ValueError if the agent has no token configured.
+    """
+    agent = get_agent(agent_id)
+    if not agent or not agent.get("telegram_bot_token"):
+        raise ValueError("Agent has no Telegram bot token configured")
+
+    return state.open_registration_window(agent_id)
+
+
+def register_all_webhooks() -> None:
+    """Re-register webhooks for all agents with Telegram bot tokens.
+
+    Called on startup to ensure webhooks point to the current backend URL.
+    """
+    agents = list_agents()
+    count = 0
+    for agent in agents:
+        token = agent.get("telegram_bot_token", "")
+        if not token:
+            continue
+
+        slug = agent["slug"]
+        webhook_url = f"{settings.backend_url}/api/telegram/webhook/{slug}"
+
+        try:
+            result = set_webhook(webhook_url, token)
+            if result.get("ok"):
+                count += 1
+            else:
+                logger.warning(
+                    "Startup webhook registration failed for %s: %s",
+                    agent["agent_name"], result.get("error", "unknown"),
+                )
+        except Exception as e:
+            logger.warning("Startup webhook registration error for %s: %s", agent["agent_name"], e)
+
+    if count:
+        logger.info("Registered Telegram webhooks for %d agent(s)", count)
+
+
+def try_auto_register(
+    agent_id: str, telegram_user_id: str, sender_name: str,
+) -> bool:
+    """Try to auto-register a Telegram user during the registration window.
+
+    Returns True if registration succeeded, False if the window is closed.
+    """
+    if not state.is_registration_open(agent_id):
+        return False
+
+    state.create_mapping("telegram", telegram_user_id, agent_id, sender_name)
+    state.close_registration_window(agent_id, telegram_user_id)
+    return True

--- a/backend/integrations/telegram/models.py
+++ b/backend/integrations/telegram/models.py
@@ -1,0 +1,12 @@
+"""Telegram integration — Pydantic request/response models."""
+
+from pydantic import BaseModel
+
+
+class SetBotTokenRequest(BaseModel):
+    agent_id: str
+    bot_token: str
+
+
+class ResetRegistrationRequest(BaseModel):
+    agent_id: str

--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -1,0 +1,207 @@
+"""Telegram integration — FastAPI router.
+
+Handles inbound Telegram webhooks (unauthenticated, routed by agent slug)
+and JWT-protected admin endpoints for bot token management and registration.
+"""
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from core.auth import get_current_user
+from agents import db as agent_db
+
+from . import state, lifecycle, service
+from .client import send_message
+from .models import SetBotTokenRequest, ResetRegistrationRequest
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["telegram"])
+
+_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="telegram-webhook")
+
+
+# ---------------------------------------------------------------------------
+# Telegram webhook — per-agent, no JWT, routed by slug
+# ---------------------------------------------------------------------------
+
+@router.post("/webhook/{agent_slug}", status_code=200)
+async def telegram_webhook(agent_slug: str, request: Request):
+    """Receive inbound Telegram messages for an agent's bot.
+
+    Returns 200 immediately; processes message and sends reply in background.
+    """
+    try:
+        raw = await request.json()
+    except Exception:
+        logger.warning("Telegram webhook (%s): unparseable body", agent_slug)
+        return {"status": "ok"}
+
+    # Telegram sends an Update object
+    message = raw.get("message")
+    if not message:
+        return {"status": "ok"}
+
+    text = message.get("text", "")
+    if not text:
+        return {"status": "ok"}
+
+    chat = message.get("chat", {})
+    chat_id = chat.get("id")
+    from_user = message.get("from", {})
+    user_id = str(from_user.get("id", ""))
+    first_name = from_user.get("first_name", "")
+    last_name = from_user.get("last_name", "")
+    sender_name = f"{first_name} {last_name}".strip() or "Unknown"
+
+    if not chat_id or not user_id:
+        return {"status": "ok"}
+
+    logger.info(
+        "Telegram webhook: slug=%s user_id=%s name=%s chat_id=%s msg=%s",
+        agent_slug, user_id, sender_name, chat_id, text[:100],
+    )
+
+    _executor.submit(
+        _safe_process_telegram, agent_slug, user_id, sender_name, text, chat_id,
+    )
+    return {"status": "ok"}
+
+
+def _safe_process_telegram(
+    agent_slug: str, user_id: str, sender_name: str, message: str, chat_id: int,
+) -> None:
+    """Process a Telegram message in a background thread."""
+    bot_token = ""
+    try:
+        # Resolve slug → agent
+        agent = agent_db.get_agent_by_slug(agent_slug)
+        if not agent:
+            logger.warning("Telegram webhook: unknown slug %s", agent_slug)
+            return
+
+        bot_token = agent.get("telegram_bot_token", "")
+        if not bot_token:
+            return
+
+        # Check if sender has a mapping
+        mapping = state.get_mapping_by_sender("telegram", user_id)
+        if not mapping:
+            # Try auto-registration
+            if lifecycle.try_auto_register(agent["id"], user_id, sender_name):
+                logger.info("Auto-registered Telegram user %s for agent %s", user_id, agent["agent_name"])
+            else:
+                send_message(
+                    chat_id,
+                    "Registration window is closed. Please ask the admin to reset it in Chatty.",
+                    bot_token,
+                )
+                return
+
+        # Process the message via async service
+        loop = asyncio.new_event_loop()
+        try:
+            response = loop.run_until_complete(
+                service.process_message(user_id, sender_name, message)
+            )
+        finally:
+            loop.close()
+
+        send_message(chat_id, response, bot_token)
+    except Exception:
+        logger.exception("Telegram processing failed (slug=%s, user_id=%s)", agent_slug, user_id)
+        try:
+            if bot_token:
+                send_message(
+                    chat_id, "I had trouble processing that. Please try again.", bot_token,
+                )
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints — JWT protected
+# ---------------------------------------------------------------------------
+
+@router.post("/bot-token")
+def set_bot_token(
+    req: SetBotTokenRequest, user: dict = Depends(get_current_user),
+):
+    """Validate and save a Telegram bot token for an agent.
+
+    Registers the webhook and opens a 10-minute registration window.
+    """
+    try:
+        result = lifecycle.validate_and_save_token(req.agent_id, req.bot_token)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.delete("/bot-token/{agent_id}")
+def remove_bot_token(
+    agent_id: str, user: dict = Depends(get_current_user),
+):
+    """Remove a Telegram bot token from an agent."""
+    lifecycle.remove_token(agent_id)
+    return {"ok": True}
+
+
+@router.post("/reset-registration")
+def reset_registration(
+    req: ResetRegistrationRequest, user: dict = Depends(get_current_user),
+):
+    """Reset (re-open) the Telegram registration window for an agent."""
+    try:
+        window = lifecycle.reset_registration_window(req.agent_id)
+        return window
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/registration-window/{agent_id}")
+def get_registration_window(
+    agent_id: str, user: dict = Depends(get_current_user),
+):
+    """Get the current Telegram registration window status for an agent."""
+    window = state.get_registration_window(agent_id)
+    if not window:
+        return {"open": False, "window": None}
+    return {
+        "open": state.is_registration_open(agent_id),
+        "window": window,
+    }
+
+
+@router.get("/status/{agent_id}")
+def get_telegram_status(
+    agent_id: str, user: dict = Depends(get_current_user),
+):
+    """Get the Telegram bot status for an agent."""
+    agent = agent_db.get_agent(agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    bot_token = agent.get("telegram_bot_token", "")
+    return {
+        "connected": bool(bot_token),
+        "enabled": bool(agent.get("telegram_enabled")),
+        "bot_username": agent.get("telegram_bot_username", ""),
+    }
+
+
+@router.get("/mappings")
+def list_mappings(user: dict = Depends(get_current_user)):
+    """List all Telegram user mappings."""
+    return {"mappings": state.get_user_mappings()}
+
+
+@router.delete("/mappings/{mapping_id}")
+def delete_mapping(mapping_id: str, user: dict = Depends(get_current_user)):
+    """Delete a Telegram user mapping."""
+    if state.delete_mapping(mapping_id):
+        return {"ok": True}
+    raise HTTPException(status_code=404, detail="Mapping not found")

--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -5,6 +5,7 @@ and JWT-protected admin endpoints for bot token management and registration.
 """
 
 import asyncio
+import hmac
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
@@ -33,7 +34,18 @@ async def telegram_webhook(agent_slug: str, request: Request):
     """Receive inbound Telegram messages for an agent's bot.
 
     Returns 200 immediately; processes message and sends reply in background.
+    Verifies the X-Telegram-Bot-Api-Secret-Token header against the stored secret.
     """
+    # Verify webhook secret token
+    agent = agent_db.get_agent_by_slug(agent_slug)
+    if agent:
+        expected_secret = state.get_webhook_secret(agent["id"])
+        if expected_secret:
+            received_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+            if not hmac.compare_digest(received_secret, expected_secret):
+                logger.warning("Telegram webhook (%s): invalid secret token", agent_slug)
+                return {"status": "ok"}  # Return 200 to avoid Telegram retries
+
     try:
         raw = await request.json()
     except Exception:
@@ -85,6 +97,10 @@ def _safe_process_telegram(
 
         bot_token = agent.get("telegram_bot_token", "")
         if not bot_token:
+            return
+
+        # Check Telegram is enabled before any processing
+        if not agent.get("telegram_enabled"):
             return
 
         # Check if sender has a mapping

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -1,0 +1,213 @@
+"""Telegram integration — Message processing service.
+
+Routes inbound Telegram messages to the appropriate Chatty agent,
+runs the agent (non-streaming), and returns the response text.
+The router handles sending the response back via the Telegram client.
+"""
+
+import importlib
+import logging
+import uuid
+
+from agents import db as agent_db
+from agents.engine import (
+    build_agent_config,
+    get_context_manager,
+    get_chat_service,
+)
+from core.providers import get_ai_provider
+from core.providers.credentials import CredentialStore
+from core.agents.tool_registry import ToolRegistry
+from core.agents.reminders.tools import (
+    create_reminder_handler,
+    list_reminders_handler,
+    cancel_reminder_handler,
+)
+from core.agents.scheduled_actions.tools import (
+    create_scheduled_action_handler,
+    list_scheduled_actions_handler,
+    update_scheduled_action_handler,
+    delete_scheduled_action_handler,
+)
+from core.agents import ai_service
+
+from . import state
+
+logger = logging.getLogger(__name__)
+
+# Maximum recent messages to include for context
+MAX_CONTEXT_MESSAGES = 20
+
+# Integration module registry (same as agents/router.py)
+_INTEGRATION_MODULES = {
+    "crm_lite": ("integrations.crm_lite.tools", "CRM_LITE_TOOL_DEFS"),
+    "odoo": ("integrations.odoo.tools", "ODOO_TOOL_DEFS"),
+    "bamboohr": ("integrations.bamboohr.tools", "BAMBOOHR_TOOL_DEFS"),
+    "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
+}
+
+
+def _load_integration_tools() -> tuple[list[dict], dict]:
+    """Load tool definitions and executors from all enabled integrations."""
+    from integrations.registry import is_enabled
+
+    tool_defs: list[dict] = []
+    executors: dict = {}
+
+    for name, (module_path, defs_attr) in _INTEGRATION_MODULES.items():
+        if not is_enabled(name):
+            continue
+        try:
+            if name == "crm_lite":
+                from integrations.crm_lite.db import init_db, _connection
+                if _connection is None:
+                    init_db()
+
+            mod = importlib.import_module(module_path)
+            defs = getattr(mod, defs_attr, [])
+            execs = getattr(mod, "TOOL_EXECUTORS", {})
+            tool_defs.extend(defs)
+            executors.update(execs)
+        except Exception as e:
+            logger.warning("Failed to load integration %s: %s", name, e)
+
+    return tool_defs, executors
+
+
+def _build_agent_handlers(agent_slug: str) -> tuple[dict, dict]:
+    """Build reminder and scheduled action handler dicts for an agent."""
+    reminder_handlers = {
+        "create_reminder": lambda **kw: create_reminder_handler(agent_slug, **kw),
+        "list_reminders": lambda **kw: list_reminders_handler(agent_slug, **kw),
+        "cancel_reminder": lambda **kw: cancel_reminder_handler(agent_slug, **kw),
+    }
+    sa_handlers = {
+        "create_scheduled_action": lambda **kw: create_scheduled_action_handler(agent_slug, **kw),
+        "list_scheduled_actions": lambda **kw: list_scheduled_actions_handler(agent_slug, **kw),
+        "update_scheduled_action": lambda **kw: update_scheduled_action_handler(agent_slug, **kw),
+        "delete_scheduled_action": lambda **kw: delete_scheduled_action_handler(agent_slug, **kw),
+    }
+    return reminder_handlers, sa_handlers
+
+
+async def process_message(
+    sender_id: str,
+    sender_name: str,
+    message_text: str,
+) -> str:
+    """Route an inbound Telegram message to the appropriate agent and return the response.
+
+    Args:
+        sender_id: Telegram user ID (string)
+        sender_name: Display name from Telegram
+        message_text: The message content
+
+    Returns:
+        The agent's response text.
+    """
+    # 1. Look up sender → agent_id
+    mapping = state.get_mapping_by_sender("telegram", sender_id)
+    if not mapping:
+        return (
+            "I don't recognize your account yet. "
+            "Please ask the admin to reset the registration window."
+        )
+
+    agent_id = mapping["agent_id"]
+
+    # 2. Load agent
+    agent = agent_db.get_agent(agent_id)
+    if not agent:
+        return "This agent is no longer available."
+
+    # 3. Check Telegram is enabled
+    if not agent.get("telegram_enabled"):
+        return "Telegram messaging is currently disabled for this agent."
+
+    slug = agent["slug"]
+
+    # 4. Build the agent pipeline (mirrors agents/router.py::_stream_chat)
+    config = build_agent_config(agent)
+    ctx_manager = get_context_manager(slug)
+    chat_service = get_chat_service(slug)
+
+    store = CredentialStore()
+    provider = get_ai_provider(
+        agent_provider=config.provider_override or None,
+        agent_model=config.model_override or None,
+    )
+    if not provider:
+        return "No AI provider is configured. Please set up an AI provider in Settings."
+
+    google_token = ""
+    if config.gmail_enabled or config.calendar_enabled:
+        google_token = store.get_google_token() or ""
+
+    integration_tool_defs, integration_executors = _load_integration_tools()
+
+    reminder_handlers, sa_handlers = _build_agent_handlers(slug)
+    registry = ToolRegistry(
+        context_dir=config.context_dir,
+        google_access_token=google_token,
+        integration_executors=integration_executors,
+        agent_slug=slug,
+        reminder_handlers=reminder_handlers,
+        scheduled_action_handlers=sa_handlers,
+    )
+
+    # 5. Get/create Telegram conversation for multi-turn context
+    conv = state.get_or_create_conversation(sender_id, agent_id)
+
+    # 6. Resolve or create Chatty chat history conversation
+    chatty_conv_id = conv.get("chatty_conversation_id")
+    if not chatty_conv_id and chat_service:
+        try:
+            new_conv = chat_service.create_conversation()
+            chatty_conv_id = new_conv["id"]
+            state.set_chatty_conversation_id(conv["id"], chatty_conv_id)
+        except Exception as e:
+            logger.warning("Failed to create chat history conversation: %s", e)
+
+    # 7. Load recent messages for context
+    messages = _load_recent_messages(chat_service, chatty_conv_id)
+    if not messages:
+        messages = [{"role": "user", "content": message_text}]
+    else:
+        # Append the new user message
+        messages.append({"role": "user", "content": message_text})
+
+    # 8. Run the agent (non-streaming)
+    response = await ai_service.run_sync(
+        config=config,
+        provider=provider,
+        registry=registry,
+        ctx_manager=ctx_manager,
+        messages=messages,
+        chat_service=chat_service,
+        conversation_id=chatty_conv_id,
+        integration_tool_defs=integration_tool_defs or None,
+    )
+
+    return response or "I had trouble generating a response. Please try again."
+
+
+def _load_recent_messages(chat_service, conversation_id: str | None) -> list[dict]:
+    """Load recent messages from chat history for conversation context."""
+    if not chat_service or not conversation_id:
+        return []
+
+    try:
+        conv = chat_service.get_conversation(conversation_id)
+        if not conv or "messages" not in conv:
+            return []
+
+        messages = []
+        for msg in conv["messages"][-MAX_CONTEXT_MESSAGES:]:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            if role in ("user", "assistant") and content:
+                messages.append({"role": role, "content": content})
+        return messages
+    except Exception as e:
+        logger.warning("Failed to load chat history messages: %s", e)
+        return []

--- a/backend/integrations/telegram/state.py
+++ b/backend/integrations/telegram/state.py
@@ -1,0 +1,265 @@
+"""Telegram integration — Persistent state (SQLite).
+
+Stores user mappings (Telegram user ID -> agent), registration windows,
+and conversation state for multi-turn context.
+"""
+
+import logging
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "telegram"
+DB_PATH = DATA_DIR / "telegram.db"
+
+_write_lock = threading.Lock()
+
+
+def _get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def init_db() -> None:
+    """Create tables if they don't exist."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    conn = _get_conn()
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS user_mappings (
+            id TEXT PRIMARY KEY,
+            platform TEXT NOT NULL,
+            platform_user_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            sender_name TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            UNIQUE(platform, platform_user_id)
+        )
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS telegram_registration_windows (
+            agent_id TEXT PRIMARY KEY,
+            opened_at   TEXT NOT NULL,
+            expires_at  TEXT NOT NULL,
+            registered_user_id TEXT
+        )
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS conversations (
+            id TEXT PRIMARY KEY,
+            platform TEXT NOT NULL,
+            sender_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            chatty_conversation_id TEXT,
+            last_active TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(platform, sender_id, agent_id)
+        )
+    """)
+
+    conn.commit()
+    conn.close()
+    logger.info("Telegram state DB initialized at %s", DB_PATH)
+
+
+# ---------------------------------------------------------------------------
+# User mappings
+# ---------------------------------------------------------------------------
+
+def get_user_mappings() -> list[dict]:
+    conn = _get_conn()
+    try:
+        rows = conn.execute(
+            "SELECT id, platform, platform_user_id, agent_id, sender_name, created_at "
+            "FROM user_mappings ORDER BY created_at DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_mapping_by_sender(platform: str, platform_user_id: str) -> dict | None:
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT id, platform, platform_user_id, agent_id, sender_name "
+            "FROM user_mappings WHERE platform = ? AND platform_user_id = ?",
+            (platform, platform_user_id),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def create_mapping(
+    platform: str, platform_user_id: str, agent_id: str, sender_name: str = "",
+) -> dict:
+    now = datetime.now(timezone.utc).isoformat()
+    mapping_id = str(uuid.uuid4())
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO user_mappings
+                   (id, platform, platform_user_id, agent_id, sender_name, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(platform, platform_user_id)
+                   DO UPDATE SET agent_id = excluded.agent_id,
+                                 sender_name = excluded.sender_name""",
+                (mapping_id, platform, platform_user_id, agent_id, sender_name, now),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    return {
+        "id": mapping_id, "platform": platform,
+        "platform_user_id": platform_user_id,
+        "agent_id": agent_id, "sender_name": sender_name,
+    }
+
+
+def delete_mapping(mapping_id: str) -> bool:
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            cursor = conn.execute(
+                "DELETE FROM user_mappings WHERE id = ?", (mapping_id,),
+            )
+            conn.commit()
+            deleted = cursor.rowcount > 0
+        finally:
+            conn.close()
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Conversation state
+# ---------------------------------------------------------------------------
+
+def get_or_create_conversation(
+    sender_id: str, agent_id: str, platform: str = "telegram",
+) -> dict:
+    """Look up an existing conversation or create a new one."""
+    now = datetime.now(timezone.utc).isoformat()
+
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            row = conn.execute(
+                """SELECT id, chatty_conversation_id FROM conversations
+                   WHERE platform = ? AND sender_id = ? AND agent_id = ?""",
+                (platform, sender_id, agent_id),
+            ).fetchone()
+
+            if row:
+                conn.execute(
+                    "UPDATE conversations SET last_active = ? WHERE id = ?",
+                    (now, row["id"]),
+                )
+                conn.commit()
+                return {
+                    "id": row["id"],
+                    "chatty_conversation_id": row["chatty_conversation_id"],
+                    "is_new": False,
+                }
+
+            conv_id = str(uuid.uuid4())
+            conn.execute(
+                """INSERT INTO conversations
+                   (id, platform, sender_id, agent_id, last_active, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (conv_id, platform, sender_id, agent_id, now, now),
+            )
+            conn.commit()
+            return {"id": conv_id, "chatty_conversation_id": None, "is_new": True}
+        finally:
+            conn.close()
+
+
+def set_chatty_conversation_id(conv_id: str, chatty_conversation_id: str) -> None:
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                "UPDATE conversations SET chatty_conversation_id = ? WHERE id = ?",
+                (chatty_conversation_id, conv_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Telegram registration windows
+# ---------------------------------------------------------------------------
+
+def open_registration_window(agent_id: str, minutes: int = 10) -> dict:
+    """Open (or re-open) a registration window for an agent's Telegram bot."""
+    now = datetime.now(timezone.utc)
+    expires = now + timedelta(minutes=minutes)
+    now_iso = now.isoformat()
+    expires_iso = expires.isoformat()
+
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO telegram_registration_windows
+                   (agent_id, opened_at, expires_at, registered_user_id)
+                   VALUES (?, ?, ?, NULL)
+                   ON CONFLICT(agent_id)
+                   DO UPDATE SET opened_at = excluded.opened_at,
+                                 expires_at = excluded.expires_at,
+                                 registered_user_id = NULL""",
+                (agent_id, now_iso, expires_iso),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    return {"agent_id": agent_id, "opened_at": now_iso, "expires_at": expires_iso}
+
+
+def get_registration_window(agent_id: str) -> dict | None:
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT * FROM telegram_registration_windows WHERE agent_id = ?",
+            (agent_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def close_registration_window(agent_id: str, user_id: str) -> None:
+    """Close the window by recording the registered user ID."""
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                "UPDATE telegram_registration_windows SET registered_user_id = ? WHERE agent_id = ?",
+                (user_id, agent_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def is_registration_open(agent_id: str) -> bool:
+    """Check if a registration window is currently open (not expired, not used)."""
+    window = get_registration_window(agent_id)
+    if not window:
+        return False
+    if window.get("registered_user_id"):
+        return False
+    now = datetime.now(timezone.utc).isoformat()
+    return now < window["expires_at"]

--- a/backend/integrations/telegram/state.py
+++ b/backend/integrations/telegram/state.py
@@ -5,6 +5,7 @@ and conversation state for multi-turn context.
 """
 
 import logging
+import secrets
 import sqlite3
 import threading
 import uuid
@@ -50,6 +51,11 @@ def init_db() -> None:
             opened_at   TEXT NOT NULL,
             expires_at  TEXT NOT NULL,
             registered_user_id TEXT
+        )
+
+        CREATE TABLE IF NOT EXISTS webhook_secrets (
+            agent_id TEXT PRIMARY KEY,
+            secret TEXT NOT NULL
         )
     """)
 
@@ -118,10 +124,16 @@ def create_mapping(
                 (mapping_id, platform, platform_user_id, agent_id, sender_name, now),
             )
             conn.commit()
+            # Re-query to get the actual row ID (may differ on upsert)
+            row = conn.execute(
+                "SELECT id FROM user_mappings WHERE platform = ? AND platform_user_id = ?",
+                (platform, platform_user_id),
+            ).fetchone()
+            actual_id = row["id"] if row else mapping_id
         finally:
             conn.close()
     return {
-        "id": mapping_id, "platform": platform,
+        "id": actual_id, "platform": platform,
         "platform_user_id": platform_user_id,
         "agent_id": agent_id, "sender_name": sender_name,
     }
@@ -263,3 +275,58 @@ def is_registration_open(agent_id: str) -> bool:
         return False
     now = datetime.now(timezone.utc).isoformat()
     return now < window["expires_at"]
+
+
+# ---------------------------------------------------------------------------
+# Webhook secrets (per-agent)
+# ---------------------------------------------------------------------------
+
+def get_or_create_webhook_secret(agent_id: str) -> str:
+    """Get the webhook secret for an agent, creating one if it doesn't exist."""
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT secret FROM webhook_secrets WHERE agent_id = ?", (agent_id,),
+        ).fetchone()
+        if row:
+            return row["secret"]
+    finally:
+        conn.close()
+
+    # Generate and store a new secret
+    secret = secrets.token_urlsafe(32)
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO webhook_secrets (agent_id, secret) VALUES (?, ?)
+                   ON CONFLICT(agent_id) DO UPDATE SET secret = excluded.secret""",
+                (agent_id, secret),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    return secret
+
+
+def get_webhook_secret(agent_id: str) -> str | None:
+    """Get the webhook secret for an agent, or None if not set."""
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT secret FROM webhook_secrets WHERE agent_id = ?", (agent_id,),
+        ).fetchone()
+        return row["secret"] if row else None
+    finally:
+        conn.close()
+
+
+def delete_webhook_secret(agent_id: str) -> None:
+    """Delete the webhook secret for an agent."""
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            conn.execute("DELETE FROM webhook_secrets WHERE agent_id = ?", (agent_id,))
+            conn.commit()
+        finally:
+            conn.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from webby.router import router as webby_router
 from core.agents.scheduled_actions.router import router as scheduled_actions_router
 from setup.router import router as setup_router
 from backup.router import router as backup_router
+from integrations.telegram.router import router as telegram_router
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -38,7 +39,7 @@ async def lifespan(app: FastAPI):
 
     # Ensure data directories exist
     data_root = Path(__file__).resolve().parent / "data"
-    for subdir in ("agents", "branding", "integrations", "reminders"):
+    for subdir in ("agents", "branding", "integrations", "reminders", "telegram"):
         (data_root / subdir).mkdir(parents=True, exist_ok=True)
 
     # Initialize agent registry DB
@@ -50,6 +51,13 @@ async def lifespan(app: FastAPI):
     if integration_enabled("crm_lite"):
         from integrations.crm_lite.db import init_db as init_crm_db
         init_crm_db()
+
+    # Initialize Telegram state DB + register webhooks
+    from integrations.telegram.state import init_db as init_telegram_db
+    init_telegram_db()
+
+    from integrations.telegram.lifecycle import register_all_webhooks
+    register_all_webhooks()
 
     # Initialize reminders + scheduled actions DB
     from core.agents.reminders.db import init_db as init_reminders_db
@@ -105,6 +113,7 @@ app.include_router(webby_router, tags=["webby"])
 app.include_router(scheduled_actions_router, prefix="/api/scheduled-actions", tags=["scheduled-actions"])
 app.include_router(setup_router, prefix="/api/setup", tags=["setup"])
 app.include_router(backup_router, prefix="/api/backup", tags=["backup"])
+app.include_router(telegram_router, prefix="/api/telegram", tags=["telegram"])
 
 
 @app.get("/api/health")

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -15,6 +15,7 @@ import { AgentContextEditor } from './components/AgentContextEditor';
 import ReportsPanel from './reports/ReportsPanel';
 import { ConversationSidebar } from './components/ConversationSidebar';
 import { AvatarPicker } from './components/AvatarPicker';
+import { TelegramSettings } from './components/TelegramSettings';
 
 interface AgentRow {
   id: string;
@@ -24,9 +25,12 @@ interface AgentRow {
   onboarding_complete: boolean;
   gmail_enabled: boolean;
   calendar_enabled: boolean;
+  telegram_enabled: boolean;
+  telegram_bot_token: string;
+  telegram_bot_username: string;
 }
 
-type Tab = 'chat' | 'knowledge' | 'reports';
+type Tab = 'chat' | 'knowledge' | 'reports' | 'telegram';
 
 const TOOL_MODES: { key: ToolMode; label: string; activeClass: string }[] = [
   { key: 'read-only', label: 'Read Only', activeClass: 'bg-gray-600' },
@@ -213,7 +217,7 @@ export function AgentPage() {
 
         {/* Tab switcher */}
         <div className="ml-auto flex items-center bg-gray-800 rounded-lg p-0.5 gap-0.5">
-          {(['chat', 'knowledge', 'reports'] as Tab[]).map(tab => (
+          {(['chat', 'knowledge', 'reports', 'telegram'] as Tab[]).map(tab => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
@@ -223,7 +227,7 @@ export function AgentPage() {
                   : 'text-gray-400 hover:text-white'
               }`}
             >
-              {tab === 'chat' ? 'Chat' : tab === 'knowledge' ? 'Knowledge' : 'Reports'}
+              {tab === 'chat' ? 'Chat' : tab === 'knowledge' ? 'Knowledge' : tab === 'reports' ? 'Reports' : 'Telegram'}
             </button>
           ))}
         </div>
@@ -267,8 +271,21 @@ export function AgentPage() {
           </>
         ) : activeTab === 'knowledge' ? (
           <AgentContextEditor agentId={agentId!} />
-        ) : (
+        ) : activeTab === 'reports' ? (
           <ReportsPanel apiPrefix={apiPrefix} />
+        ) : (
+          <div className="flex-1 overflow-y-auto">
+            <TelegramSettings
+              agentId={agentId!}
+              agentName={agent.agent_name}
+              botToken={agent.telegram_bot_token || ''}
+              botUsername={agent.telegram_bot_username || ''}
+              telegramEnabled={agent.telegram_enabled}
+              onUpdate={() => {
+                api<AgentRow>(`/api/agents/${agentId}`).then(setAgent).catch(() => {});
+              }}
+            />
+          </div>
         )}
       </div>
 

--- a/frontend/src/agent/components/TelegramSettings.tsx
+++ b/frontend/src/agent/components/TelegramSettings.tsx
@@ -1,0 +1,660 @@
+/**
+ * Chatty — TelegramSettings.
+ * Guided onboarding wizard + management view for connecting
+ * an agent to a Telegram bot.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { api } from '../../core/api/client';
+
+interface Props {
+  agentId: string;
+  agentName: string;
+  botToken: string;
+  botUsername: string;
+  telegramEnabled: boolean;
+  onUpdate: () => void;
+}
+
+type WizardStep = 'create-bot' | 'paste-token' | 'link-account' | 'all-set';
+
+interface RegistrationWindow {
+  agent_id: string;
+  opened_at: string;
+  expires_at: string;
+  registered_user_id: string | null;
+}
+
+const TELEGRAM_BLUE = '#0088cc';
+
+export function TelegramSettings({ agentId, agentName, botToken, botUsername, telegramEnabled, onUpdate }: Props) {
+  // If already connected, show management view
+  if (botToken) {
+    return (
+      <ManagementView
+        agentId={agentId}
+        agentName={agentName}
+        botUsername={botUsername}
+        telegramEnabled={telegramEnabled}
+        onUpdate={onUpdate}
+      />
+    );
+  }
+
+  // Otherwise show onboarding wizard
+  return (
+    <OnboardingWizard
+      agentId={agentId}
+      agentName={agentName}
+      onUpdate={onUpdate}
+    />
+  );
+}
+
+
+// ── Onboarding Wizard ─────────────────────────────────────────────────────────
+
+function OnboardingWizard({ agentId, agentName, onUpdate }: {
+  agentId: string;
+  agentName: string;
+  onUpdate: () => void;
+}) {
+  const [step, setStep] = useState<WizardStep>('create-bot');
+  const [tokenInput, setTokenInput] = useState('');
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState('');
+  const [connectedUsername, setConnectedUsername] = useState('');
+  const [registrationExpires, setRegistrationExpires] = useState('');
+  const [registrationComplete, setRegistrationComplete] = useState(false);
+
+  const steps: WizardStep[] = ['create-bot', 'paste-token', 'link-account', 'all-set'];
+  const currentIndex = steps.indexOf(step);
+
+  async function handleConnect() {
+    if (!tokenInput.trim()) return;
+    setConnecting(true);
+    setError('');
+    try {
+      const result = await api<{
+        bot_username: string;
+        webhook_ok: boolean;
+        registration_expires_at: string;
+      }>('/api/telegram/bot-token', {
+        method: 'POST',
+        body: JSON.stringify({ agent_id: agentId, bot_token: tokenInput.trim() }),
+      });
+      setConnectedUsername(result.bot_username);
+      setRegistrationExpires(result.registration_expires_at);
+      onUpdate();
+      setStep('link-account');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to validate token');
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  function handleRegistrationDone() {
+    setRegistrationComplete(true);
+    setStep('all-set');
+  }
+
+  return (
+    <div className="max-w-lg mx-auto py-6 space-y-6">
+      {/* Header */}
+      <div className="text-center space-y-2">
+        <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl" style={{ backgroundColor: `${TELEGRAM_BLUE}20` }}>
+          <TelegramIcon size={32} />
+        </div>
+        <h2 className="text-xl font-bold text-white">Connect to Telegram</h2>
+        <p className="text-gray-400 text-sm">
+          Let people message <span className="text-white font-medium">{agentName}</span> directly on Telegram
+        </p>
+      </div>
+
+      {/* Progress dots */}
+      <div className="flex justify-center gap-2">
+        {steps.map((s, i) => (
+          <div
+            key={s}
+            className={`w-2 h-2 rounded-full transition-all ${
+              i === currentIndex
+                ? 'w-6 bg-[#0088cc]'
+                : i < currentIndex
+                  ? 'bg-[#0088cc]/60'
+                  : 'bg-gray-700'
+            }`}
+          />
+        ))}
+      </div>
+
+      {/* Step content */}
+      {step === 'create-bot' && (
+        <StepCreateBot onNext={() => setStep('paste-token')} />
+      )}
+
+      {step === 'paste-token' && (
+        <StepPasteToken
+          tokenInput={tokenInput}
+          setTokenInput={setTokenInput}
+          connecting={connecting}
+          error={error}
+          onConnect={handleConnect}
+          onBack={() => setStep('create-bot')}
+        />
+      )}
+
+      {step === 'link-account' && (
+        <StepLinkAccount
+          botUsername={connectedUsername}
+          expiresAt={registrationExpires}
+          agentId={agentId}
+          agentName={agentName}
+          onDone={handleRegistrationDone}
+        />
+      )}
+
+      {step === 'all-set' && (
+        <StepAllSet
+          agentName={agentName}
+          botUsername={connectedUsername}
+        />
+      )}
+    </div>
+  );
+}
+
+
+// ── Step 1: Create Your Telegram Bot ──────────────────────────────────────────
+
+function StepCreateBot({ onNext }: { onNext: () => void }) {
+  return (
+    <div className="space-y-4">
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-5 space-y-4">
+        <h3 className="text-white font-semibold text-base">Step 1: Create Your Telegram Bot</h3>
+
+        <ol className="space-y-3 text-sm">
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#0088cc]/20 text-[#0088cc] flex items-center justify-center text-xs font-bold">1</span>
+            <span className="text-gray-300">Open Telegram and search for <span className="font-mono bg-gray-700 px-1.5 py-0.5 rounded text-white">@BotFather</span></span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#0088cc]/20 text-[#0088cc] flex items-center justify-center text-xs font-bold">2</span>
+            <span className="text-gray-300">Send <span className="font-mono bg-gray-700 px-1.5 py-0.5 rounded text-white">/newbot</span></span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#0088cc]/20 text-[#0088cc] flex items-center justify-center text-xs font-bold">3</span>
+            <span className="text-gray-300">Choose a name (e.g., "My Business Assistant")</span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#0088cc]/20 text-[#0088cc] flex items-center justify-center text-xs font-bold">4</span>
+            <span className="text-gray-300">Choose a username ending in <span className="font-mono bg-gray-700 px-1.5 py-0.5 rounded text-white">bot</span> (e.g., <span className="font-mono text-white">mybiz_assistant_bot</span>)</span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#0088cc]/20 text-[#0088cc] flex items-center justify-center text-xs font-bold">5</span>
+            <span className="text-gray-300">BotFather will give you a <span className="text-white font-medium">bot token</span> — copy it</span>
+          </li>
+        </ol>
+
+        {/* Screenshot placeholder: BotFather conversation */}
+        <div className="rounded-lg bg-gray-900 border border-gray-700 aspect-video flex items-center justify-center">
+          <div className="text-center text-gray-500 text-sm">
+            <div className="text-2xl mb-1">🤖</div>
+            <div className="font-medium">BotFather Conversation</div>
+            <div className="text-xs text-gray-600 mt-0.5">Screenshot placeholder</div>
+          </div>
+        </div>
+
+        {/* Screenshot placeholder: Token response */}
+        <div className="rounded-lg bg-gray-900 border border-gray-700 aspect-[16/7] flex items-center justify-center">
+          <div className="text-center text-gray-500 text-sm">
+            <div className="text-2xl mb-1">🔑</div>
+            <div className="font-medium">Bot Token Response</div>
+            <div className="text-xs text-gray-600 mt-0.5">Screenshot placeholder</div>
+          </div>
+        </div>
+      </div>
+
+      <button
+        onClick={onNext}
+        className="w-full py-3 rounded-xl font-semibold text-white transition hover:opacity-90"
+        style={{ backgroundColor: TELEGRAM_BLUE }}
+      >
+        I have my bot token — Next
+      </button>
+    </div>
+  );
+}
+
+
+// ── Step 2: Paste Your Bot Token ──────────────────────────────────────────────
+
+function StepPasteToken({ tokenInput, setTokenInput, connecting, error, onConnect, onBack }: {
+  tokenInput: string;
+  setTokenInput: (v: string) => void;
+  connecting: boolean;
+  error: string;
+  onConnect: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-5 space-y-4">
+        <h3 className="text-white font-semibold text-base">Step 2: Paste Your Bot Token</h3>
+        <p className="text-gray-400 text-sm">
+          Paste the token that BotFather gave you. It looks like:
+        </p>
+        <div className="font-mono text-xs text-gray-500 bg-gray-900 rounded-lg px-3 py-2 border border-gray-700">
+          123456789:ABCdefGHIjklMNOpqrsTUVwxyz
+        </div>
+
+        <input
+          type="text"
+          value={tokenInput}
+          onChange={e => setTokenInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && onConnect()}
+          placeholder="Paste your bot token here"
+          className="w-full bg-gray-900 border border-gray-600 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-[#0088cc] font-mono transition"
+          autoFocus
+        />
+
+        {error && (
+          <div className="bg-red-900/30 border border-red-800/50 rounded-lg px-3 py-2 text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        {/* Screenshot placeholder: Where to find the token */}
+        <div className="rounded-lg bg-gray-900 border border-gray-700 aspect-[16/7] flex items-center justify-center">
+          <div className="text-center text-gray-500 text-sm">
+            <div className="text-2xl mb-1">📋</div>
+            <div className="font-medium">Where to Find the Token</div>
+            <div className="text-xs text-gray-600 mt-0.5">Screenshot placeholder</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          className="flex-1 py-3 rounded-xl font-semibold text-gray-400 border border-gray-700 hover:bg-gray-800 transition"
+        >
+          Back
+        </button>
+        <button
+          onClick={onConnect}
+          disabled={connecting || !tokenInput.trim()}
+          className="flex-1 py-3 rounded-xl font-semibold text-white transition hover:opacity-90 disabled:opacity-50"
+          style={{ backgroundColor: TELEGRAM_BLUE }}
+        >
+          {connecting ? (
+            <span className="flex items-center justify-center gap-2">
+              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              Validating...
+            </span>
+          ) : 'Connect'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+
+// ── Step 3: Link Your Telegram Account ────────────────────────────────────────
+
+function StepLinkAccount({ botUsername, expiresAt, agentId, agentName, onDone }: {
+  botUsername: string;
+  expiresAt: string;
+  agentId: string;
+  agentName: string;
+  onDone: () => void;
+}) {
+  const [minutesLeft, setMinutesLeft] = useState(10);
+  const [checking, setChecking] = useState(false);
+  const [linked, setLinked] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Countdown timer
+  useEffect(() => {
+    if (!expiresAt) return;
+    const update = () => {
+      const diff = new Date(expiresAt).getTime() - Date.now();
+      setMinutesLeft(Math.max(0, Math.ceil(diff / 60000)));
+    };
+    update();
+    const interval = setInterval(update, 10000);
+    return () => clearInterval(interval);
+  }, [expiresAt]);
+
+  // Auto-poll registration status every 5 seconds
+  useEffect(() => {
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await api<{ open: boolean; window: RegistrationWindow | null }>(`/api/telegram/registration-window/${agentId}`);
+        if (res.window?.registered_user_id) {
+          setLinked(true);
+          if (pollRef.current) clearInterval(pollRef.current);
+        }
+      } catch { /* ignore */ }
+    }, 5000);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [agentId]);
+
+  const handleCheck = useCallback(async () => {
+    setChecking(true);
+    try {
+      const res = await api<{ open: boolean; window: RegistrationWindow | null }>(`/api/telegram/registration-window/${agentId}`);
+      if (res.window?.registered_user_id) {
+        setLinked(true);
+      }
+    } catch { /* ignore */ }
+    finally { setChecking(false); }
+  }, [agentId]);
+
+  if (linked) {
+    return (
+      <div className="space-y-4">
+        <div className="bg-green-900/20 border border-green-800/50 rounded-xl p-5 text-center space-y-3">
+          <div className="text-4xl">🎉</div>
+          <h3 className="text-white font-semibold text-lg">Account Linked!</h3>
+          <p className="text-green-300 text-sm">
+            Messages to <span className="font-mono font-bold">@{botUsername}</span> will be handled by <span className="font-bold">{agentName}</span>.
+          </p>
+        </div>
+        <button
+          onClick={onDone}
+          className="w-full py-3 rounded-xl font-semibold text-white transition hover:opacity-90"
+          style={{ backgroundColor: TELEGRAM_BLUE }}
+        >
+          Continue
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-5 space-y-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-white font-semibold text-base">Step 3: Link Your Telegram Account</h3>
+          <span className="text-xs bg-green-900/40 text-green-400 border border-green-700/40 rounded-full px-2 py-0.5">
+            Bot connected!
+          </span>
+        </div>
+
+        <p className="text-gray-300 text-sm">
+          Your bot <span className="font-mono font-bold text-white">@{botUsername}</span> is ready. Now link your Telegram account:
+        </p>
+
+        <ol className="space-y-3 text-sm">
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#0088cc]/20 text-[#0088cc] flex items-center justify-center text-xs font-bold">1</span>
+            <span className="text-gray-300">Open Telegram</span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#0088cc]/20 text-[#0088cc] flex items-center justify-center text-xs font-bold">2</span>
+            <span className="text-gray-300">Search for <span className="font-mono bg-gray-700 px-1.5 py-0.5 rounded text-white">@{botUsername}</span></span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#0088cc]/20 text-[#0088cc] flex items-center justify-center text-xs font-bold">3</span>
+            <span className="text-gray-300">Send any message (e.g., "Hello!")</span>
+          </li>
+        </ol>
+
+        {/* Timer */}
+        <div className="flex items-center gap-2 bg-gray-900 rounded-lg px-3 py-2 border border-gray-700">
+          <div className="w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
+          <span className="text-yellow-300 text-sm">
+            {minutesLeft > 0
+              ? `Registration window open — ${minutesLeft} minute${minutesLeft !== 1 ? 's' : ''} remaining`
+              : 'Registration window expired — reset below'}
+          </span>
+        </div>
+
+        {/* Screenshot placeholders */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-lg bg-gray-900 border border-gray-700 aspect-[4/3] flex items-center justify-center">
+            <div className="text-center text-gray-500 text-xs">
+              <div className="text-xl mb-1">🔍</div>
+              <div>Search for bot</div>
+              <div className="text-gray-600">Screenshot</div>
+            </div>
+          </div>
+          <div className="rounded-lg bg-gray-900 border border-gray-700 aspect-[4/3] flex items-center justify-center">
+            <div className="text-center text-gray-500 text-xs">
+              <div className="text-xl mb-1">💬</div>
+              <div>Send first message</div>
+              <div className="text-gray-600">Screenshot</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <button
+        onClick={handleCheck}
+        disabled={checking}
+        className="w-full py-3 rounded-xl font-semibold text-white transition hover:opacity-90 disabled:opacity-50"
+        style={{ backgroundColor: TELEGRAM_BLUE }}
+      >
+        {checking ? (
+          <span className="flex items-center justify-center gap-2">
+            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+            Checking...
+          </span>
+        ) : "I've sent a message"}
+      </button>
+    </div>
+  );
+}
+
+
+// ── Step 4: All Set ───────────────────────────────────────────────────────────
+
+function StepAllSet({ agentName, botUsername }: {
+  agentName: string;
+  botUsername: string;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="bg-gradient-to-b from-[#0088cc]/10 to-transparent rounded-xl border border-[#0088cc]/30 p-6 text-center space-y-4">
+        <div className="text-5xl">🚀</div>
+        <h3 className="text-white font-bold text-xl">All Set!</h3>
+        <p className="text-gray-300 text-sm">
+          Your agent <span className="text-white font-bold">{agentName}</span> is now live on Telegram as{' '}
+          <span className="font-mono font-bold text-[#0088cc]">@{botUsername}</span>
+        </p>
+        <p className="text-gray-400 text-xs">
+          Messages sent to the bot will be answered by your agent with full access to tools and knowledge.
+        </p>
+      </div>
+
+      <a
+        href={`https://t.me/${botUsername}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block w-full py-3 rounded-xl font-semibold text-white text-center transition hover:opacity-90"
+        style={{ backgroundColor: TELEGRAM_BLUE }}
+      >
+        Open @{botUsername} in Telegram
+      </a>
+    </div>
+  );
+}
+
+
+// ── Management View (already connected) ───────────────────────────────────────
+
+function ManagementView({ agentId, agentName, botUsername, telegramEnabled, onUpdate }: {
+  agentId: string;
+  agentName: string;
+  botUsername: string;
+  telegramEnabled: boolean;
+  onUpdate: () => void;
+}) {
+  const [toggling, setToggling] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [showConfirmDisconnect, setShowConfirmDisconnect] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [resetSuccess, setResetSuccess] = useState(false);
+
+  async function handleToggle() {
+    setToggling(true);
+    try {
+      await api(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ telegram_enabled: !telegramEnabled }),
+      });
+      onUpdate();
+    } finally { setToggling(false); }
+  }
+
+  async function handleDisconnect() {
+    setDisconnecting(true);
+    try {
+      await api(`/api/telegram/bot-token/${agentId}`, { method: 'DELETE' });
+      onUpdate();
+    } finally {
+      setDisconnecting(false);
+      setShowConfirmDisconnect(false);
+    }
+  }
+
+  async function handleResetRegistration() {
+    setResetting(true);
+    setResetSuccess(false);
+    try {
+      await api('/api/telegram/reset-registration', {
+        method: 'POST',
+        body: JSON.stringify({ agent_id: agentId }),
+      });
+      setResetSuccess(true);
+      setTimeout(() => setResetSuccess(false), 5000);
+    } finally { setResetting(false); }
+  }
+
+  return (
+    <div className="max-w-lg mx-auto py-6 space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-2">
+        <div className="w-10 h-10 rounded-xl flex items-center justify-center" style={{ backgroundColor: `${TELEGRAM_BLUE}20` }}>
+          <TelegramIcon size={24} />
+        </div>
+        <div>
+          <h2 className="text-white font-bold text-lg">Telegram</h2>
+          <p className="text-gray-400 text-sm">{agentName}</p>
+        </div>
+      </div>
+
+      {/* Status card */}
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-4 space-y-4">
+        {/* Connected status */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className={`w-2.5 h-2.5 rounded-full ${telegramEnabled ? 'bg-green-400' : 'bg-gray-500'}`} />
+            <span className="text-white font-medium">@{botUsername}</span>
+          </div>
+          <span className={`text-xs px-2 py-0.5 rounded-full ${
+            telegramEnabled
+              ? 'bg-green-900/40 text-green-400 border border-green-700/40'
+              : 'bg-gray-700 text-gray-400 border border-gray-600'
+          }`}>
+            {telegramEnabled ? 'Active' : 'Disabled'}
+          </span>
+        </div>
+
+        {/* Enable/disable toggle */}
+        <div className="flex items-center justify-between py-2 border-t border-gray-700">
+          <div>
+            <p className="text-white text-sm font-medium">Telegram Messaging</p>
+            <p className="text-gray-500 text-xs">Respond to messages on Telegram</p>
+          </div>
+          <button
+            onClick={handleToggle}
+            disabled={toggling}
+            className={`relative w-11 h-6 rounded-full transition ${telegramEnabled ? 'bg-[#0088cc]' : 'bg-gray-600'} ${toggling ? 'opacity-50' : ''}`}
+          >
+            <span className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-all ${telegramEnabled ? 'left-5' : 'left-0.5'}`} />
+          </button>
+        </div>
+
+        {/* Open in Telegram */}
+        <a
+          href={`https://t.me/${botUsername}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 text-sm text-[#0088cc] hover:underline"
+        >
+          <span>Open in Telegram</span>
+          <span className="text-xs">↗</span>
+        </a>
+      </div>
+
+      {/* Registration management */}
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-4 space-y-3">
+        <h3 className="text-white text-sm font-semibold">Account Linking</h3>
+        <p className="text-gray-400 text-xs">
+          Reset the registration window to link a different Telegram account to this agent.
+        </p>
+        <button
+          onClick={handleResetRegistration}
+          disabled={resetting}
+          className="text-sm px-4 py-2 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600 transition disabled:opacity-50"
+        >
+          {resetting ? 'Resetting...' : 'Reset Registration Window'}
+        </button>
+        {resetSuccess && (
+          <p className="text-green-400 text-xs">Registration window reopened for 10 minutes. Message the bot to link your account.</p>
+        )}
+      </div>
+
+      {/* Disconnect */}
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-4 space-y-3">
+        <h3 className="text-white text-sm font-semibold">Disconnect Bot</h3>
+        <p className="text-gray-400 text-xs">
+          Remove the Telegram bot connection. The bot will stop responding to messages.
+        </p>
+        {!showConfirmDisconnect ? (
+          <button
+            onClick={() => setShowConfirmDisconnect(true)}
+            className="text-sm px-4 py-2 rounded-lg bg-red-900/30 text-red-400 border border-red-800/40 hover:bg-red-900/50 transition"
+          >
+            Disconnect
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleDisconnect}
+              disabled={disconnecting}
+              className="text-sm px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 transition disabled:opacity-50"
+            >
+              {disconnecting ? 'Disconnecting...' : 'Confirm Disconnect'}
+            </button>
+            <button
+              onClick={() => setShowConfirmDisconnect(false)}
+              className="text-sm px-4 py-2 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600 transition"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+
+// ── Telegram Icon ─────────────────────────────────────────────────────────────
+
+function TelegramIcon({ size = 24 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z"
+        fill={TELEGRAM_BLUE}
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

- **Port CAKE OS Telegram integration** to Chatty with full adaptation to provider-agnostic architecture (works with Anthropic, OpenAI, Google Gemini)
- **Per-agent Telegram bots**: each agent gets its own @BotFather bot with token management, webhook registration, and 10-min auto-registration windows
- **Guided onboarding wizard**: 4-step frontend flow walks users through creating a bot, pasting the token, linking their Telegram account, with screenshot placeholders for future docs
- **Non-streaming `run_sync()`**: new provider-agnostic execution path in `ai_service.py` for messaging channels that need a single text response instead of SSE stream

### New files
- `backend/integrations/telegram/` — client, state DB, lifecycle, service, router, models (7 files)
- `frontend/src/agent/components/TelegramSettings.tsx` — onboarding wizard + management view

### Modified files
- `backend/agents/db.py` — telegram columns + migration
- `backend/agents/router.py` — telegram_enabled in UpdateAgentRequest
- `backend/core/agents/ai_service.py` — run_sync() function
- `backend/main.py` — router mounting + startup init
- `backend/integrations/registry.py` — Telegram entry
- `frontend/src/agent/AgentPage.tsx` — Telegram tab

## Test plan

- [ ] Backend starts cleanly with `uvicorn main:app` (telegram.db initialized, no webhook errors)
- [ ] `POST /api/telegram/bot-token` validates and saves a BotFather token
- [ ] `POST /api/telegram/webhook/{slug}` processes simulated Telegram Update payloads
- [ ] Frontend Telegram tab renders onboarding wizard for unconfigured agents
- [ ] Frontend management view shows after connecting (toggle, disconnect, reset registration)
- [ ] End-to-end: connect real bot, message on Telegram, receive AI response
- [ ] TypeScript compiles cleanly (`tsc --noEmit` passes)