### PR TITLE
Fix avatar generation for OpenAI API key users

### DIFF
--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -30,11 +30,11 @@ import shutil
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from core.auth import get_current_user
+from core.auth import get_current_user, decode_access_token
 from core.providers import get_ai_provider
 from core.providers.credentials import CredentialStore
 from core.agents.tool_registry import ToolRegistry
@@ -252,7 +252,7 @@ async def avatar_availability(agent_id: str, user=Depends(get_current_user)):
     _get_agent_or_404(agent_id)
     store = CredentialStore()
     _, profile = store.get_active_profile(provider_override="openai")
-    openai_connected = bool(profile and profile.get("access"))
+    openai_connected = bool(profile and (profile.get("access") or profile.get("key")))
     return {"generate_available": openai_connected, "upload_available": True}
 
 
@@ -271,13 +271,17 @@ async def avatar_generate(agent_id: str, user=Depends(get_current_user)):
         raise HTTPException(429, f"Please wait {remaining}s before generating again")
 
     ctx_manager = get_context_manager(agent["slug"])
-    identity = ctx_manager.read_context("identity.md")
-    soul = ctx_manager.read_context("soul.md")
+    identity = ctx_manager.read_context("profile.md")
+    soul = ctx_manager.read_context("preferences.md")
+    db_personality = agent.get("personality", "")
+    if db_personality:
+        soul = f"{soul}\n\n{db_personality}" if soul else db_personality
     agent_name = agent.get("agent_name") or "Assistant"
 
     store = CredentialStore()
     _, profile = store.get_active_profile(provider_override="openai")
-    openai_token = (profile or {}).get("access", "")
+    p = profile or {}
+    openai_token = p.get("key") or p.get("access") or ""
 
     try:
         urls = await generate_avatar_options(identity, soul, agent_name, openai_token, count=3)
@@ -352,9 +356,26 @@ async def avatar_upload(
 
 
 @router.get("/{agent_id}/avatar")
-async def get_avatar(agent_id: str, user=Depends(get_current_user)):
-    """Serve the agent's avatar image."""
+async def get_avatar(agent_id: str, request: Request, token: str | None = None):
+    """Serve the agent's avatar image.
+
+    Supports ?token= query param for <img> tags that can't send auth headers.
+    """
     from fastapi.responses import FileResponse
+
+    auth_header = request.headers.get("Authorization")
+    jwt_token = None
+    if auth_header and auth_header.startswith("Bearer "):
+        jwt_token = auth_header.removeprefix("Bearer ").strip()
+    elif token:
+        jwt_token = token
+
+    if not jwt_token:
+        raise HTTPException(401, "Not authenticated")
+    try:
+        decode_access_token(jwt_token)
+    except Exception:
+        raise HTTPException(401, "Invalid or expired token")
 
     agent = _get_agent_or_404(agent_id)
     avatar_path = DATA_DIR / agent["slug"] / "avatar.png"

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -164,7 +164,7 @@ export function AgentPage() {
 
         <div className="w-8 h-8 rounded-full bg-indigo-600 flex items-center justify-center text-xs font-bold flex-shrink-0 overflow-hidden">
           {agent.avatar_url
-            ? <img src={agent.avatar_url} alt={agent.agent_name} className="w-full h-full object-cover" />
+            ? <img src={`${agent.avatar_url}?token=${localStorage.getItem('chatty_token') || ''}`} alt={agent.agent_name} className="w-full h-full object-cover" />
             : initials}
         </div>
 

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -164,7 +164,7 @@ export function AgentPage() {
 
         <div className="w-8 h-8 rounded-full bg-indigo-600 flex items-center justify-center text-xs font-bold flex-shrink-0 overflow-hidden">
           {agent.avatar_url
-            ? <img src={`${agent.avatar_url}?token=${localStorage.getItem('chatty_token') || ''}`} alt={agent.agent_name} className="w-full h-full object-cover" />
+            ? <img src={`${agent.avatar_url}${agent.avatar_url.includes('?') ? '&' : '?'}token=${localStorage.getItem('chatty_token') || ''}`} alt={agent.agent_name} className="w-full h-full object-cover" />
             : initials}
         </div>
 

--- a/frontend/src/dashboard/AgentCard.tsx
+++ b/frontend/src/dashboard/AgentCard.tsx
@@ -32,7 +32,7 @@ export function AgentCard({ agent, onDelete }: Props) {
       {/* Avatar */}
       <div className="w-14 h-14 rounded-xl bg-brand flex items-center justify-center text-white font-bold text-xl mb-4">
         {agent.avatar_url
-          ? <img src={agent.avatar_url} alt={agent.agent_name} className="w-full h-full object-cover rounded-xl" />
+          ? <img src={`${agent.avatar_url}?token=${localStorage.getItem('chatty_token') || ''}`} alt={agent.agent_name} className="w-full h-full object-cover rounded-xl" />
           : initials
         }
       </div>

--- a/frontend/src/dashboard/AgentCard.tsx
+++ b/frontend/src/dashboard/AgentCard.tsx
@@ -32,7 +32,7 @@ export function AgentCard({ agent, onDelete }: Props) {
       {/* Avatar */}
       <div className="w-14 h-14 rounded-xl bg-brand flex items-center justify-center text-white font-bold text-xl mb-4">
         {agent.avatar_url
-          ? <img src={`${agent.avatar_url}?token=${localStorage.getItem('chatty_token') || ''}`} alt={agent.agent_name} className="w-full h-full object-cover rounded-xl" />
+          ? <img src={`${agent.avatar_url}${agent.avatar_url.includes('?') ? '&' : '?'}token=${localStorage.getItem('chatty_token') || ''}`} alt={agent.agent_name} className="w-full h-full object-cover rounded-xl" />
           : initials
         }
       </div>


### PR DESCRIPTION
## Summary
- **Context file mismatch**: Avatar generation now reads `profile.md`/`preferences.md` (Chatty's onboarding files) instead of `identity.md`/`soul.md` (CakeOS names that don't exist), so DALL-E 3 gets real personality context for avatar generation
- **API key detection**: Availability check and token extraction now handle both `api_key` and `oauth` credential types — previously only OAuth users could generate avatars
- **Image auth**: Avatar serving endpoint accepts `?token=` query param for `<img>` tags that can't send Authorization headers; frontend appends JWT token to avatar URLs

## Test plan
- [ ] With an OpenAI API key configured, verify `/avatar/availability` returns `generate_available: true`
- [ ] After onboarding, trigger avatar generation and verify DALL-E prompt uses personality context
- [ ] After selecting an avatar, verify the image loads in both AgentPage header and dashboard AgentCard (no 401)
- [ ] Verify manual avatar upload still works
- [ ] Verify other authenticated endpoints still reject unauthenticated requests