### PR TITLE
Add full QuickBooks Online read+write API tools

### DIFF
--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -375,6 +375,23 @@ async def chat(
                 "Use crm_dashboard when the user asks for an overview or summary of their business."
             )
 
+        qbo_tools = [t for t in integration_tool_defs if t.get("name", "").startswith("qbo_")]
+        if qbo_tools:
+            system_prompt += (
+                "\n\n# QuickBooks Online Tools Available\n\n"
+                "You have QuickBooks tools for invoicing, payments, estimates, customers, vendors, items, "
+                "and financial reports.\n\n"
+                "**Key patterns:**\n"
+                "- Use `qbo_query` to look up IDs first: `SELECT Id, DisplayName FROM Customer WHERE DisplayName LIKE '%Smith%'`\n"
+                "- Use `qbo_get_entity` for full details of any record.\n"
+                "- For invoices: create with `qbo_create_invoice`, then optionally send with `qbo_send_invoice`.\n"
+                "- For estimates: create with `qbo_create_estimate`, then send with `qbo_send_estimate`.\n"
+                "- To record payments: use `qbo_record_payment`, optionally link to invoice IDs.\n"
+                "- For customers, vendors, items, bills: use `qbo_create_entity` / `qbo_update_entity`.\n"
+                "- **Never guess IDs** — always query first to find the correct Customer, Item, or Invoice ID.\n"
+                "- Amounts are in the company's home currency.\n"
+            )
+
     accumulated_text = ""
 
     # ── Reconstruct approved tool in message history ──────────────────
@@ -602,6 +619,23 @@ async def run_sync(
                 "\n\n# Odoo ERP Tools Available\n\n"
                 "You have Odoo tools for CRM, helpdesk, sales, purchasing, contacts, projects, "
                 "and timesheets. Use them when the user asks about business operations."
+            )
+
+        qbo_tools = [t for t in integration_tool_defs if t.get("name", "").startswith("qbo_")]
+        if qbo_tools:
+            system_prompt += (
+                "\n\n# QuickBooks Online Tools Available\n\n"
+                "You have QuickBooks tools for invoicing, payments, estimates, customers, vendors, items, "
+                "and financial reports.\n\n"
+                "**Key patterns:**\n"
+                "- Use `qbo_query` to look up IDs first: `SELECT Id, DisplayName FROM Customer WHERE DisplayName LIKE '%Smith%'`\n"
+                "- Use `qbo_get_entity` for full details of any record.\n"
+                "- For invoices: create with `qbo_create_invoice`, then optionally send with `qbo_send_invoice`.\n"
+                "- For estimates: create with `qbo_create_estimate`, then send with `qbo_send_estimate`.\n"
+                "- To record payments: use `qbo_record_payment`, optionally link to invoice IDs.\n"
+                "- For customers, vendors, items, bills: use `qbo_create_entity` / `qbo_update_entity`.\n"
+                "- **Never guess IDs** — always query first to find the correct Customer, Item, or Invoice ID.\n"
+                "- Amounts are in the company's home currency.\n"
             )
 
     # Chat history — save user message

--- a/backend/integrations/quickbooks/client.py
+++ b/backend/integrations/quickbooks/client.py
@@ -111,6 +111,142 @@ class QuickBooksClient:
             logger.error("QBO P&L error: %s", e)
             return {"error": str(e)}
 
+    def get_balance_sheet(self, start_date: str, end_date: str) -> dict:
+        """Fetch Balance Sheet report."""
+        try:
+            resp = httpx.get(
+                f"{QBO_BASE_URL}/{self.company_id}/reports/BalanceSheet",
+                headers=self._headers(),
+                params={"start_date": start_date, "end_date": end_date, "minorversion": "65"},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            logger.error("QBO Balance Sheet error: %s", e)
+            return {"error": str(e)}
+
+    # ── Entity CRUD methods ──────────────────────────────────────────────────
+
+    def _entity_url(self, entity_type: str, entity_id: str = "") -> str:
+        """Build QBO API URL for an entity type."""
+        path = entity_type.lower()
+        base = f"{QBO_BASE_URL}/{self.company_id}/{path}"
+        if entity_id:
+            base = f"{base}/{entity_id}"
+        return base
+
+    def get_entity(self, entity_type: str, entity_id: str) -> dict:
+        """Fetch a single entity by type and ID."""
+        try:
+            resp = httpx.get(
+                self._entity_url(entity_type, entity_id),
+                headers=self._headers(),
+                params={"minorversion": "65"},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            # QBO nests the entity under its PascalCase type name
+            return data.get(entity_type, data)
+        except Exception as e:
+            logger.error("QBO get %s/%s error: %s", entity_type, entity_id, e)
+            return {"error": str(e)}
+
+    def create_entity(self, entity_type: str, data: dict) -> dict:
+        """Create a new entity. Returns the created entity dict."""
+        try:
+            resp = httpx.post(
+                self._entity_url(entity_type),
+                headers=self._headers(),
+                params={"minorversion": "65"},
+                json=data,
+                timeout=15,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            return result.get(entity_type, result)
+        except httpx.HTTPStatusError as e:
+            body = e.response.text
+            logger.error("QBO create %s failed (%s): %s", entity_type, e.response.status_code, body)
+            return {"error": f"QBO API error {e.response.status_code}: {body}"}
+        except Exception as e:
+            logger.error("QBO create %s error: %s", entity_type, e)
+            return {"error": str(e)}
+
+    def update_entity(self, entity_type: str, data: dict) -> dict:
+        """Update an existing entity. data must include Id and SyncToken."""
+        try:
+            resp = httpx.post(
+                self._entity_url(entity_type),
+                headers=self._headers(),
+                params={"minorversion": "65"},
+                json=data,
+                timeout=15,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            return result.get(entity_type, result)
+        except httpx.HTTPStatusError as e:
+            body = e.response.text
+            logger.error("QBO update %s failed (%s): %s", entity_type, e.response.status_code, body)
+            return {"error": f"QBO API error {e.response.status_code}: {body}"}
+        except Exception as e:
+            logger.error("QBO update %s error: %s", entity_type, e)
+            return {"error": str(e)}
+
+    def void_entity(self, entity_type: str, entity_id: str, sync_token: str) -> dict:
+        """Void an entity (e.g. Invoice). Sets balance to zero without deleting."""
+        try:
+            resp = httpx.post(
+                self._entity_url(entity_type),
+                headers=self._headers(),
+                params={"operation": "void", "minorversion": "65"},
+                json={"Id": entity_id, "SyncToken": sync_token, "sparse": True},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            return result.get(entity_type, result)
+        except httpx.HTTPStatusError as e:
+            body = e.response.text
+            logger.error("QBO void %s/%s failed (%s): %s", entity_type, entity_id, e.response.status_code, body)
+            return {"error": f"QBO API error {e.response.status_code}: {body}"}
+        except Exception as e:
+            logger.error("QBO void %s/%s error: %s", entity_type, entity_id, e)
+            return {"error": str(e)}
+
+    def send_entity(self, entity_type: str, entity_id: str, email: str | None = None) -> dict:
+        """Email an entity (Invoice or Estimate) to the customer."""
+        try:
+            params: dict[str, str] = {"minorversion": "65"}
+            if email:
+                params["sendTo"] = email
+            resp = httpx.post(
+                f"{self._entity_url(entity_type, entity_id)}/send",
+                headers=self._headers(),
+                params=params,
+                timeout=15,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            return result.get(entity_type, result)
+        except httpx.HTTPStatusError as e:
+            body = e.response.text
+            logger.error("QBO send %s/%s failed (%s): %s", entity_type, entity_id, e.response.status_code, body)
+            return {"error": f"QBO API error {e.response.status_code}: {body}"}
+        except Exception as e:
+            logger.error("QBO send %s/%s error: %s", entity_type, entity_id, e)
+            return {"error": str(e)}
+
+    def _fetch_sync_token(self, entity_type: str, entity_id: str) -> tuple[dict, str] | None:
+        """Fetch an entity and return (full_entity, sync_token), or None if not found."""
+        entity = self.get_entity(entity_type, entity_id)
+        if not entity or "error" in entity:
+            return None
+        sync_token = entity.get("SyncToken", "0")
+        return entity, sync_token
+
 
 def get_client() -> QuickBooksClient | None:
     """Return a configured QBO client from stored credentials, or None."""

--- a/backend/integrations/quickbooks/tools.py
+++ b/backend/integrations/quickbooks/tools.py
@@ -1,8 +1,66 @@
-"""Chatty — QuickBooks Online agent tools."""
+"""Chatty — QuickBooks Online agent tools.
+
+Full suite of read + write tools for QBO entities.
+Write tools are marked with "writes": True so the approval flow
+intercepts them in normal mode.
+"""
 
 from .client import get_client
 
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+_ALLOWED_CREATE_TYPES = {
+    "Customer", "Vendor", "Item", "Bill", "VendorCredit", "Purchase", "CreditMemo",
+}
+_ALLOWED_UPDATE_TYPES = {"Customer", "Vendor", "Item"}
+_ALLOWED_GET_TYPES = {
+    "Customer", "Vendor", "Item", "Invoice", "Estimate", "Payment",
+    "Bill", "Purchase", "CreditMemo", "Account",
+}
+
+
+def _build_line_items(line_items: list[dict]) -> list[dict]:
+    """Convert simplified line items into QBO Line array format.
+
+    Accepts: [{description, amount, quantity?, item_id?, rate?}, ...]
+    Returns: QBO SalesItemLineDetail lines.
+    """
+    lines = []
+    for item in line_items:
+        amount = item.get("amount", 0)
+        qty = item.get("quantity", 1)
+        rate = item.get("rate", amount / qty if qty else amount)
+        detail: dict = {"Qty": qty, "UnitPrice": rate}
+        if item.get("item_id"):
+            detail["ItemRef"] = {"value": str(item["item_id"])}
+        line: dict = {
+            "DetailType": "SalesItemLineDetail",
+            "Amount": amount,
+            "SalesItemLineDetail": detail,
+        }
+        if item.get("description"):
+            line["Description"] = item["description"]
+        lines.append(line)
+    return lines
+
+
+def _build_payment_lines(invoice_ids: list[str], total_amount: float) -> list[dict]:
+    """Build QBO Payment Line array linking to invoices."""
+    if not invoice_ids:
+        return []
+    lines = []
+    for inv_id in invoice_ids:
+        lines.append({
+            "Amount": total_amount / len(invoice_ids),
+            "LinkedTxn": [{"TxnId": str(inv_id), "TxnType": "Invoice"}],
+        })
+    return lines
+
+
+# ── Tool definitions ─────────────────────────────────────────────────────────
+
 QB_TOOL_DEFS = [
+    # ── Read tools ───────────────────────────────────────────────────────
     {
         "name": "qbo_query",
         "description": "Query QuickBooks records using SQL-style syntax. E.g. SELECT * FROM Invoice WHERE TotalAmt > 1000",
@@ -28,8 +86,252 @@ QB_TOOL_DEFS = [
         },
         "kind": "integration",
     },
+    {
+        "name": "qbo_get_balance_sheet",
+        "description": "Get Balance Sheet report for a date range.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
+                "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+            },
+            "required": ["start_date", "end_date"],
+        },
+        "kind": "integration",
+    },
+    {
+        "name": "qbo_get_entity",
+        "description": "Get a single QuickBooks entity by type and ID. Returns full details including all fields.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "entity_type": {
+                    "type": "string",
+                    "description": "Entity type",
+                    "enum": sorted(_ALLOWED_GET_TYPES),
+                },
+                "entity_id": {"type": "string", "description": "The entity ID"},
+            },
+            "required": ["entity_type", "entity_id"],
+        },
+        "kind": "integration",
+    },
+
+    # ── Invoice tools ────────────────────────────────────────────────────
+    {
+        "name": "qbo_create_invoice",
+        "description": "Create a new invoice in QuickBooks. Requires customer ID and at least one line item.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "customer_id": {"type": "string", "description": "QBO Customer Id (query customers first to find the ID)"},
+                "line_items": {
+                    "type": "array",
+                    "description": "Invoice line items",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "description": {"type": "string", "description": "Line item description"},
+                            "amount": {"type": "number", "description": "Total line amount"},
+                            "quantity": {"type": "number", "description": "Quantity (default 1)"},
+                            "rate": {"type": "number", "description": "Unit price (defaults to amount/quantity)"},
+                            "item_id": {"type": "string", "description": "QBO Item Id (product/service)"},
+                        },
+                        "required": ["amount"],
+                    },
+                },
+                "due_date": {"type": "string", "description": "Due date YYYY-MM-DD"},
+                "txn_date": {"type": "string", "description": "Invoice date YYYY-MM-DD (defaults to today)"},
+                "doc_number": {"type": "string", "description": "Custom invoice number"},
+                "customer_memo": {"type": "string", "description": "Memo visible to customer"},
+                "private_note": {"type": "string", "description": "Internal note (not visible to customer)"},
+            },
+            "required": ["customer_id", "line_items"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+    {
+        "name": "qbo_update_invoice",
+        "description": "Update an existing invoice. Fetches current data and SyncToken automatically. Provide only fields to change.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "invoice_id": {"type": "string", "description": "QBO Invoice Id"},
+                "line_items": {
+                    "type": "array",
+                    "description": "Replaces all line items if provided",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "description": {"type": "string"},
+                            "amount": {"type": "number"},
+                            "quantity": {"type": "number"},
+                            "rate": {"type": "number"},
+                            "item_id": {"type": "string"},
+                        },
+                        "required": ["amount"],
+                    },
+                },
+                "due_date": {"type": "string", "description": "New due date YYYY-MM-DD"},
+                "customer_memo": {"type": "string", "description": "Updated memo for customer"},
+                "private_note": {"type": "string", "description": "Updated internal note"},
+                "doc_number": {"type": "string", "description": "Updated invoice number"},
+            },
+            "required": ["invoice_id"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+    {
+        "name": "qbo_send_invoice",
+        "description": "Email an invoice to the customer. The customer's email must be on file in QuickBooks unless you provide an override.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "invoice_id": {"type": "string", "description": "QBO Invoice Id"},
+                "email_to": {"type": "string", "description": "Override recipient email address (optional)"},
+            },
+            "required": ["invoice_id"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+    {
+        "name": "qbo_void_invoice",
+        "description": "Void an invoice in QuickBooks. Sets the balance to zero without deleting the record.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "invoice_id": {"type": "string", "description": "QBO Invoice Id"},
+            },
+            "required": ["invoice_id"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+
+    # ── Payment tools ────────────────────────────────────────────────────
+    {
+        "name": "qbo_record_payment",
+        "description": "Record a payment received from a customer, optionally linked to specific invoices.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "customer_id": {"type": "string", "description": "QBO Customer Id"},
+                "total_amount": {"type": "number", "description": "Payment amount"},
+                "payment_date": {"type": "string", "description": "Payment date YYYY-MM-DD (defaults to today)"},
+                "invoice_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Invoice Ids to apply this payment to",
+                },
+                "payment_method": {"type": "string", "description": "E.g. 'Check', 'Credit Card', 'Cash'"},
+                "reference_number": {"type": "string", "description": "Check number or payment reference"},
+                "private_note": {"type": "string", "description": "Internal note"},
+            },
+            "required": ["customer_id", "total_amount"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+
+    # ── Estimate tools ───────────────────────────────────────────────────
+    {
+        "name": "qbo_create_estimate",
+        "description": "Create a new estimate/quote for a customer in QuickBooks.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "customer_id": {"type": "string", "description": "QBO Customer Id"},
+                "line_items": {
+                    "type": "array",
+                    "description": "Estimate line items",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "description": {"type": "string"},
+                            "amount": {"type": "number"},
+                            "quantity": {"type": "number"},
+                            "rate": {"type": "number"},
+                            "item_id": {"type": "string"},
+                        },
+                        "required": ["amount"],
+                    },
+                },
+                "expiration_date": {"type": "string", "description": "Estimate expiration date YYYY-MM-DD"},
+                "txn_date": {"type": "string", "description": "Estimate date YYYY-MM-DD"},
+                "customer_memo": {"type": "string", "description": "Memo visible to customer"},
+                "private_note": {"type": "string", "description": "Internal note"},
+            },
+            "required": ["customer_id", "line_items"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+    {
+        "name": "qbo_send_estimate",
+        "description": "Email an estimate/quote to the customer.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "estimate_id": {"type": "string", "description": "QBO Estimate Id"},
+                "email_to": {"type": "string", "description": "Override recipient email address (optional)"},
+            },
+            "required": ["estimate_id"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+
+    # ── Generic entity tools ─────────────────────────────────────────────
+    {
+        "name": "qbo_create_entity",
+        "description": "Create a Customer, Vendor, Item (product/service), Bill, Expense, or Credit Memo in QuickBooks. Pass the entity type and fields as a JSON object following the QBO API schema.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "entity_type": {
+                    "type": "string",
+                    "description": "Entity type to create",
+                    "enum": sorted(_ALLOWED_CREATE_TYPES),
+                },
+                "data": {
+                    "type": "object",
+                    "description": "Entity fields per QBO API. E.g. for Customer: {\"DisplayName\": \"Acme Corp\", \"PrimaryEmailAddr\": {\"Address\": \"acme@example.com\"}}",
+                },
+            },
+            "required": ["entity_type", "data"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+    {
+        "name": "qbo_update_entity",
+        "description": "Update an existing Customer, Vendor, or Item in QuickBooks. Automatically fetches the current record to get the SyncToken. Provide only the fields to change.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "entity_type": {
+                    "type": "string",
+                    "description": "Entity type to update",
+                    "enum": sorted(_ALLOWED_UPDATE_TYPES),
+                },
+                "entity_id": {"type": "string", "description": "The entity ID to update"},
+                "data": {
+                    "type": "object",
+                    "description": "Fields to update (merged with current record)",
+                },
+            },
+            "required": ["entity_type", "entity_id", "data"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
 ]
 
+
+# ── Executor functions ───────────────────────────────────────────────────────
 
 def qbo_query(sql: str) -> dict:
     client = get_client()
@@ -46,7 +348,316 @@ def qbo_profit_and_loss(start_date: str, end_date: str) -> dict:
     return client.get_profit_and_loss(start_date, end_date)
 
 
+def qbo_get_balance_sheet(start_date: str, end_date: str) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+    return client.get_balance_sheet(start_date, end_date)
+
+
+def qbo_get_entity(entity_type: str, entity_id: str) -> dict:
+    if entity_type not in _ALLOWED_GET_TYPES:
+        return {"error": f"Entity type '{entity_type}' not supported. Allowed: {sorted(_ALLOWED_GET_TYPES)}"}
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+    result = client.get_entity(entity_type, entity_id)
+    if "error" in result:
+        return result
+    return {"ok": True, "entity_type": entity_type, "entity": result}
+
+
+# ── Invoice executors ────────────────────────────────────────────────────────
+
+def qbo_create_invoice(
+    customer_id: str,
+    line_items: list[dict],
+    due_date: str = "",
+    txn_date: str = "",
+    doc_number: str = "",
+    customer_memo: str = "",
+    private_note: str = "",
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+    if not line_items:
+        return {"error": "At least one line item is required"}
+
+    payload: dict = {
+        "CustomerRef": {"value": str(customer_id)},
+        "Line": _build_line_items(line_items),
+    }
+    if due_date:
+        payload["DueDate"] = due_date
+    if txn_date:
+        payload["TxnDate"] = txn_date
+    if doc_number:
+        payload["DocNumber"] = doc_number
+    if customer_memo:
+        payload["CustomerMemo"] = {"value": customer_memo}
+    if private_note:
+        payload["PrivateNote"] = private_note
+
+    result = client.create_entity("Invoice", payload)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "id": result.get("Id"),
+        "doc_number": result.get("DocNumber"),
+        "total": result.get("TotalAmt"),
+        "balance": result.get("Balance"),
+        "status": result.get("EmailStatus"),
+    }
+
+
+def qbo_update_invoice(
+    invoice_id: str,
+    line_items: list[dict] | None = None,
+    due_date: str = "",
+    customer_memo: str = "",
+    private_note: str = "",
+    doc_number: str = "",
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+
+    fetched = client._fetch_sync_token("Invoice", invoice_id)
+    if not fetched:
+        return {"error": f"Invoice {invoice_id} not found"}
+    current, _ = fetched
+
+    if line_items is not None:
+        current["Line"] = _build_line_items(line_items)
+    if due_date:
+        current["DueDate"] = due_date
+    if customer_memo:
+        current["CustomerMemo"] = {"value": customer_memo}
+    if private_note:
+        current["PrivateNote"] = private_note
+    if doc_number:
+        current["DocNumber"] = doc_number
+
+    result = client.update_entity("Invoice", current)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "id": result.get("Id"),
+        "doc_number": result.get("DocNumber"),
+        "total": result.get("TotalAmt"),
+        "balance": result.get("Balance"),
+    }
+
+
+def qbo_send_invoice(invoice_id: str, email_to: str = "") -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+    result = client.send_entity("Invoice", invoice_id, email_to or None)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "id": result.get("Id"),
+        "email_status": result.get("EmailStatus"),
+        "delivered_to": result.get("BillEmail", {}).get("Address", ""),
+    }
+
+
+def qbo_void_invoice(invoice_id: str) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+
+    fetched = client._fetch_sync_token("Invoice", invoice_id)
+    if not fetched:
+        return {"error": f"Invoice {invoice_id} not found"}
+    _, sync_token = fetched
+
+    result = client.void_entity("Invoice", invoice_id, sync_token)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "id": result.get("Id"),
+        "doc_number": result.get("DocNumber"),
+        "balance": result.get("Balance"),
+        "voided": True,
+    }
+
+
+# ── Payment executor ─────────────────────────────────────────────────────────
+
+def qbo_record_payment(
+    customer_id: str,
+    total_amount: float,
+    payment_date: str = "",
+    invoice_ids: list[str] | None = None,
+    payment_method: str = "",
+    reference_number: str = "",
+    private_note: str = "",
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+
+    payload: dict = {
+        "CustomerRef": {"value": str(customer_id)},
+        "TotalAmt": total_amount,
+    }
+    if payment_date:
+        payload["TxnDate"] = payment_date
+    if invoice_ids:
+        payload["Line"] = _build_payment_lines(invoice_ids, total_amount)
+    if payment_method:
+        payload["PaymentMethodRef"] = {"value": payment_method}
+    if reference_number:
+        payload["PaymentRefNum"] = reference_number
+    if private_note:
+        payload["PrivateNote"] = private_note
+
+    result = client.create_entity("Payment", payload)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "id": result.get("Id"),
+        "amount": result.get("TotalAmt"),
+        "date": result.get("TxnDate"),
+        "unapplied": result.get("UnappliedAmt"),
+    }
+
+
+# ── Estimate executors ───────────────────────────────────────────────────────
+
+def qbo_create_estimate(
+    customer_id: str,
+    line_items: list[dict],
+    expiration_date: str = "",
+    txn_date: str = "",
+    customer_memo: str = "",
+    private_note: str = "",
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+    if not line_items:
+        return {"error": "At least one line item is required"}
+
+    payload: dict = {
+        "CustomerRef": {"value": str(customer_id)},
+        "Line": _build_line_items(line_items),
+    }
+    if expiration_date:
+        payload["ExpirationDate"] = expiration_date
+    if txn_date:
+        payload["TxnDate"] = txn_date
+    if customer_memo:
+        payload["CustomerMemo"] = {"value": customer_memo}
+    if private_note:
+        payload["PrivateNote"] = private_note
+
+    result = client.create_entity("Estimate", payload)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "id": result.get("Id"),
+        "doc_number": result.get("DocNumber"),
+        "total": result.get("TotalAmt"),
+        "status": result.get("TxnStatus"),
+    }
+
+
+def qbo_send_estimate(estimate_id: str, email_to: str = "") -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+    result = client.send_entity("Estimate", estimate_id, email_to or None)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "id": result.get("Id"),
+        "email_status": result.get("EmailStatus"),
+        "delivered_to": result.get("BillEmail", {}).get("Address", ""),
+    }
+
+
+# ── Generic entity executors ─────────────────────────────────────────────────
+
+def qbo_create_entity(entity_type: str, data: dict) -> dict:
+    if entity_type not in _ALLOWED_CREATE_TYPES:
+        return {"error": f"Entity type '{entity_type}' not supported for creation. Allowed: {sorted(_ALLOWED_CREATE_TYPES)}"}
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+    if not data:
+        return {"error": "data is required"}
+
+    result = client.create_entity(entity_type, data)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "entity_type": entity_type,
+        "id": result.get("Id"),
+        "display_name": result.get("DisplayName", result.get("Name", "")),
+        "sync_token": result.get("SyncToken"),
+    }
+
+
+def qbo_update_entity(entity_type: str, entity_id: str, data: dict) -> dict:
+    if entity_type not in _ALLOWED_UPDATE_TYPES:
+        return {"error": f"Entity type '{entity_type}' not supported for update. Allowed: {sorted(_ALLOWED_UPDATE_TYPES)}"}
+    client = get_client()
+    if not client:
+        return {"error": "QuickBooks not configured or unavailable"}
+    if not data:
+        return {"error": "data is required — provide at least one field to update"}
+
+    fetched = client._fetch_sync_token(entity_type, entity_id)
+    if not fetched:
+        return {"error": f"{entity_type} {entity_id} not found"}
+    current, _ = fetched
+
+    # Merge updates on top of current entity
+    current.update(data)
+
+    result = client.update_entity(entity_type, current)
+    if "error" in result:
+        return result
+    return {
+        "ok": True,
+        "entity_type": entity_type,
+        "id": result.get("Id"),
+        "display_name": result.get("DisplayName", result.get("Name", "")),
+        "sync_token": result.get("SyncToken"),
+    }
+
+
+# ── Executor map ─────────────────────────────────────────────────────────────
+
 TOOL_EXECUTORS = {
+    # Read tools
     "qbo_query": lambda **kw: qbo_query(**kw),
     "qbo_profit_and_loss": lambda **kw: qbo_profit_and_loss(**kw),
+    "qbo_get_balance_sheet": lambda **kw: qbo_get_balance_sheet(**kw),
+    "qbo_get_entity": lambda **kw: qbo_get_entity(**kw),
+    # Invoice tools
+    "qbo_create_invoice": lambda **kw: qbo_create_invoice(**kw),
+    "qbo_update_invoice": lambda **kw: qbo_update_invoice(**kw),
+    "qbo_send_invoice": lambda **kw: qbo_send_invoice(**kw),
+    "qbo_void_invoice": lambda **kw: qbo_void_invoice(**kw),
+    # Payment tools
+    "qbo_record_payment": lambda **kw: qbo_record_payment(**kw),
+    # Estimate tools
+    "qbo_create_estimate": lambda **kw: qbo_create_estimate(**kw),
+    "qbo_send_estimate": lambda **kw: qbo_send_estimate(**kw),
+    # Generic entity tools
+    "qbo_create_entity": lambda **kw: qbo_create_entity(**kw),
+    "qbo_update_entity": lambda **kw: qbo_update_entity(**kw),
 }

--- a/backend/integrations/quickbooks/tools.py
+++ b/backend/integrations/quickbooks/tools.py
@@ -19,6 +19,17 @@ _ALLOWED_GET_TYPES = {
 }
 
 
+def _deep_merge(base: dict, updates: dict) -> dict:
+    """Recursively merge updates into base dict, preserving nested sibling keys."""
+    merged = dict(base)
+    for key, value in updates.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def _build_line_items(line_items: list[dict]) -> list[dict]:
     """Convert simplified line items into QBO Line array format.
 
@@ -44,15 +55,16 @@ def _build_line_items(line_items: list[dict]) -> list[dict]:
     return lines
 
 
-def _build_payment_lines(invoice_ids: list[str], total_amount: float) -> list[dict]:
-    """Build QBO Payment Line array linking to invoices."""
-    if not invoice_ids:
-        return []
+def _build_payment_lines(line_items: list[dict]) -> list[dict]:
+    """Build QBO Payment Line array linking to invoices.
+
+    Accepts: [{invoice_id, amount}, ...]
+    """
     lines = []
-    for inv_id in invoice_ids:
+    for item in line_items:
         lines.append({
-            "Amount": total_amount / len(invoice_ids),
-            "LinkedTxn": [{"TxnId": str(inv_id), "TxnType": "Invoice"}],
+            "Amount": item["amount"],
+            "LinkedTxn": [{"TxnId": str(item["invoice_id"]), "TxnType": "Invoice"}],
         })
     return lines
 
@@ -214,19 +226,26 @@ QB_TOOL_DEFS = [
     # ── Payment tools ────────────────────────────────────────────────────
     {
         "name": "qbo_record_payment",
-        "description": "Record a payment received from a customer, optionally linked to specific invoices.",
+        "description": "Record a payment received from a customer, optionally linked to specific invoices with per-invoice amounts.",
         "input_schema": {
             "type": "object",
             "properties": {
                 "customer_id": {"type": "string", "description": "QBO Customer Id"},
                 "total_amount": {"type": "number", "description": "Payment amount"},
                 "payment_date": {"type": "string", "description": "Payment date YYYY-MM-DD (defaults to today)"},
-                "invoice_ids": {
+                "invoice_allocations": {
                     "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Invoice Ids to apply this payment to",
+                    "description": "How to apply payment across invoices. Each entry specifies an invoice and the amount to apply to it.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "invoice_id": {"type": "string", "description": "QBO Invoice Id"},
+                            "amount": {"type": "number", "description": "Amount to apply to this invoice"},
+                        },
+                        "required": ["invoice_id", "amount"],
+                    },
                 },
-                "payment_method": {"type": "string", "description": "E.g. 'Check', 'Credit Card', 'Cash'"},
+                "payment_method_id": {"type": "string", "description": "QBO PaymentMethod Id (use qbo_query to look up: SELECT Id, Name FROM PaymentMethod)"},
                 "reference_number": {"type": "string", "description": "Check number or payment reference"},
                 "private_note": {"type": "string", "description": "Internal note"},
             },
@@ -495,8 +514,8 @@ def qbo_record_payment(
     customer_id: str,
     total_amount: float,
     payment_date: str = "",
-    invoice_ids: list[str] | None = None,
-    payment_method: str = "",
+    invoice_allocations: list[dict] | None = None,
+    payment_method_id: str = "",
     reference_number: str = "",
     private_note: str = "",
 ) -> dict:
@@ -510,10 +529,10 @@ def qbo_record_payment(
     }
     if payment_date:
         payload["TxnDate"] = payment_date
-    if invoice_ids:
-        payload["Line"] = _build_payment_lines(invoice_ids, total_amount)
-    if payment_method:
-        payload["PaymentMethodRef"] = {"value": payment_method}
+    if invoice_allocations:
+        payload["Line"] = _build_payment_lines(invoice_allocations)
+    if payment_method_id:
+        payload["PaymentMethodRef"] = {"value": payment_method_id}
     if reference_number:
         payload["PaymentRefNum"] = reference_number
     if private_note:
@@ -624,8 +643,8 @@ def qbo_update_entity(entity_type: str, entity_id: str, data: dict) -> dict:
         return {"error": f"{entity_type} {entity_id} not found"}
     current, _ = fetched
 
-    # Merge updates on top of current entity
-    current.update(data)
+    # Deep merge updates on top of current entity (preserves nested sibling keys)
+    current = _deep_merge(current, data)
 
     result = client.update_entity(entity_type, current)
     if "error" in result:

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -152,6 +152,7 @@ export type SSEEvent =
   | { type: 'tool_start'; tool: string; tool_use_id: string }
   | { type: 'tool_args'; tool: string; tool_use_id: string; args: Record<string, unknown> }
   | { type: 'tool_end'; tool: string; tool_use_id: string; result: unknown; elapsed_ms: number }
+  | { type: 'confirm'; tool: string; args: Record<string, unknown>; tool_use_id: string; description: string }
   | { type: 'title_update'; title: string; conversation_id: string }
   | { type: 'done' }
   | { type: 'error'; error: string };


### PR DESCRIPTION
## Summary
- Expand QBO integration from 2 read-only tools to 15 tools: invoices (create/update/send/void), payments (record), estimates (create/send), generic entity CRUD (Customer, Vendor, Item, Bill, etc.), balance sheet report, and single-entity lookup
- All write tools marked with `writes: True` to automatically trigger the existing approval confirmation flow in normal mode — no changes needed to the approval UI or AI service interception logic
- Add QBO-specific system prompt instructions teaching the AI to query IDs first, use the right tools for each operation, and never guess IDs
- Fix missing `confirm` SSE event variant in the TypeScript `SSEEvent` union type

## Test plan
- [ ] Verify existing read tools still work: `qbo_query` with SQL, `qbo_profit_and_loss` with date range
- [ ] Test invoice lifecycle: create → update → send → void
- [ ] Test payment recording linked to invoices
- [ ] Test estimate lifecycle: create → send
- [ ] Test generic entity CRUD: create customer, update customer
- [ ] Verify approval flow in normal mode: create invoice triggers ConfirmationCard, approve executes, deny blocks
- [ ] Verify read-only mode filters out write tools but keeps read tools
- [ ] Verify power mode executes write tools without confirmation
- [ ] Check system prompt includes QBO instructions when QuickBooks is enabled
- [ ] Verify no TypeScript errors after SSEEvent type fix