### PR TITLE
Add CODEOWNERS for required maintainer review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every PR requires review from the repo owner
+* @wwilson1017


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` so @wwilson1017 is automatically requested as reviewer on every PR
- Works with the branch protection rule already enabled on `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)