### PR TITLE
Port CAKE OS agent features: memory, dreaming, modes, UX

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,176 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize]
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend checks
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Import check — verify all modules load
+        working-directory: backend
+        run: |
+          python -c "
+          import importlib, sys
+
+          failures = []
+
+          # Core modules
+          core_modules = [
+              'core.config', 'core.auth', 'core.storage',
+              'core.agents.config', 'core.agents.ai_service',
+              'core.agents.tool_registry', 'core.agents.tool_definitions',
+              'core.agents.context_manager',
+              'core.agents.chat_history.db', 'core.agents.chat_history.service',
+              'core.agents.reminders.db',
+              'core.agents.scheduled_actions.service',
+              'core.agents.scheduled_actions.processor',
+              'core.agents.memory.db', 'core.agents.memory.types',
+              'core.agents.memory.search_tools', 'core.agents.memory.processor',
+              'core.agents.dreaming.tracker', 'core.agents.dreaming.scorer',
+              'core.agents.dreaming.processor',
+              'core.agents.shared_context.db', 'core.agents.shared_context.service',
+              'core.agents.shared_context.router', 'core.agents.shared_context.tools',
+              'core.agents.tool_config_db',
+              'core.agents.tools.memory_tools',
+              'core.agents.tools.context_tools',
+              'core.agents.tools.web_tools',
+              'core.agents.tools.real_tools',
+              'core.agents.tools.report_tools',
+              'core.providers.base',
+              'core.providers.anthropic_provider',
+              'core.providers.credentials',
+              'agents.db', 'agents.engine', 'agents.router',
+              'agents.onboarding', 'agents.templates',
+          ]
+
+          for mod in core_modules:
+              try:
+                  importlib.import_module(mod)
+                  print(f'  {mod}: OK')
+              except Exception as e:
+                  failures.append(f'  {mod}: {e}')
+                  print(f'  {mod}: FAIL — {e}')
+
+          if failures:
+              print(f'\nFAIL: {len(failures)} module(s) failed to import')
+              sys.exit(1)
+
+          print(f'\nOK: All {len(core_modules)} modules imported successfully')
+          "
+
+      - name: Startup smoke test — DB schema validation
+        working-directory: backend
+        run: |
+          python -c "
+          import sys, tempfile, shutil
+          from pathlib import Path
+
+          tmp = tempfile.mkdtemp(prefix='chatty_smoke_')
+          try:
+              # 1. Reminders DB (also creates dreaming tables)
+              from core.agents.reminders import db
+              db.DATA_DIR = Path(tmp)
+              db.DB_PATH = Path(tmp) / 'reminders.db'
+              db.init_db()
+              print('  Reminders DB init: OK')
+
+              # Verify dreaming tables exist
+              conn = db.get_db()
+              conn.execute('SELECT COUNT(*) FROM context_usage').fetchone()
+              print('  context_usage table: OK')
+              conn.execute('SELECT COUNT(*) FROM dreaming_runs').fetchone()
+              print('  dreaming_runs table: OK')
+
+              # 2. Shared context DB
+              from core.agents.shared_context import db as sc_db
+              sc_db.DATA_DIR = Path(tmp) / 'shared'
+              sc_db.DB_PATH = Path(tmp) / 'shared' / 'shared_context.db'
+              sc_db.init_db()
+              print('  Shared context DB init: OK')
+
+              # 3. Tool config DB
+              from core.agents import tool_config_db
+              tool_config_db.DATA_DIR = Path(tmp) / 'configs'
+              tool_config_db.DB_PATH = Path(tmp) / 'configs' / 'tool_configs.db'
+              tool_config_db.init_db()
+              print('  Tool config DB init: OK')
+
+              # 4. Memory DB
+              from core.agents.memory.db import MemoryDB
+              mem_dir = Path(tmp) / 'mem'
+              mem_dir.mkdir()
+              mem_db = MemoryDB(mem_dir, 'test/')
+              mem_db.init_db()
+              print('  Memory DB init: OK')
+
+              # Verify FTS5 works
+              mem_db.index_document('topic', 'test.md', 'Test', 'Hello world test content')
+              results = mem_db.search('hello')
+              assert len(results) > 0, 'FTS5 search returned no results'
+              print('  FTS5 search: OK')
+
+              print('\nOK: All startup checks passed')
+          except Exception as e:
+              import traceback
+              traceback.print_exc()
+              sys.exit(1)
+          finally:
+              try:
+                  from core.agents.reminders import db as db_mod
+                  if db_mod._connection:
+                      db_mod._connection.close()
+                      db_mod._connection = None
+              except Exception:
+                  pass
+              shutil.rmtree(tmp, ignore_errors=True)
+          "
+
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build (tsc + vite)
+        working-directory: frontend
+        run: npm run build

--- a/backend/agents/engine.py
+++ b/backend/agents/engine.py
@@ -85,6 +85,27 @@ def get_context_manager(slug: str) -> ContextManager:
     )
 
 
+@lru_cache(maxsize=32)
+def _get_initialized_memory_db(slug: str):
+    """Return an initialized MemoryDB for the given agent slug.
+
+    LRU cache ensures we reuse the same DB connection across requests.
+    """
+    from core.agents.memory.db import MemoryDB
+    ctx_dir = _context_dir(slug)
+    db = MemoryDB(ctx_dir, _gcs_prefix(slug) + "context/")
+    db.init_db()
+    # Reindex all files on first init so FTS5 has data
+    ctx_manager = get_context_manager(slug)
+    db.reindex_all(ctx_manager)
+    return db
+
+
+def ensure_memory_db(slug: str):
+    """Ensure the MemoryDB is initialized for this agent. Called lazily."""
+    return _get_initialized_memory_db(slug)
+
+
 def get_chat_service(slug: str) -> ChatHistoryService:
     """Return an initialized ChatHistoryService for the given agent slug."""
     db = _get_initialized_db(slug)

--- a/backend/agents/engine.py
+++ b/backend/agents/engine.py
@@ -70,6 +70,7 @@ def build_agent_config(agent_row: dict) -> AgentConfig:
         gmail_enabled=bool(agent_row.get("gmail_enabled", 0)),
         calendar_enabled=bool(agent_row.get("calendar_enabled", 0)),
         context_dir=str(_context_dir(slug)),
+        gcs_prefix=_gcs_prefix(slug) + "context/",
         chat_db_path=str(_agent_dir(slug) / "chat.db"),
         onboarding_complete=bool(agent_row.get("onboarding_complete", 0)),
         training_topics=topics,

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -54,6 +54,7 @@ from .engine import (
     build_agent_config,
     get_context_manager,
     get_chat_service,
+    ensure_memory_db,
     invalidate_cache,
     DATA_DIR,
 )
@@ -401,6 +402,12 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
     config = build_agent_config(agent)
     ctx_manager = get_context_manager(agent["slug"])
     chat_service = get_chat_service(agent["slug"])
+
+    # Ensure MemoryDB is initialized (lazy, cached after first call)
+    try:
+        ensure_memory_db(agent["slug"])
+    except Exception:
+        pass  # Non-critical — search will degrade gracefully
 
     store = CredentialStore()
     provider = get_ai_provider(

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -165,6 +165,8 @@ class ChatRequest(BaseModel):
     messages: list[dict]
     conversation_id: str | None = None
     training_mode: bool = False
+    training_type: str | None = None
+    plan_mode: bool = False
     tool_mode: str = "normal"
     approved_tool: dict | None = None
 
@@ -393,6 +395,7 @@ async def get_avatar(agent_id: str, request: Request, token: str | None = None):
 # ── Per-agent: Chat (shared helper) ──────────────────────────────────────────
 
 def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_id: str | None,
+                  training_type: str | None = None, plan_mode: bool = False,
                   tool_mode: str = "normal", approved_tool: dict | None = None):
     """Build provider, registry, and return a StreamingResponse for agent chat."""
     config = build_agent_config(agent)
@@ -416,9 +419,11 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
     reminder_handlers, sa_handlers = _build_agent_handlers(agent["slug"])
     registry = ToolRegistry(
         context_dir=config.context_dir,
+        gcs_prefix=config.gcs_prefix,
         google_access_token=google_token,
         integration_executors=integration_executors,
         agent_slug=agent["slug"],
+        agent_name=config.agent_name,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
     )
@@ -434,6 +439,8 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
             ctx_manager=ctx_manager,
             messages=messages,
             training_mode=training_mode,
+            training_type=training_type,
+            plan_mode=plan_mode,
             conversation_id=conversation_id,
             chat_service=chat_service,
             anthropic_api_key=anthropic_api_key,
@@ -459,7 +466,50 @@ async def agent_chat(agent_id: str, req: ChatRequest, user=Depends(get_current_u
     """Stream a chat response for a specific agent."""
     agent = _get_agent_or_404(agent_id)
     return _stream_chat(agent, req.messages, req.training_mode, req.conversation_id,
+                        training_type=req.training_type, plan_mode=req.plan_mode,
                         tool_mode=req.tool_mode, approved_tool=req.approved_tool)
+
+
+# ── Per-agent: Plan mode approve/iterate ──────────────────────────────────────
+
+
+class PlanApproveRequest(BaseModel):
+    messages: list[dict]
+    conversation_id: str | None = None
+    plan_text: str = ""
+
+
+class PlanIterateRequest(BaseModel):
+    messages: list[dict]
+    conversation_id: str | None = None
+    feedback: str = ""
+
+
+@router.post("/{agent_id}/plan/approve")
+async def plan_approve(agent_id: str, req: PlanApproveRequest, user=Depends(get_current_user)):
+    """Approve a plan and execute it in power mode."""
+    agent = _get_agent_or_404(agent_id)
+    # Append the plan + approval as a user message
+    messages = list(req.messages)
+    messages.append({
+        "role": "user",
+        "content": f"[Plan Approved] Execute this plan:\n\n{req.plan_text}",
+    })
+    return _stream_chat(agent, messages, False, req.conversation_id,
+                        tool_mode="power")
+
+
+@router.post("/{agent_id}/plan/iterate")
+async def plan_iterate(agent_id: str, req: PlanIterateRequest, user=Depends(get_current_user)):
+    """Send feedback on a plan and stay in plan mode."""
+    agent = _get_agent_or_404(agent_id)
+    messages = list(req.messages)
+    messages.append({
+        "role": "user",
+        "content": req.feedback or "Please revise the plan.",
+    })
+    return _stream_chat(agent, messages, False, req.conversation_id,
+                        plan_mode=True)
 
 
 # ── Per-agent: Onboarding progress ───────────────────────────────────────────
@@ -684,6 +734,7 @@ async def agent_chat_upload(
 
     return _stream_chat(
         agent, messages, body.get("training_mode", False), body.get("conversation_id"),
+        training_type=body.get("training_type"), plan_mode=body.get("plan_mode", False),
         tool_mode=body.get("tool_mode", "normal"), approved_tool=body.get("approved_tool"),
     )
 

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -267,17 +267,24 @@ def _build_system_prompt(
     except Exception:
         pass
 
-    # Relevance pre-fetch — on first message, inject relevant context
+    # Relevance pre-fetch — on first message, inject relevant context.
+    # Capped at 30K chars to avoid prompt bloat on broad queries.
     if first_user_message:
         relevant = ctx_manager.relevance_prefetch(first_user_message)
         if relevant:
-            parts.append("# Likely Relevant Context")
-            parts.append("")
+            prefetch_parts: list[str] = []
+            prefetch_chars = 0
+            max_prefetch = 30_000
             for item in relevant:
-                label = f"[{item['kind']}] {item['name']}"
-                parts.append(f"## {label}")
+                section = f"## [{item['kind']}] {item['name']}\n\n{item['content']}"
+                if prefetch_chars + len(section) > max_prefetch:
+                    break
+                prefetch_parts.append(section)
+                prefetch_chars += len(section)
+            if prefetch_parts:
+                parts.append("# Likely Relevant Context")
                 parts.append("")
-                parts.append(item["content"])
+                parts.extend(prefetch_parts)
                 parts.append("")
 
     parts.extend([

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -8,8 +8,11 @@ SSE event types emitted:
   conversation_id  — new/existing conversation ID
   text             — streamed assistant text
   tool_start       — tool call beginning  {tool, tool_use_id}
-  tool_args        — tool call arguments  {tool, tool_use_id, args}
+  tool_args        — tool call arguments  {tool, tool_use_id, args, description}
   tool_end         — tool result          {tool, tool_use_id, result, elapsed_ms}
+  confirm          — write tool needs approval {tool, args, tool_use_id, description}
+  plan_ready       — plan mode completed  {plan_text, status}
+  usage            — token usage          {input_tokens, output_tokens, context_window}
   title_update     — AI-generated title   {title, conversation_id}
   done             — stream complete
   error            — error message
@@ -66,6 +69,51 @@ When you see a message containing "[KNOWLEDGE CHECKPOINT]", you MUST:
 4. Briefly confirm what you saved (1-2 sentences max), then continue naturally
 
 If there is genuinely nothing new to save, say so in one sentence and move on."""
+
+
+def _improve_instructions(config: AgentConfig) -> str:
+    """Return system prompt for knowledge improvement mode."""
+    return f"""# Instructions — Knowledge Improvement Mode
+
+You are {config.agent_name} in **Improve Mode**. Your goal is to strengthen your knowledge base — not learn from scratch, but fill gaps, fix stale info, and deepen thin coverage.
+
+## Procedure
+
+1. **Read all your context files** — list_context_files, then read each one.
+2. **Identify the weakest spots:**
+   - Thin files (< 3 meaningful lines)
+   - Stale info (hasn't been updated, may be outdated)
+   - Missing topics (things you should know but don't have a file for)
+   - Contradictions or duplicates
+3. **Rank by impact** — which gap, if filled, would help you most in daily work?
+4. **Suggest the highest-impact area** to the user and ask focused questions about it.
+5. **Save incrementally** — after each answer, update the relevant file immediately.
+6. **Repeat** — move to the next gap until the user exits.
+
+## Rules
+- Always save with `write_context_file` or `append_to_context_file` — never narrate without saving.
+- Don't re-ask things you already know. Reference existing knowledge.
+- One topic at a time. Go deep, not wide.
+- If the user wants to talk about something else, go with it — save what you learn."""
+
+
+def _plan_mode_instructions() -> str:
+    """Return system prompt addendum for plan mode."""
+    return """# Plan Mode — Active
+
+You are in Plan Mode. Investigate the user's request thoroughly before proposing changes.
+
+## Rules
+1. **Read before writing.** Use read-only tools to gather information.
+2. **Think step by step.** Understand the full picture before acting.
+3. **Present a structured plan** when you're ready:
+   - What you'll do (numbered steps)
+   - What files/data you'll modify
+   - Any risks or considerations
+4. When your plan is complete, call `exit_plan_mode` with the plan text.
+5. Do NOT execute changes until the user approves the plan.
+
+You are operating in read-only mode — write tools are disabled until the plan is approved."""
 
 
 def _training_instructions(config: AgentConfig) -> str:
@@ -148,13 +196,16 @@ def _build_system_prompt(
     config: AgentConfig,
     ctx_manager: ContextManager,
     training_mode: bool = False,
+    training_type: str | None = None,
+    plan_mode: bool = False,
+    first_user_message: str = "",
 ) -> str:
     """Assemble the full system prompt."""
     now_ct = datetime.now(CT_TZ)
     date_str = now_ct.strftime("%A, %B %d, %Y")
     time_str = now_ct.strftime("%I:%M %p CT")
 
-    context = ctx_manager.load_all_context()
+    context = ctx_manager.load_all_context(agent_name=config.agent_name)
 
     personality = config.personality or (
         f"You are {config.agent_name}, a helpful personal AI assistant."
@@ -170,15 +221,78 @@ def _build_system_prompt(
         "",
         context if context else "(No knowledge files yet. Create them using write_context_file.)",
         "",
+    ]
+
+    # Daily notes — inject today's note if it exists
+    today_note = ctx_manager.today_daily_note_text()
+    if today_note:
+        parts.extend([
+            "# Today's Daily Note",
+            "",
+            today_note,
+            "",
+        ])
+
+    # Daily notes manifest — recent days for reference
+    daily_manifest = ctx_manager.daily_notes_manifest(limit=30)
+    if daily_manifest:
+        parts.extend([
+            "# Recent Daily Notes",
+            "",
+            daily_manifest,
+            "",
+        ])
+
+    # Topic files manifest
+    topic_manifest = ctx_manager.topic_files_manifest()
+    if topic_manifest:
+        parts.extend([
+            "# Topic Files",
+            "",
+            topic_manifest,
+            "",
+        ])
+
+    # Shared context manifest
+    try:
+        from core.agents.shared_context.service import get_shared_manifest
+        shared_manifest = get_shared_manifest()
+        if shared_manifest:
+            parts.extend([
+                "# Shared Knowledge (visible to all agents)",
+                "",
+                shared_manifest,
+                "",
+            ])
+    except Exception:
+        pass
+
+    # Relevance pre-fetch — on first message, inject relevant context
+    if first_user_message:
+        relevant = ctx_manager.relevance_prefetch(first_user_message)
+        if relevant:
+            parts.append("# Likely Relevant Context")
+            parts.append("")
+            for item in relevant:
+                label = f"[{item['kind']}] {item['name']}"
+                parts.append(f"## {label}")
+                parts.append("")
+                parts.append(item["content"])
+                parts.append("")
+
+    parts.extend([
         "# Current Session",
         "",
         f"- Date: {date_str}",
         f"- Time: {time_str}",
         "",
-    ]
+    ])
 
     if training_mode:
-        parts.append(_training_instructions(config))
+        if training_type == "improve":
+            parts.append(_improve_instructions(config))
+        else:
+            parts.append(_training_instructions(config))
     else:
         parts.extend([
             "# Instructions",
@@ -191,6 +305,7 @@ def _build_system_prompt(
             "",
         ])
         parts.append(_knowledge_management_instructions())
+        parts.append(_memory_instructions())
         parts.append(get_report_instructions())
         parts.append(get_scheduling_instructions())
 
@@ -199,7 +314,28 @@ def _build_system_prompt(
         if _integration_enabled("qb_csv"):
             parts.append(get_qb_csv_instructions())
 
+    if plan_mode:
+        parts.append(_plan_mode_instructions())
+
     return "\n".join(parts)
+
+
+def _memory_instructions() -> str:
+    """Instructions for using the memory system (daily notes, MEMORY.md, search)."""
+    return """## Memory System
+
+You have a structured memory system beyond basic context files:
+
+- **Daily Notes** — Use `append_daily_note` to log significant events, decisions, and information as they happen. Each entry is timestamped automatically. Optionally tag entries with a type (decision, person, task, etc.).
+- **MEMORY.md** — Your living snapshot of key facts. Read with `read_memory`, update with `update_memory`. This file is automatically regenerated nightly from your daily notes.
+- **Search** — Use `search_memory` to find information across all your files, daily notes, and facts.
+- **Facts** — Use `add_fact` to record structured entity-relationship facts (e.g. "John Smith works at Acme Corp"). Query with `query_facts`.
+- **Shared Context** — Use `list_shared_context` / `read_shared_context` / `write_shared_context` to access knowledge shared across all agents.
+
+Guidelines:
+- Log important events and decisions to daily notes as they happen
+- Use search_memory before saying "I don't know" — you might have recorded it
+- When you learn structured facts (people, relationships, dates), use add_fact"""
 
 
 # ── Background GCS sync ────────────────────────────────────────────────────────
@@ -288,6 +424,8 @@ async def chat(
     ctx_manager: ContextManager,
     messages: list[dict],
     training_mode: bool = False,
+    training_type: str | None = None,
+    plan_mode: bool = False,
     conversation_id: str | None = None,
     chat_service=None,
     anthropic_api_key: str = "",
@@ -306,6 +444,8 @@ async def chat(
         ctx_manager: Context file manager
         messages: Full conversation history
         training_mode: If True, injects onboarding system prompt
+        training_type: 'topic' (default training) or 'improve' (knowledge refinement)
+        plan_mode: If True, forces read-only mode and injects plan instructions
         conversation_id: Existing conversation ID (None to create new)
         chat_service: Optional ChatHistoryService for persistence
         anthropic_api_key: For smart title generation (uses haiku, optional)
@@ -320,6 +460,11 @@ async def chat(
     # Training mode forces power (no confirmations needed during onboarding)
     if training_mode:
         tool_mode = "power"
+
+    # Plan mode forces read-only
+    if plan_mode:
+        tool_mode = "read-only"
+
     persist = not training_mode and chat_service is not None
 
     # ── Get tool definitions ──────────────────────────────────────────
@@ -383,8 +528,41 @@ async def chat(
                     "content": last.get("content", "") + "\n\n[KNOWLEDGE CHECKPOINT]",
                 }
 
+    # ── Plan mode: add virtual exit_plan_mode tool ──────────────────
+    if plan_mode:
+        exit_plan_tool = {
+            "name": "exit_plan_mode",
+            "description": "Call this when your investigation is complete and you have a structured plan to present. Include the full plan as the 'plan' argument.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "plan": {
+                        "type": "string",
+                        "description": "The full structured plan in markdown format",
+                    },
+                },
+                "required": ["plan"],
+            },
+            "kind": "plan",
+            "writes": False,
+        }
+        tool_defs.append(exit_plan_tool)
+        kind_map["exit_plan_mode"] = "plan"
+
     # ── Build system prompt ───────────────────────────────────────────
-    system_prompt = _build_system_prompt(config, ctx_manager, training_mode=training_mode)
+    # Determine first user message for relevance pre-fetch
+    first_user_msg = ""
+    user_msgs = [m for m in messages if m.get("role") == "user"]
+    if len(user_msgs) == 1:
+        first_user_msg = user_msgs[0].get("content", "")
+
+    system_prompt = _build_system_prompt(
+        config, ctx_manager,
+        training_mode=training_mode,
+        training_type=training_type,
+        plan_mode=plan_mode,
+        first_user_message=first_user_msg,
+    )
 
     # Append integration-specific instructions
     if integration_tool_defs:
@@ -481,16 +659,32 @@ async def chat(
                 })
 
             elif etype == "tool_args":
+                tool_name_for_desc = event["tool"]
+                tool_desc = next(
+                    (t.get("description", "") for t in tool_defs if t["name"] == tool_name_for_desc),
+                    "",
+                )
                 yield _sse({
                     "type": "tool_args",
                     "tool": event["tool"],
                     "tool_use_id": event["tool_use_id"],
                     "args": event.get("args", {}),
+                    "description": tool_desc,
                 })
 
             elif etype == "_turn_complete":
                 tool_calls_this_turn = event.get("tool_calls", [])
                 stop_reason = event.get("stop_reason", "stop")
+
+                # Emit usage event
+                usage = event.get("usage", {})
+                if usage:
+                    yield _sse({
+                        "type": "usage",
+                        "input_tokens": usage.get("input_tokens", 0),
+                        "output_tokens": usage.get("output_tokens", 0),
+                        "context_window": 200000,  # Default context window
+                    })
 
                 # Save assistant turn to history
                 if persist and turn_text and conversation_id:
@@ -535,6 +729,32 @@ async def chat(
             tool_use_id = tc.get("id", "")
             tool_args = tc.get("args", {})
             kind = kind_map.get(tool_name, "context")
+
+            # ── Plan mode: intercept exit_plan_mode ──
+            if tool_name == "exit_plan_mode" and plan_mode:
+                plan_text = tool_args.get("plan", "")
+                yield _sse({
+                    "type": "plan_ready",
+                    "plan_text": plan_text,
+                    "status": "pending",
+                })
+                # Feed a result back so provider can wrap up
+                results.append({
+                    "tool_use_id": tool_use_id,
+                    "tool_name": tool_name,
+                    "content": json.dumps({"ok": True, "message": "Plan presented to user for approval."}),
+                })
+                # Let the AI do one more turn to narrate, then stop
+                current_messages = provider.add_tool_results(current_messages, tool_calls_this_turn, results)
+                async for event in provider.stream_turn(current_messages, provider_tools, system_prompt):
+                    etype = event.get("type")
+                    if etype == "text":
+                        accumulated_text += event["text"]
+                        yield _sse({"type": "text", "text": event["text"]})
+                    elif etype == "_turn_complete":
+                        break
+                yield _sse({"type": "done"})
+                return
 
             # ── Normal mode: intercept write tools (not context_memory) ──
             is_write = writes_map.get(tool_name, False)

--- a/backend/core/agents/chat_history/service.py
+++ b/backend/core/agents/chat_history/service.py
@@ -113,6 +113,23 @@ class ChatHistoryService:
             )
             db.commit()
 
+    def get_messages_on_date(self, date: str) -> list[dict]:
+        """Return all messages from a given date (YYYY-MM-DD), ordered by conversation then sequence.
+
+        Each row includes conversation_id, conversation_title, role, content.
+        Used by the daily note summarization job.
+        """
+        db = self._db.get_db()
+        rows = db.execute(
+            """SELECT m.conversation_id, c.title AS conversation_title, m.role, m.content
+               FROM messages m
+               JOIN conversations c ON c.id = m.conversation_id
+               WHERE DATE(m.created_at) = ?
+               ORDER BY m.conversation_id, m.seq""",
+            (date,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
     def search_conversations(self, query: str, limit: int = 20) -> list[dict]:
         """Search message content (case-insensitive), return matching conversations with snippets."""
         db = self._db.get_db()

--- a/backend/core/agents/config.py
+++ b/backend/core/agents/config.py
@@ -30,6 +30,9 @@ class AgentConfig:
     # Context directory (absolute path)
     context_dir: str = ""
 
+    # GCS prefix for this agent's data
+    gcs_prefix: str = ""
+
     # Chat history DB path (absolute path)
     chat_db_path: str = ""
 

--- a/backend/core/agents/context_manager.py
+++ b/backend/core/agents/context_manager.py
@@ -1,19 +1,97 @@
-"""
-Chatty — Context file manager.
+"""Chatty — Context file manager.
 
 Manages a directory of markdown context files that form an agent's long-term memory.
 All .md files in data_dir are loaded into the system prompt.
 """
 
+import json
 import logging
+import re
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from core.storage import upload_config, delete_config
 
 logger = logging.getLogger(__name__)
 
-# Cap total context injected into system prompt (characters, ~50k tokens)
+# Cap total context injected into system prompt (characters, ~50k tokens).
+# Last-resort circuit breaker so a runaway file can't produce a multi-megabyte
+# prompt; normal flow never hits this.
 MAX_CONTEXT_CHARS = 200_000
+
+CT_TZ = ZoneInfo("America/Chicago")
+
+# English stopwords for the relevance pre-fetch scorer. Deliberately small —
+# we want a cheap, directional match signal, not a full NLP pipeline.
+_STOPWORDS = {
+    "a", "an", "the", "and", "or", "but", "if", "of", "in", "on", "at", "to",
+    "for", "with", "by", "from", "as", "is", "are", "was", "were", "be", "been",
+    "being", "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "can", "i", "you", "he", "she", "it", "we", "they",
+    "me", "him", "her", "us", "them", "my", "your", "his", "its", "our", "their",
+    "this", "that", "these", "those", "there", "here", "what", "which", "who",
+    "whom", "whose", "when", "where", "why", "how", "not", "no", "yes", "so",
+    "than", "then", "too", "very", "just", "about", "into", "over", "up", "down",
+    "out", "off", "any", "all", "some", "each", "more", "most", "other", "such",
+    "own", "same", "s", "t", "don", "now", "re", "ve", "ll", "d", "m",
+}
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase, split on non-alphanumerics, strip stopwords and 1-char tokens."""
+    if not text:
+        return []
+    return [
+        t for t in _TOKEN_RE.findall(text.lower())
+        if len(t) > 1 and t not in _STOPWORDS
+    ]
+
+
+_DATE_HEADING_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_TIME_HEADING_RE = re.compile(r"^\d{1,2}:\d{2}\s*(am|pm)?", re.IGNORECASE)
+
+
+def _first_headline(content: str) -> str:
+    """Return a short headline for a markdown file.
+
+    Preference order:
+      1. A line starting with "Headline:" (used by the nightly daily-note
+         summarizer to stamp each day with a one-line recap).
+      2. The first heading that isn't just a date or timestamp.
+      3. The first non-empty body line.
+
+    Strips leading '#' characters and whitespace. Returns at most ~120 chars.
+    """
+    if not content:
+        return ""
+    heading_fallback = ""
+    text_fallback = ""
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("---"):
+            continue
+        if line.lower().startswith("headline:"):
+            headline = line.split(":", 1)[1].strip()
+            if headline:
+                return headline[:120]
+        if line.startswith("#"):
+            stripped = line.lstrip("#").strip()
+            if not stripped:
+                continue
+            # Skip date / timestamp headings — they're useless as summaries
+            if _DATE_HEADING_RE.match(stripped) or _TIME_HEADING_RE.match(stripped):
+                continue
+            if not heading_fallback:
+                heading_fallback = stripped[:120]
+            continue
+        if not text_fallback:
+            text_fallback = line[:120]
+    return heading_fallback or text_fallback
 
 
 class ContextManager:
@@ -21,23 +99,62 @@ class ContextManager:
 
     def __init__(self, data_dir: Path, gcs_prefix: str):
         self.data_dir = data_dir
+        self.tools_dir = data_dir / "tools"
+        self.daily_dir = data_dir / "daily"
         self.gcs_prefix = gcs_prefix
 
     def ensure_dir(self):
         """Create the data directory if it doesn't exist."""
         self.data_dir.mkdir(parents=True, exist_ok=True)
 
-    def load_all_context(self) -> str:
+    def ensure_daily_dir(self):
+        """Create the daily notes subdirectory if it doesn't exist."""
+        self.daily_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_sorted_files(self) -> list[Path]:
+        """Return .md files sorted by dreaming priority, then default rules.
+
+        soul.md is pinned to position 1, MEMORY.md to position 2 (the agent's
+        living snapshot, always loaded right after identity). Everything else
+        follows dreaming priority, then alphabetical.
+        """
+        self.ensure_dir()
+
+        # Check for dreaming-generated load order
+        order_file = self.data_dir / "_load-order.json"
+        priority: dict[str, int] = {}
+        if order_file.exists():
+            try:
+                order = json.loads(order_file.read_text(encoding="utf-8"))
+                priority = {name: i for i, name in enumerate(order)}
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        return sorted(
+            self.data_dir.glob("*.md"),
+            key=lambda f: (
+                f.name != "soul.md",           # soul.md always first
+                f.name != "MEMORY.md",          # MEMORY.md pinned second
+                f.name.startswith("_"),         # underscore files last
+                priority.get(f.name, 999),      # dreaming priority
+                f.name,                         # alpha fallback
+            ),
+        )
+
+    def load_all_context(self, agent_name: str | None = None) -> str:
         """Load all .md files and concatenate them with headers. Used for system prompt.
 
         Enforces MAX_CONTEXT_CHARS to prevent prompt bloat. soul.md is loaded first
         as the agent's identity anchor. Files starting with '_' (like
         _training-progress.md) are loaded last so operational files take priority.
+
+        If agent_name is provided, records load/truncation events for the dreaming system.
         """
-        self.ensure_dir()
-        files = sorted(self.data_dir.glob("*.md"), key=lambda f: (f.name.startswith("_"), f.name))
+        files = self._get_sorted_files()
         parts = []
         total = 0
+        loaded_files: list[str] = []
+        truncated_files: list[str] = []
 
         # Load soul.md first for identity prominence
         soul_file = self.data_dir / "soul.md"
@@ -47,10 +164,26 @@ class ContextManager:
                 section = f"## soul\n\n{soul_content}"
                 parts.append(section)
                 total += len(section)
+                loaded_files.append("soul.md")
 
+        # Load MEMORY.md second — the living snapshot. Always included if it
+        # exists with content; no size gate (consolidation keeps it tight).
+        memory_file = self.data_dir / "MEMORY.md"
+        if memory_file.exists():
+            memory_content = memory_file.read_text(encoding="utf-8").strip()
+            if memory_content:
+                section = f"## MEMORY\n\n{memory_content}"
+                parts.append(section)
+                total += len(section)
+                loaded_files.append("MEMORY.md")
+
+        truncated = False
         for f in files:
-            if f.name == "soul.md":
+            if f.name == "soul.md" or f.name == "MEMORY.md":
                 continue  # already loaded above
+            if truncated:
+                truncated_files.append(f.name)
+                continue
             content = f.read_text(encoding="utf-8").strip()
             if not content:
                 continue
@@ -58,9 +191,20 @@ class ContextManager:
             if total + len(section) > MAX_CONTEXT_CHARS:
                 parts.append(f"## {f.stem}\n\n(Truncated — context size limit reached)")
                 logger.warning("Context size limit reached at %s (%d chars)", f.name, total)
-                break
+                truncated_files.append(f.name)
+                truncated = True
+                continue
             parts.append(section)
             total += len(section)
+            loaded_files.append(f.name)
+
+        # Record load events for dreaming (fire-and-forget)
+        if agent_name and (loaded_files or truncated_files):
+            try:
+                from core.agents.dreaming.tracker import record_load_events
+                record_load_events(agent_name, loaded_files, truncated_files)
+            except Exception:
+                pass
 
         return "\n\n---\n\n".join(parts) if parts else ""
 
@@ -101,3 +245,271 @@ class ContextManager:
         delete_config(filename, prefix=self.gcs_prefix)
         logger.info("Context file deleted and synced: %s", filename)
         return True
+
+    # ------------------------------------------------------------------
+    # MEMORY.md — living snapshot helpers
+    # ------------------------------------------------------------------
+
+    def read_memory(self) -> str:
+        """Return MEMORY.md contents (empty string if not yet created)."""
+        path = self.data_dir / "MEMORY.md"
+        if not path.exists():
+            return ""
+        return path.read_text(encoding="utf-8")
+
+    def write_memory(self, content: str) -> None:
+        """Write MEMORY.md and sync to GCS. No size enforcement — the
+        consolidation LLM prompt is responsible for keeping it tight.
+        """
+        self.write_context("MEMORY.md", content)
+
+    # ------------------------------------------------------------------
+    # Daily notes — per-day running log
+    # ------------------------------------------------------------------
+
+    def _today_str(self) -> str:
+        return datetime.now(CT_TZ).strftime("%Y-%m-%d")
+
+    def _daily_path(self, date: str) -> Path:
+        return self.daily_dir / f"{date}.md"
+
+    def append_daily_note(self, content: str, date: str | None = None) -> dict:
+        """Append a timestamped entry to the given day's daily note.
+
+        Creates the file (and the daily/ dir) if missing. Syncs the changed
+        file to GCS under `daily/YYYY-MM-DD.md`.
+        """
+        self.ensure_daily_dir()
+        date = date or self._today_str()
+        path = self._daily_path(date)
+
+        now = datetime.now(CT_TZ)
+        # %I is zero-padded across platforms; strip leading 0 manually for readability
+        stamp = now.strftime("%I:%M %p CT").lstrip("0")
+
+        body = (content or "").strip()
+        entry = f"\n### {stamp}\n\n{body}\n" if body else ""
+        if not entry:
+            return {"date": date, "ok": False, "error": "empty content"}
+
+        if path.exists():
+            existing = path.read_text(encoding="utf-8")
+            new_content = existing.rstrip() + "\n" + entry
+        else:
+            new_content = f"# {date}\n{entry}"
+
+        path.write_text(new_content, encoding="utf-8")
+        try:
+            upload_config(path, f"daily/{date}.md", prefix=self.gcs_prefix)
+        except Exception:
+            logger.warning("GCS upload failed for daily/%s.md", date, exc_info=True)
+        logger.info("Daily note appended: %s", date)
+        return {"date": date, "ok": True}
+
+    def read_daily_note(self, date: str) -> str:
+        """Return the full content of a daily note (empty string if missing)."""
+        path = self._daily_path(date)
+        if not path.exists():
+            return ""
+        return path.read_text(encoding="utf-8")
+
+    def today_daily_note_text(self) -> str:
+        """Return today's daily note, or empty string if no entries yet today."""
+        return self.read_daily_note(self._today_str())
+
+    def list_daily_notes(self, limit: int = 30) -> list[dict]:
+        """List recent daily notes, newest first."""
+        self.ensure_daily_dir()
+        entries: list[dict] = []
+        for f in sorted(self.daily_dir.glob("*.md"), reverse=True):
+            date = f.stem
+            content = f.read_text(encoding="utf-8")
+            stat = f.stat()
+            entries.append({
+                "name": f.name,
+                "date": date,
+                "headline": _first_headline(content),
+                "size_bytes": stat.st_size,
+                "modified": stat.st_mtime,
+            })
+            if len(entries) >= limit:
+                break
+        return entries
+
+    def daily_notes_manifest(self, limit: int = 30) -> str:
+        """Render the recent-daily-notes manifest for system prompt injection.
+
+        One line per day: `- 2026-04-10 · <headline>`. Returns empty string
+        if there are no daily notes yet.
+        """
+        entries = self.list_daily_notes(limit=limit)
+        if not entries:
+            return ""
+        lines = []
+        today = self._today_str()
+        for e in entries:
+            # Don't list today in the manifest — today's full content is
+            # already injected elsewhere in the prompt.
+            if e["date"] == today:
+                continue
+            headline = e["headline"] or "(no summary yet)"
+            lines.append(f"- {e['date']} · {headline}")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Daily note retention — archive old notes
+    # ------------------------------------------------------------------
+
+    def archive_old_daily_notes(self, max_age_days: int = 90) -> dict:
+        """Move daily notes older than *max_age_days* to daily/archive/.
+
+        Archived notes are excluded from manifests and pre-fetch but remain
+        on disk (and in FTS5) so ``search_memory`` still finds them.
+        Returns ``{"archived": N}``.
+        """
+        self.ensure_daily_dir()
+        archive_dir = self.daily_dir / "archive"
+        today = datetime.now(CT_TZ).date()
+        count = 0
+        for f in sorted(self.daily_dir.glob("*.md")):
+            try:
+                note_date = datetime.strptime(f.stem, "%Y-%m-%d").date()
+            except ValueError:
+                continue
+            if (today - note_date).days > max_age_days:
+                archive_dir.mkdir(parents=True, exist_ok=True)
+                dest = archive_dir / f.name
+                f.rename(dest)
+                count += 1
+        if count:
+            logger.info("Archived %d daily notes older than %d days", count, max_age_days)
+        return {"archived": count}
+
+    # ------------------------------------------------------------------
+    # Topic files manifest
+    # ------------------------------------------------------------------
+
+    def _manifest_topic_files(self) -> list[Path]:
+        """Return topic files eligible for the manifest: *.md files that are
+        not soul.md, not MEMORY.md, and not underscore-prefixed internals.
+        """
+        self.ensure_dir()
+        result = []
+        for f in sorted(self.data_dir.glob("*.md")):
+            if f.name in ("soul.md", "MEMORY.md"):
+                continue
+            if f.name.startswith("_"):
+                continue
+            result.append(f)
+        return result
+
+    def topic_files_manifest(self) -> str:
+        """Render the topic files manifest for system prompt injection.
+
+        One line per non-always-loaded markdown file:
+        `- filename.md · <headline or filename stem> · YYYY-MM-DD`
+        """
+        files = self._manifest_topic_files()
+        if not files:
+            return ""
+        lines = []
+        for f in files:
+            try:
+                content = f.read_text(encoding="utf-8")
+            except Exception:
+                content = ""
+            headline = _first_headline(content) or f.stem.replace("-", " ")
+            modified = datetime.fromtimestamp(f.stat().st_mtime).strftime("%Y-%m-%d")
+            lines.append(f"- {f.name} · {headline} · {modified}")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Relevance pre-fetch — simple BM25-lite scorer over topic files +
+    # recent daily notes. Returns every file whose score crosses the
+    # match threshold; no fixed top-K, no content truncation.
+    # ------------------------------------------------------------------
+
+    def relevance_prefetch(self, first_user_message: str) -> list[dict]:
+        """Score topic files and recent daily notes against the user message.
+
+        Returns a list of `{"kind": "topic"|"daily", "name": str, "content": str}`
+        for every file whose match score exceeds 0. Caller injects them
+        fully (no truncation) into the system prompt under a "likely
+        relevant" block.
+        """
+        query_tokens = _tokenize(first_user_message)
+        if not query_tokens:
+            return []
+        query_set = set(query_tokens)
+
+        results: list[tuple[float, dict]] = []
+
+        # Topic files
+        for f in self._manifest_topic_files():
+            try:
+                content = f.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            score = _score_match(
+                query_set,
+                name=f.name,
+                headline=_first_headline(content),
+                body=content,
+            )
+            if score > 0:
+                results.append((score, {
+                    "kind": "topic",
+                    "name": f.name,
+                    "content": content,
+                }))
+
+        # Recent daily notes (last ~30), skipping today (already loaded)
+        today = self._today_str()
+        for entry in self.list_daily_notes(limit=30):
+            if entry["date"] == today:
+                continue
+            content = self.read_daily_note(entry["date"])
+            if not content:
+                continue
+            score = _score_match(
+                query_set,
+                name=entry["name"],
+                headline=entry["headline"],
+                body=content,
+            )
+            if score > 0:
+                results.append((score, {
+                    "kind": "daily",
+                    "name": entry["date"],
+                    "content": content,
+                }))
+
+        # Sort by score descending, no truncation
+        results.sort(key=lambda pair: pair[0], reverse=True)
+        return [item for _, item in results]
+
+
+def _score_match(query_tokens: set[str], *, name: str, headline: str, body: str) -> float:
+    """BM25-lite relevance score. Filename and headline hits are weighted
+    heavier than body hits because they're stronger topic signals.
+    """
+    if not query_tokens:
+        return 0.0
+    name_tokens = set(_tokenize(name))
+    headline_tokens = set(_tokenize(headline))
+    body_tokens = _tokenize(body)
+    body_set = set(body_tokens)
+
+    score = 0.0
+    # Filename overlap: strong signal
+    score += 5.0 * len(query_tokens & name_tokens)
+    # Headline overlap: strong signal
+    score += 3.0 * len(query_tokens & headline_tokens)
+    # Body overlap: presence signal + frequency bonus
+    body_hits = query_tokens & body_set
+    score += 1.0 * len(body_hits)
+    if body_hits and body_tokens:
+        # Small frequency bonus, diminishing returns
+        freq = sum(body_tokens.count(t) for t in body_hits)
+        score += min(freq * 0.05, 2.0)
+    return score

--- a/backend/core/agents/dreaming/__init__.py
+++ b/backend/core/agents/dreaming/__init__.py
@@ -1,0 +1,1 @@
+"""Dreaming — Context usage tracking and automated memory consolidation."""

--- a/backend/core/agents/dreaming/processor.py
+++ b/backend/core/agents/dreaming/processor.py
@@ -1,0 +1,112 @@
+"""Dreaming processor — automated context consolidation.
+
+Runs daily as a scheduled action. Pure Python (no Claude calls).
+Archives dormant files and reorders context loading priority.
+"""
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+from core.agents.context_manager import ContextManager
+from core.agents.reminders import db
+from . import scorer
+
+logger = logging.getLogger(__name__)
+
+# Files that should never be archived
+PROTECTED_FILES = {"soul.md", "MEMORY.md", "_training-progress.md"}
+
+
+def process_dreaming(agent_name: str, ctx_manager: ContextManager) -> dict:
+    """Run the dreaming cycle for an agent. Returns a summary."""
+    start = time.monotonic()
+    data_dir = ctx_manager.data_dir
+    gcs_prefix = ctx_manager.gcs_prefix
+
+    scores = scorer.score_context_files(agent_name, data_dir)
+    archived = []
+    load_order_changed = False
+
+    # 1. Archive dormant files (score < 0.1, not protected)
+    for item in scores:
+        if item["classification"] != "dormant":
+            continue
+        fname = item["filename"]
+        if fname in PROTECTED_FILES:
+            continue
+        src = data_dir / fname
+        dst = data_dir / f"_archived-{fname}"
+        if src.exists() and not dst.exists():
+            try:
+                src.rename(dst)
+                # Sync: upload archived, delete original from GCS
+                from core.storage import upload_file, delete_config
+                upload_file(dst, f"{gcs_prefix}_archived-{fname}")
+                delete_config(fname, prefix=gcs_prefix)
+                archived.append(fname)
+                logger.info("Dreaming archived %s/%s (score=%.3f)", agent_name, fname, item["score"])
+            except Exception as e:
+                logger.warning("Failed to archive %s/%s: %s", agent_name, fname, e)
+
+    # 2. Update load order (_load-order.json)
+    active_files = [
+        item["filename"]
+        for item in scores
+        if item["classification"] in ("active", "stale")
+        and item["filename"] not in archived
+        and not item["filename"].startswith("_")
+        and item["filename"] != "soul.md"
+    ]
+
+    order_file = data_dir / "_load-order.json"
+    old_order = []
+    if order_file.exists():
+        try:
+            old_order = json.loads(order_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    if active_files != old_order:
+        try:
+            order_file.write_text(json.dumps(active_files, indent=2), encoding="utf-8")
+            from core.storage import upload_file
+            upload_file(order_file, f"{gcs_prefix}_load-order.json")
+            load_order_changed = True
+        except Exception as e:
+            logger.warning("Failed to write _load-order.json for %s: %s", agent_name, e)
+
+    # 3. Record the run
+    duration_ms = int((time.monotonic() - start) * 1000)
+    details = json.dumps({
+        "scores": scores[:10],  # Top 10 for storage
+        "archived": archived,
+    })
+
+    try:
+        conn = db.get_db()
+        with db.write_lock():
+            conn.execute(
+                """INSERT INTO dreaming_runs
+                   (agent, files_scored, files_archived, load_order_changed, details, duration_ms)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (agent_name, len(scores), len(archived), 1 if load_order_changed else 0, details, duration_ms),
+            )
+            conn.commit()
+    except Exception as e:
+        logger.warning("Failed to record dreaming run for %s: %s", agent_name, e)
+
+    summary = {
+        "agent": agent_name,
+        "files_scored": len(scores),
+        "files_archived": len(archived),
+        "archived": archived,
+        "load_order_changed": load_order_changed,
+        "duration_ms": duration_ms,
+    }
+    logger.info(
+        "Dreaming %s: scored=%d, archived=%d, reorder=%s (%dms)",
+        agent_name, len(scores), len(archived), load_order_changed, duration_ms,
+    )
+    return summary

--- a/backend/core/agents/dreaming/scorer.py
+++ b/backend/core/agents/dreaming/scorer.py
@@ -1,0 +1,103 @@
+"""Dreaming scorer — ranks context files by usage signals.
+
+Uses weighted signals (write recency, write frequency, mention frequency,
+load rate, file age) to determine which files are most valuable to an agent.
+"""
+
+import math
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import tracker
+
+logger = logging.getLogger(__name__)
+
+# Signal weights (sum to 1.0)
+WEIGHT_WRITE_RECENCY = 0.30
+WEIGHT_WRITE_FREQUENCY = 0.25
+WEIGHT_MENTION_FREQUENCY = 0.20
+WEIGHT_LOAD_RATE = 0.15
+WEIGHT_FILE_AGE = 0.10
+
+# Thresholds
+ARCHIVE_THRESHOLD = 0.1   # Below this = dormant
+STALE_THRESHOLD = 0.4     # Below this = stale
+HALF_LIFE_DAYS = 14.0     # Recency decay
+
+
+def score_context_files(agent: str, data_dir: Path, days: int = 30) -> list[dict]:
+    """Score all context files for an agent by usage signals.
+
+    Returns list of {filename, score, classification, signals} sorted by score DESC.
+    Classification: 'active' (>0.4), 'stale' (0.1-0.4), 'dormant' (<0.1).
+    """
+    usage_data = tracker.get_file_scores(agent, days=days)
+    usage_by_file = {d["filename"]: d for d in usage_data}
+
+    now = datetime.now(timezone.utc)
+    results = []
+
+    for f in sorted(data_dir.glob("*.md")):
+        if f.name.startswith("_") and f.name != "_training-progress.md":
+            continue  # Skip already-archived files
+
+        usage = usage_by_file.get(f.name, {})
+        writes = usage.get("write", 0) + usage.get("append", 0)
+        mentions = usage.get("mentioned_in_response", 0)
+        loaded = usage.get("loaded", 0)
+        truncated = usage.get("truncated", 0)
+
+        # Signal 1: Write recency (exponential decay)
+        file_mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc)
+        days_since_write = (now - file_mtime).total_seconds() / 86400
+        lam = math.log(2) / HALF_LIFE_DAYS
+        write_recency = math.exp(-lam * days_since_write)
+
+        # Signal 2: Write frequency
+        write_freq = math.log1p(writes) / math.log1p(10)
+
+        # Signal 3: Mention frequency
+        mention_freq = math.log1p(mentions) / math.log1p(10)
+
+        # Signal 4: Load rate (1.0 if never truncated)
+        total_loads = loaded + truncated
+        load_rate = loaded / total_loads if total_loads > 0 else 1.0
+
+        # Signal 5: File age (newer = small boost)
+        file_ctime = datetime.fromtimestamp(f.stat().st_ctime, tz=timezone.utc)
+        days_old = (now - file_ctime).total_seconds() / 86400
+        file_age_score = 1.0 - min(days_old / 90, 1.0)
+
+        # Weighted score
+        score = (
+            WEIGHT_WRITE_RECENCY * write_recency
+            + WEIGHT_WRITE_FREQUENCY * write_freq
+            + WEIGHT_MENTION_FREQUENCY * mention_freq
+            + WEIGHT_LOAD_RATE * load_rate
+            + WEIGHT_FILE_AGE * file_age_score
+        )
+
+        # Classify
+        if score >= STALE_THRESHOLD:
+            classification = "active"
+        elif score >= ARCHIVE_THRESHOLD:
+            classification = "stale"
+        else:
+            classification = "dormant"
+
+        results.append({
+            "filename": f.name,
+            "score": round(score, 3),
+            "classification": classification,
+            "signals": {
+                "write_recency": round(write_recency, 3),
+                "write_frequency": round(write_freq, 3),
+                "mention_frequency": round(mention_freq, 3),
+                "load_rate": round(load_rate, 3),
+                "file_age": round(file_age_score, 3),
+            },
+        })
+
+    results.sort(key=lambda r: r["score"], reverse=True)
+    return results

--- a/backend/core/agents/dreaming/tracker.py
+++ b/backend/core/agents/dreaming/tracker.py
@@ -1,0 +1,97 @@
+"""Context usage tracker — records which knowledge files agents interact with.
+
+Signals are used by the dreaming scorer to determine file value and
+prioritize context loading order.
+"""
+
+import logging
+from datetime import datetime, timezone, timedelta
+
+from core.agents.reminders import db
+
+logger = logging.getLogger(__name__)
+
+
+def record_context_event(
+    agent: str,
+    filename: str,
+    event_type: str,
+    source: str = "chat",
+    conversation_id: str | None = None,
+) -> None:
+    """Record a context usage event. Fire-and-forget — never raises."""
+    try:
+        conn = db.get_db()
+        with db.write_lock():
+            conn.execute(
+                """INSERT INTO context_usage (agent, filename, event_type, source, conversation_id)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (agent, filename, event_type, source, conversation_id),
+            )
+            conn.commit()
+    except Exception as e:
+        logger.debug("Failed to record context event: %s", e)
+
+
+def record_load_events(agent: str, loaded: list[str], truncated: list[str], source: str = "chat") -> None:
+    """Batch-record load/truncated events for files in a single prompt build."""
+    try:
+        conn = db.get_db()
+        with db.write_lock():
+            for f in loaded:
+                conn.execute(
+                    "INSERT INTO context_usage (agent, filename, event_type, source) VALUES (?, ?, 'loaded', ?)",
+                    (agent, f, source),
+                )
+            for f in truncated:
+                conn.execute(
+                    "INSERT INTO context_usage (agent, filename, event_type, source) VALUES (?, ?, 'truncated', ?)",
+                    (agent, f, source),
+                )
+            conn.commit()
+    except Exception as e:
+        logger.debug("Failed to record load events: %s", e)
+
+
+def get_file_scores(agent: str, days: int = 30) -> list[dict]:
+    """Aggregate context usage into per-file event counts for the scorer."""
+    conn = db.get_db()
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%S")
+    rows = conn.execute(
+        """SELECT filename, event_type, COUNT(*) as cnt
+           FROM context_usage
+           WHERE agent = ? AND created_at >= ?
+           GROUP BY filename, event_type
+           ORDER BY filename""",
+        (agent, cutoff),
+    ).fetchall()
+
+    # Pivot into per-file dicts
+    files: dict[str, dict] = {}
+    for row in rows:
+        fname = row["filename"]
+        if fname not in files:
+            files[fname] = {"filename": fname, "write": 0, "append": 0, "loaded": 0, "truncated": 0, "mentioned_in_response": 0, "delete": 0}
+        files[fname][row["event_type"]] = row["cnt"]
+
+    return list(files.values())
+
+
+def get_recent_events(agent: str, limit: int = 50) -> list[dict]:
+    """Return recent context usage events for an agent."""
+    conn = db.get_db()
+    rows = conn.execute(
+        "SELECT * FROM context_usage WHERE agent = ? ORDER BY created_at DESC LIMIT ?",
+        (agent, limit),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def cleanup_old(retention_days: int = 90) -> int:
+    """Delete context usage records older than retention period."""
+    conn = db.get_db()
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).strftime("%Y-%m-%dT%H:%M:%S")
+    with db.write_lock():
+        cursor = conn.execute("DELETE FROM context_usage WHERE created_at < ?", (cutoff,))
+        conn.commit()
+        return cursor.rowcount

--- a/backend/core/agents/memory/__init__.py
+++ b/backend/core/agents/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Chatty agent memory — FTS5 search, temporal facts, daily note summarizer, and MEMORY.md consolidator."""

--- a/backend/core/agents/memory/db.py
+++ b/backend/core/agents/memory/db.py
@@ -1,0 +1,447 @@
+"""Per-agent memory database — FTS5 full-text search + temporal facts.
+
+Follows the same patterns as ChatHistoryDB: single shared SQLite connection,
+WAL mode, threading write-lock, GCS backup/restore.  Each agent gets its own
+memory.db alongside its chat_history.db.
+
+Zero new dependencies — FTS5 is built into Python's sqlite3.
+"""
+
+import logging
+import re
+import sqlite3
+import threading
+from datetime import date, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from core.storage import download_file, upload_file
+
+from .types import validate_memory_type
+
+logger = logging.getLogger(__name__)
+
+CT_TZ = ZoneInfo("America/Chicago")
+
+# Module-level cache: one MemoryDB per data_dir (string key).
+_instances: dict[str, "MemoryDB"] = {}
+
+
+def get_instance(data_dir: str) -> "MemoryDB | None":
+    """Return the cached MemoryDB for *data_dir*, or None if not yet initialized."""
+    return _instances.get(data_dir)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """\
+-- Content table backing the FTS5 index
+CREATE TABLE IF NOT EXISTS memory_documents (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_type TEXT    NOT NULL CHECK(source_type IN ('daily','memory','topic','fact')),
+    source_id   TEXT    NOT NULL,
+    title       TEXT    NOT NULL DEFAULT '',
+    content     TEXT    NOT NULL,
+    memory_type TEXT,
+    date        TEXT,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(source_type, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memdoc_source ON memory_documents(source_type, source_id);
+CREATE INDEX IF NOT EXISTS idx_memdoc_type   ON memory_documents(memory_type) WHERE memory_type IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_memdoc_date   ON memory_documents(date)        WHERE date IS NOT NULL;
+
+-- Temporal facts (entity-relationship triples with validity windows)
+CREATE TABLE IF NOT EXISTS facts (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    subject     TEXT    NOT NULL,
+    predicate   TEXT    NOT NULL,
+    object      TEXT    NOT NULL,
+    valid_from  TEXT    NOT NULL DEFAULT (date('now')),
+    valid_to    TEXT,
+    created_by  TEXT    NOT NULL DEFAULT '',
+    source      TEXT    NOT NULL DEFAULT '',
+    confidence  REAL    NOT NULL DEFAULT 1.0 CHECK(confidence >= 0.0 AND confidence <= 1.0),
+    memory_type TEXT,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_facts_subject ON facts(subject);
+CREATE INDEX IF NOT EXISTS idx_facts_valid   ON facts(valid_from, valid_to);
+CREATE INDEX IF NOT EXISTS idx_facts_type    ON facts(memory_type) WHERE memory_type IS NOT NULL;
+"""
+
+# FTS5 setup is separate because CREATE VIRTUAL TABLE doesn't support IF NOT EXISTS
+# inside executescript cleanly on all Python/SQLite combos.
+_FTS5_SETUP = """\
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+    title, content, memory_type, source_type,
+    content='memory_documents',
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+
+-- Triggers to keep FTS5 in sync with the content table
+CREATE TRIGGER IF NOT EXISTS memory_fts_ai AFTER INSERT ON memory_documents BEGIN
+    INSERT INTO memory_fts(rowid, title, content, memory_type, source_type)
+    VALUES (new.id, new.title, new.content, COALESCE(new.memory_type,''), new.source_type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memory_fts_ad AFTER DELETE ON memory_documents BEGIN
+    INSERT INTO memory_fts(memory_fts, rowid, title, content, memory_type, source_type)
+    VALUES ('delete', old.id, old.title, old.content, COALESCE(old.memory_type,''), old.source_type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memory_fts_au AFTER UPDATE ON memory_documents BEGIN
+    INSERT INTO memory_fts(memory_fts, rowid, title, content, memory_type, source_type)
+    VALUES ('delete', old.id, old.title, old.content, COALESCE(old.memory_type,''), old.source_type);
+    INSERT INTO memory_fts(rowid, title, content, memory_type, source_type)
+    VALUES (new.id, new.title, new.content, COALESCE(new.memory_type,''), new.source_type);
+END;
+"""
+
+
+# ---------------------------------------------------------------------------
+# FTS5 query sanitizer
+# ---------------------------------------------------------------------------
+
+_FTS_SPECIAL = re.compile(r'["\*\(\)\+\-\^~:]')
+
+
+def _sanitize_fts_query(raw: str) -> str:
+    """Escape special FTS5 characters and wrap each token in quotes for safety."""
+    raw = _FTS_SPECIAL.sub(" ", raw)
+    tokens = raw.split()
+    if not tokens:
+        return '""'
+    # Quote each token individually so multi-word queries use implicit AND
+    return " ".join(f'"{t}"' for t in tokens if t.strip())
+
+
+# ---------------------------------------------------------------------------
+# MemoryDB
+# ---------------------------------------------------------------------------
+
+class MemoryDB:
+    """Per-agent memory database with FTS5 search and temporal facts."""
+
+    def __init__(self, data_dir: Path, gcs_prefix: str, db_filename: str = "memory.db"):
+        self.data_dir = data_dir
+        self.db_path = data_dir / db_filename
+        self.gcs_key = gcs_prefix + db_filename
+        self._connection: sqlite3.Connection | None = None
+        self._write_lock = threading.Lock()
+
+    def get_db(self) -> sqlite3.Connection:
+        if self._connection is None:
+            raise RuntimeError("MemoryDB not initialized — call init_db() first")
+        return self._connection
+
+    @property
+    def write_lock(self) -> threading.Lock:
+        return self._write_lock
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def init_db(self) -> None:
+        """Download from GCS if absent, open connection, create schema."""
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+        if not self.db_path.exists():
+            download_file(self.db_path, self.gcs_key)
+
+        self._connection = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA journal_mode=WAL")
+        self._connection.execute("PRAGMA busy_timeout=5000")
+
+        self._connection.executescript(_SCHEMA)
+
+        # FTS5 availability check + setup
+        try:
+            self._connection.executescript(_FTS5_SETUP)
+        except sqlite3.OperationalError as e:
+            if "fts5" in str(e).lower():
+                logger.error(
+                    "FTS5 is not available in this SQLite build. "
+                    "Memory search will be disabled.  Error: %s", e,
+                )
+            else:
+                raise
+
+        # Cache this instance
+        _instances[str(self.data_dir)] = self
+        logger.info("MemoryDB initialized at %s", self.db_path)
+
+    def backup_to_gcs(self) -> None:
+        """Checkpoint WAL then upload the DB file to GCS."""
+        if self._connection is not None:
+            try:
+                self._connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            except Exception as e:
+                logger.warning("WAL checkpoint before memory backup failed: %s", e)
+        upload_file(self.db_path, self.gcs_key)
+
+    # ------------------------------------------------------------------
+    # FTS5 indexing
+    # ------------------------------------------------------------------
+
+    def index_document(
+        self,
+        source_type: str,
+        source_id: str,
+        title: str,
+        content: str,
+        memory_type: str | None = None,
+        date: str | None = None,
+    ) -> None:
+        """Upsert a document into memory_documents (FTS5 triggers handle the index)."""
+        memory_type = validate_memory_type(memory_type)
+        conn = self.get_db()
+        with self._write_lock:
+            conn.execute(
+                """INSERT INTO memory_documents
+                       (source_type, source_id, title, content, memory_type, date, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+                   ON CONFLICT(source_type, source_id)
+                   DO UPDATE SET title=excluded.title,
+                                 content=excluded.content,
+                                 memory_type=excluded.memory_type,
+                                 date=excluded.date,
+                                 updated_at=datetime('now')""",
+                (source_type, source_id, title, content, memory_type, date),
+            )
+            conn.commit()
+
+    def remove_document(self, source_type: str, source_id: str) -> None:
+        """Remove a document from the index."""
+        conn = self.get_db()
+        with self._write_lock:
+            conn.execute(
+                "DELETE FROM memory_documents WHERE source_type=? AND source_id=?",
+                (source_type, source_id),
+            )
+            conn.commit()
+
+    def search(
+        self,
+        query: str,
+        source_type: str | None = None,
+        memory_type: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        """FTS5 search with optional filters.  Returns ranked result dicts."""
+        conn = self.get_db()
+        limit = max(1, min(int(limit), 100))
+
+        safe_query = _sanitize_fts_query(query)
+        if not safe_query or safe_query == '""':
+            return []
+
+        # Build the MATCH expression with optional column filters
+        match_parts: list[str] = []
+        if source_type:
+            match_parts.append(f'source_type:"{source_type}"')
+        if memory_type:
+            match_parts.append(f'memory_type:"{memory_type}"')
+        match_parts.append(f"({safe_query})")
+        match_expr = " ".join(match_parts)
+
+        sql = """
+            SELECT d.id, d.source_type, d.source_id, d.title, d.memory_type, d.date,
+                   snippet(memory_fts, 1, '**', '**', '…', 40) AS snippet,
+                   bm25(memory_fts, 5.0, 1.0, 3.0, 2.0)       AS rank
+            FROM memory_fts
+            JOIN memory_documents d ON d.id = memory_fts.rowid
+            WHERE memory_fts MATCH ?
+        """
+        params: list = [match_expr]
+
+        if date_from:
+            sql += " AND d.date >= ?"
+            params.append(date_from)
+        if date_to:
+            sql += " AND d.date <= ?"
+            params.append(date_to)
+
+        sql += " ORDER BY rank LIMIT ?"
+        params.append(limit)
+
+        try:
+            rows = conn.execute(sql, params).fetchall()
+            return [dict(r) for r in rows]
+        except sqlite3.OperationalError as e:
+            logger.warning("FTS5 search failed for query=%r: %s", query, e)
+            return []
+
+    # ------------------------------------------------------------------
+    # Reindex from files on disk
+    # ------------------------------------------------------------------
+
+    def reindex_all(self, ctx_manager) -> dict:
+        """Full rebuild of FTS5 index from files on disk.
+
+        *ctx_manager* is a ContextManager instance for this agent.
+        Called on startup after init_db().
+        """
+        conn = self.get_db()
+        stats = {"documents_indexed": 0, "facts_reindexed": 0}
+
+        with self._write_lock:
+            # Clear existing document index (facts survive in their own table)
+            conn.execute("DELETE FROM memory_documents WHERE source_type != 'fact'")
+            conn.commit()
+
+        # 1. Index MEMORY.md
+        memory = ctx_manager.read_memory()
+        if memory:
+            self.index_document("memory", "MEMORY.md", "MEMORY.md", memory)
+            stats["documents_indexed"] += 1
+
+        # 2. Index daily notes
+        daily_dir = ctx_manager.daily_dir
+        if daily_dir.exists():
+            for f in sorted(daily_dir.glob("*.md")):
+                note_date = f.stem  # e.g. "2026-04-12"
+                content = f.read_text(encoding="utf-8", errors="replace")
+                if content.strip():
+                    self.index_document("daily", note_date, note_date, content, date=note_date)
+                    stats["documents_indexed"] += 1
+
+        # 3. Index topic files (skip soul.md, MEMORY.md, _-prefixed)
+        skip = {"soul.md", "memory.md"}
+        for f in sorted(ctx_manager.data_dir.glob("*.md")):
+            if f.name.startswith("_") or f.name.lower() in skip:
+                continue
+            content = f.read_text(encoding="utf-8", errors="replace")
+            if content.strip():
+                self.index_document("topic", f.name, f.name, content)
+                stats["documents_indexed"] += 1
+
+        # 4. Re-index existing facts from the facts table
+        rows = conn.execute("SELECT id, subject, predicate, object, valid_from, memory_type FROM facts WHERE valid_to IS NULL").fetchall()
+        for row in rows:
+            self.index_document(
+                "fact",
+                str(row["id"]),
+                f"{row['subject']} {row['predicate']}",
+                f"{row['subject']} {row['predicate']} {row['object']}",
+                memory_type=row["memory_type"],
+                date=row["valid_from"],
+            )
+            stats["facts_reindexed"] += 1
+
+        logger.info("MemoryDB reindex complete: %s", stats)
+        return stats
+
+    # ------------------------------------------------------------------
+    # Temporal facts
+    # ------------------------------------------------------------------
+
+    def add_fact(
+        self,
+        subject: str,
+        predicate: str,
+        object_: str,
+        valid_from: str | None = None,
+        created_by: str = "agent",
+        source: str = "",
+        confidence: float = 1.0,
+        memory_type: str | None = None,
+    ) -> dict:
+        """Insert a new fact and index it in FTS5.  Returns the fact dict."""
+        valid_from = valid_from or date.today().isoformat()
+        memory_type = validate_memory_type(memory_type)
+        confidence = max(0.0, min(float(confidence), 1.0))
+
+        conn = self.get_db()
+        with self._write_lock:
+            cursor = conn.execute(
+                """INSERT INTO facts
+                       (subject, predicate, object, valid_from, created_by, source, confidence, memory_type)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (subject, predicate, object_, valid_from, created_by, source, confidence, memory_type),
+            )
+            conn.commit()
+            fact_id = cursor.lastrowid
+
+        # Index in FTS5 (outside write lock — index_document acquires its own)
+        self.index_document(
+            "fact",
+            str(fact_id),
+            f"{subject} {predicate}",
+            f"{subject} {predicate} {object_}",
+            memory_type=memory_type,
+            date=valid_from,
+        )
+        return {
+            "id": fact_id,
+            "subject": subject,
+            "predicate": predicate,
+            "object": object_,
+            "valid_from": valid_from,
+            "memory_type": memory_type,
+            "ok": True,
+        }
+
+    def query_facts(
+        self,
+        subject: str | None = None,
+        predicate: str | None = None,
+        as_of: str | None = None,
+        memory_type: str | None = None,
+        include_expired: bool = False,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Query facts with optional filters.  *as_of* gives a point-in-time view."""
+        conn = self.get_db()
+        limit = max(1, min(int(limit), 500))
+
+        sql = "SELECT * FROM facts WHERE 1=1"
+        params: list = []
+
+        if subject:
+            sql += " AND subject LIKE ?"
+            params.append(f"%{subject}%")
+        if predicate:
+            sql += " AND predicate LIKE ?"
+            params.append(f"%{predicate}%")
+        if memory_type:
+            sql += " AND memory_type = ?"
+            params.append(memory_type)
+        if as_of:
+            sql += " AND valid_from <= ? AND (valid_to IS NULL OR valid_to >= ?)"
+            params.extend([as_of, as_of])
+        elif not include_expired:
+            sql += " AND valid_to IS NULL"
+
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+
+        rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+
+    def invalidate_fact(self, fact_id: int, valid_to: str | None = None) -> dict:
+        """Set valid_to on a fact.  Removes it from the FTS5 search index."""
+        valid_to = valid_to or date.today().isoformat()
+        conn = self.get_db()
+        with self._write_lock:
+            cursor = conn.execute(
+                "UPDATE facts SET valid_to=?, updated_at=datetime('now') WHERE id=?",
+                (valid_to, fact_id),
+            )
+            conn.commit()
+            if cursor.rowcount == 0:
+                return {"error": f"Fact {fact_id} not found"}
+
+        self.remove_document("fact", str(fact_id))
+        return {"id": fact_id, "valid_to": valid_to, "ok": True}

--- a/backend/core/agents/memory/processor.py
+++ b/backend/core/agents/memory/processor.py
@@ -1,0 +1,205 @@
+"""Memory processor — nightly daily-note summarizer and weekly MEMORY.md consolidator.
+
+Both functions are called from the scheduled_actions processor. Each runs
+one Claude API call and updates the agent's data dir (with GCS sync).
+"""
+
+import logging
+import time
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from core.agents.context_manager import ContextManager
+from core.agents.tools.memory_tools import consolidate_memory
+
+logger = logging.getLogger(__name__)
+
+CT_TZ = ZoneInfo("America/Chicago")
+
+# Cap on chat content sent to the daily summarizer — don't include more
+# than a day's worth of actual chat. In practice a single day of traffic
+# is well under this limit.
+_MAX_CHAT_INPUT_CHARS = 80_000
+
+
+def process_daily_note_summary(
+    agent_name: str,
+    ctx_manager: ContextManager,
+    chat_service,
+    api_key: str,
+) -> dict:
+    """Summarize yesterday's chat traffic into the daily note file.
+
+    Appends an `## End-of-day summary` section to
+    `daily/YYYY-MM-DD.md` for yesterday (Central Time), with a single
+    `Headline:` line at the top so the manifest surfaces a one-line
+    recap for the agent's future prompts.
+
+    If there are no messages for yesterday, no-ops.
+    """
+    start = time.monotonic()
+    yesterday = (datetime.now(CT_TZ) - timedelta(days=1)).strftime("%Y-%m-%d")
+
+    if chat_service is None:
+        return {"agent": agent_name, "date": yesterday, "status": "skipped",
+                "reason": "no chat_service registered"}
+    if not api_key:
+        return {"agent": agent_name, "date": yesterday, "status": "skipped",
+                "reason": "no api key"}
+
+    try:
+        messages = chat_service.get_messages_on_date(yesterday)
+    except Exception as e:
+        logger.warning("daily_note_summary: failed to read messages for %s/%s: %s",
+                       agent_name, yesterday, e)
+        return {"agent": agent_name, "date": yesterday, "status": "error", "error": str(e)}
+
+    if not messages:
+        return {"agent": agent_name, "date": yesterday, "status": "skipped",
+                "reason": "no messages", "duration_ms": int((time.monotonic() - start) * 1000)}
+
+    # Group messages by conversation and build a compact transcript
+    transcript_parts: list[str] = []
+    total_chars = 0
+    current_conv: str | None = None
+    for m in messages:
+        conv_id = m.get("conversation_id")
+        if conv_id != current_conv:
+            title = (m.get("conversation_title") or "Conversation").strip() or "Conversation"
+            transcript_parts.append(f"\n### {title}\n")
+            current_conv = conv_id
+        role = m.get("role", "user")
+        content = (m.get("content") or "").strip()
+        if not content:
+            continue
+        line = f"{role}: {content}"
+        if total_chars + len(line) > _MAX_CHAT_INPUT_CHARS:
+            transcript_parts.append("... (remaining messages truncated)")
+            break
+        transcript_parts.append(line)
+        total_chars += len(line)
+
+    transcript = "\n".join(transcript_parts).strip()
+    if not transcript:
+        return {"agent": agent_name, "date": yesterday, "status": "skipped",
+                "reason": "empty transcript"}
+
+    system_prompt = (
+        f"You are summarizing yesterday's chat traffic for an AI agent named {agent_name}. "
+        "Produce a terse end-of-day log in markdown. The VERY FIRST line MUST be:\n\n"
+        "Headline: <single-sentence summary under 80 chars>\n\n"
+        "Then include short bulleted sections only for what applies:\n"
+        "- Decisions made\n"
+        "- People mentioned\n"
+        "- Actions taken (tools invoked, emails sent, tickets updated, etc.)\n"
+        "- Commitments made\n"
+        "- Open questions / follow-ups for tomorrow\n\n"
+        "Be factual. Compress aggressively. Skip small talk and boilerplate. "
+        "Do not invent anything — only summarize what's actually in the transcript. "
+        "Do NOT wrap the output in triple backticks."
+    )
+    user_message = f"Transcript for {yesterday}:\n\n{transcript}"
+
+    try:
+        import anthropic
+        client = anthropic.Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=1200,
+            system=system_prompt,
+            messages=[{"role": "user", "content": user_message}],
+        )
+    except Exception as e:
+        logger.warning("daily_note_summary Claude call failed for %s/%s: %s",
+                       agent_name, yesterday, e)
+        return {"agent": agent_name, "date": yesterday, "status": "error", "error": str(e)}
+
+    summary = ""
+    for block in response.content:
+        if getattr(block, "type", None) == "text":
+            summary += block.text
+    summary = summary.strip()
+    if not summary:
+        return {"agent": agent_name, "date": yesterday, "status": "error",
+                "error": "empty summary from Claude"}
+
+    # Inject the summary into the daily note. Prepend the Headline line at
+    # the top of the file so _first_headline() picks it up for the manifest.
+    ctx_manager.ensure_daily_dir()
+    path = ctx_manager._daily_path(yesterday)
+    existing = path.read_text(encoding="utf-8") if path.exists() else f"# {yesterday}\n"
+
+    lines = summary.splitlines()
+    headline_line = lines[0] if lines and lines[0].lower().startswith("headline:") else ""
+    summary_body = "\n".join(lines[1:]).strip() if headline_line else summary
+
+    new_content_parts = []
+    if headline_line:
+        # Move the headline to the very top of the file (after the # YYYY-MM-DD)
+        existing_lines = existing.splitlines()
+        # Drop any pre-existing "Headline:" line near the top so we don't double up
+        cleaned = [ln for ln in existing_lines if not ln.lower().startswith("headline:")]
+        if cleaned and cleaned[0].startswith("#"):
+            new_content_parts.append(cleaned[0])
+            new_content_parts.append("")
+            new_content_parts.append(headline_line)
+            new_content_parts.extend(cleaned[1:])
+        else:
+            new_content_parts.append(f"# {yesterday}")
+            new_content_parts.append("")
+            new_content_parts.append(headline_line)
+            new_content_parts.extend(cleaned)
+    else:
+        new_content_parts.append(existing.rstrip())
+
+    new_content_parts.append("")
+    new_content_parts.append("## End-of-day summary")
+    new_content_parts.append("")
+    new_content_parts.append(summary_body if headline_line else summary)
+    new_content_parts.append("")
+
+    new_content = "\n".join(new_content_parts)
+    path.write_text(new_content, encoding="utf-8")
+
+    try:
+        from core.storage import upload_config
+        upload_config(path, f"daily/{yesterday}.md", prefix=ctx_manager.gcs_prefix)
+    except Exception:
+        logger.warning("GCS upload failed for daily summary %s/%s", agent_name, yesterday,
+                       exc_info=True)
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    input_tokens = getattr(response.usage, "input_tokens", 0) if hasattr(response, "usage") else 0
+    output_tokens = getattr(response.usage, "output_tokens", 0) if hasattr(response, "usage") else 0
+    logger.info(
+        "daily_note_summary %s/%s: %d messages, tokens %d/%d, %dms",
+        agent_name, yesterday, len(messages), input_tokens, output_tokens, duration_ms,
+    )
+    return {
+        "agent": agent_name,
+        "date": yesterday,
+        "status": "ok",
+        "messages_summarized": len(messages),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "duration_ms": duration_ms,
+    }
+
+
+def process_memory_consolidation(
+    agent_name: str,
+    ctx_manager: ContextManager,
+    api_key: str,
+    days: int = 7,
+) -> dict:
+    """Regenerate MEMORY.md from the last N days of daily notes."""
+    start = time.monotonic()
+    result = consolidate_memory(
+        data_dir=str(ctx_manager.data_dir),
+        gcs_prefix=ctx_manager.gcs_prefix,
+        api_key=api_key,
+        days=days,
+    )
+    result["agent"] = agent_name
+    result["duration_ms"] = int((time.monotonic() - start) * 1000)
+    return result

--- a/backend/core/agents/memory/search_tools.py
+++ b/backend/core/agents/memory/search_tools.py
@@ -1,0 +1,160 @@
+"""Memory search and fact tools — handler functions for the tool registry.
+
+Dispatched via ``kind="memory"`` in ``ToolRegistry.execute_tool``.
+Each function takes ``(data_dir, gcs_prefix, ...)`` and retrieves a cached
+``MemoryDB`` instance (created during startup or on first access).
+"""
+
+import logging
+from pathlib import Path
+
+from .db import MemoryDB, get_instance
+from .types import validate_memory_type
+
+logger = logging.getLogger(__name__)
+
+
+def _get_db(data_dir: str, gcs_prefix: str) -> MemoryDB:
+    """Get or lazily create a MemoryDB for *data_dir*."""
+    db = get_instance(data_dir)
+    if db is not None:
+        return db
+    # Lazy init (shouldn't normally happen — startup inits everything)
+    db = MemoryDB(Path(data_dir), gcs_prefix)
+    db.init_db()
+    return db
+
+
+# ------------------------------------------------------------------
+# search_memory
+# ------------------------------------------------------------------
+
+def search_memory(
+    data_dir: str,
+    gcs_prefix: str,
+    query: str,
+    source_type: str | None = None,
+    memory_type: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    limit: int = 20,
+) -> dict:
+    """Full-text search across daily notes, MEMORY.md, topic files, and facts."""
+    if not query or not query.strip():
+        return {"error": "query is required"}
+    try:
+        limit = max(1, min(int(limit), 100))
+    except (TypeError, ValueError):
+        limit = 20
+
+    db = _get_db(data_dir, gcs_prefix)
+    results = db.search(
+        query=query,
+        source_type=source_type,
+        memory_type=validate_memory_type(memory_type),
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+    )
+    return {"query": query, "results": results, "total": len(results)}
+
+
+# ------------------------------------------------------------------
+# add_fact
+# ------------------------------------------------------------------
+
+def add_fact(
+    data_dir: str,
+    gcs_prefix: str,
+    subject: str,
+    predicate: str,
+    object: str,
+    valid_from: str | None = None,
+    created_by: str = "agent",
+    source: str = "",
+    confidence: float = 1.0,
+    memory_type: str | None = None,
+) -> dict:
+    """Add a temporal fact to the knowledge base."""
+    if not subject or not subject.strip():
+        return {"error": "subject is required"}
+    if not predicate or not predicate.strip():
+        return {"error": "predicate is required"}
+    if not object or not object.strip():
+        return {"error": "object is required"}
+
+    db = _get_db(data_dir, gcs_prefix)
+    result = db.add_fact(
+        subject=subject.strip(),
+        predicate=predicate.strip(),
+        object_=object.strip(),
+        valid_from=valid_from,
+        created_by=created_by,
+        source=source,
+        confidence=confidence,
+        memory_type=memory_type,
+    )
+    # Background GCS backup
+    try:
+        db.backup_to_gcs()
+    except Exception:
+        logger.debug("GCS backup after add_fact failed", exc_info=True)
+    return result
+
+
+# ------------------------------------------------------------------
+# query_facts
+# ------------------------------------------------------------------
+
+def query_facts(
+    data_dir: str,
+    gcs_prefix: str,
+    subject: str | None = None,
+    predicate: str | None = None,
+    as_of: str | None = None,
+    memory_type: str | None = None,
+    include_expired: bool = False,
+    limit: int = 50,
+) -> dict:
+    """Query temporal facts with optional filters."""
+    try:
+        limit = max(1, min(int(limit), 500))
+    except (TypeError, ValueError):
+        limit = 50
+
+    db = _get_db(data_dir, gcs_prefix)
+    facts = db.query_facts(
+        subject=subject,
+        predicate=predicate,
+        as_of=as_of,
+        memory_type=validate_memory_type(memory_type),
+        include_expired=bool(include_expired),
+        limit=limit,
+    )
+    return {"facts": facts, "total": len(facts)}
+
+
+# ------------------------------------------------------------------
+# invalidate_fact
+# ------------------------------------------------------------------
+
+def invalidate_fact(
+    data_dir: str,
+    gcs_prefix: str,
+    fact_id: int,
+    valid_to: str | None = None,
+) -> dict:
+    """Mark a fact as no longer valid (sets valid_to)."""
+    try:
+        fact_id = int(fact_id)
+    except (TypeError, ValueError):
+        return {"error": "fact_id must be an integer"}
+
+    db = _get_db(data_dir, gcs_prefix)
+    result = db.invalidate_fact(fact_id, valid_to=valid_to)
+    if result.get("ok"):
+        try:
+            db.backup_to_gcs()
+        except Exception:
+            logger.debug("GCS backup after invalidate_fact failed", exc_info=True)
+    return result

--- a/backend/core/agents/memory/types.py
+++ b/backend/core/agents/memory/types.py
@@ -1,0 +1,69 @@
+"""Memory type classification — 10 types with durability tiers.
+
+Every daily-note entry or temporal fact can optionally carry a *memory type*
+that indicates what kind of knowledge it represents.  The type influences how
+long the consolidation pipeline retains the item and lets agents filter
+searches by category.
+"""
+
+MEMORY_TYPES: set[str] = {
+    "decision",
+    "preference",
+    "problem",
+    "milestone",
+    "insight",
+    "person",
+    "task",
+    "idea",
+    "reference",
+    "someday-maybe",
+}
+
+# ---------------------------------------------------------------------------
+# Durability tiers  (lower number = more durable)
+# ---------------------------------------------------------------------------
+
+TIER_1_ALWAYS_KEEP: set[str] = {"decision", "preference"}
+TIER_2_KEEP_IF_RECENT: set[str] = {"person", "insight", "reference"}
+TIER_3_KEEP_IF_RELEVANT: set[str] = {"milestone", "idea", "problem"}
+TIER_4_DROP_WHEN_RESOLVED: set[str] = {"task", "someday-maybe"}
+
+DURABILITY_TIERS: dict[str, int] = {}
+for _t in TIER_1_ALWAYS_KEEP:
+    DURABILITY_TIERS[_t] = 1
+for _t in TIER_2_KEEP_IF_RECENT:
+    DURABILITY_TIERS[_t] = 2
+for _t in TIER_3_KEEP_IF_RELEVANT:
+    DURABILITY_TIERS[_t] = 3
+for _t in TIER_4_DROP_WHEN_RESOLVED:
+    DURABILITY_TIERS[_t] = 4
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def validate_memory_type(memory_type: str | None) -> str | None:
+    """Normalize and validate a memory type.  Returns *None* if invalid."""
+    if not memory_type:
+        return None
+    normalized = memory_type.strip().lower()
+    return normalized if normalized in MEMORY_TYPES else None
+
+
+def type_tag(memory_type: str) -> str:
+    """Return the inline tag format, e.g. ``[decision]``."""
+    return f"[{memory_type}]"
+
+
+def extract_type_tag(line: str) -> str | None:
+    """Extract a memory-type tag from a line like ``[decision] Some text``.
+
+    Returns the tag string (e.g. ``"decision"``) or *None*.
+    """
+    stripped = line.strip()
+    if stripped.startswith("[") and "]" in stripped:
+        tag = stripped[1 : stripped.index("]")].strip().lower()
+        if tag in MEMORY_TYPES:
+            return tag
+    return None

--- a/backend/core/agents/reminders/db.py
+++ b/backend/core/agents/reminders/db.py
@@ -89,6 +89,29 @@ def init_db() -> None:
         );
         CREATE INDEX IF NOT EXISTS idx_sa_next ON scheduled_actions(enabled, next_run);
         CREATE INDEX IF NOT EXISTS idx_sa_agent ON scheduled_actions(agent);
+
+        -- Context usage tracking for the dreaming system
+        CREATE TABLE IF NOT EXISTS context_usage (
+            agent TEXT NOT NULL,
+            filename TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            source TEXT DEFAULT 'chat',
+            conversation_id TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_ctx_usage ON context_usage(agent, created_at);
+
+        -- Dreaming run history
+        CREATE TABLE IF NOT EXISTS dreaming_runs (
+            agent TEXT NOT NULL,
+            files_scored INTEGER,
+            files_archived INTEGER,
+            load_order_changed INTEGER,
+            details TEXT,
+            duration_ms INTEGER,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_dreaming_agent ON dreaming_runs(agent, created_at);
     """)
     logger.info("Reminders DB initialized at %s", DB_PATH)
 

--- a/backend/core/agents/scheduled_actions/nightly.py
+++ b/backend/core/agents/scheduled_actions/nightly.py
@@ -1,0 +1,75 @@
+"""Nightly memory and dreaming jobs — runs per-agent at 11 PM CT.
+
+Three jobs per agent (in order):
+1. Daily note summarization — Claude Haiku summarizes yesterday's chat
+2. Memory consolidation — Claude Sonnet rewrites MEMORY.md from daily notes
+3. Dreaming — score files, archive dormant ones, rebuild load order
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run_nightly_jobs() -> None:
+    """Run nightly memory/dreaming jobs for all agents with completed onboarding."""
+    try:
+        from agents.db import list_agents
+        from agents.engine import get_context_manager, get_chat_service, build_agent_config
+        from core.providers.credentials import CredentialStore
+    except Exception as e:
+        logger.error("nightly: failed to import dependencies: %s", e)
+        return
+
+    agents = list_agents()
+    if not agents:
+        return
+
+    # Get Anthropic API key for Claude calls
+    store = CredentialStore()
+    _, anthropic_profile = store.get_active_profile(provider_override="anthropic")
+    api_key = (anthropic_profile or {}).get("api_key", "")
+
+    for agent in agents:
+        if not agent.get("onboarding_complete"):
+            continue
+
+        slug = agent["slug"]
+        agent_name = agent["agent_name"]
+        ctx_manager = get_context_manager(slug)
+        chat_service = get_chat_service(slug)
+
+        # 1. Daily note summarization
+        try:
+            from core.agents.memory.processor import process_daily_note_summary
+            result = process_daily_note_summary(agent_name, ctx_manager, chat_service, api_key)
+            logger.info("nightly daily_note_summary %s: %s", agent_name, result.get("status"))
+        except Exception as e:
+            logger.warning("nightly daily_note_summary failed for %s: %s", agent_name, e)
+
+        # 2. Memory consolidation
+        if api_key:
+            try:
+                from core.agents.memory.processor import process_memory_consolidation
+                result = process_memory_consolidation(agent_name, ctx_manager, api_key, days=7)
+                logger.info("nightly memory_consolidation %s: ok=%s", agent_name, result.get("ok"))
+            except Exception as e:
+                logger.warning("nightly memory_consolidation failed for %s: %s", agent_name, e)
+
+        # 3. Dreaming (context file scoring + archival)
+        try:
+            from core.agents.dreaming.processor import process_dreaming
+            result = process_dreaming(agent_name, ctx_manager)
+            logger.info("nightly dreaming %s: archived=%d", agent_name, result.get("files_archived", 0))
+        except Exception as e:
+            logger.warning("nightly dreaming failed for %s: %s", agent_name, e)
+
+        # 4. Archive old daily notes (>90 days)
+        try:
+            result = ctx_manager.archive_old_daily_notes(max_age_days=90)
+            if result.get("archived", 0) > 0:
+                logger.info("nightly archive %s: archived %d old daily notes", agent_name, result["archived"])
+        except Exception as e:
+            logger.warning("nightly archive failed for %s: %s", agent_name, e)
+
+    logger.info("nightly jobs complete for %d agents", len(agents))

--- a/backend/core/agents/shared_context/__init__.py
+++ b/backend/core/agents/shared_context/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-agent shared context — knowledge visible to all agents."""

--- a/backend/core/agents/shared_context/db.py
+++ b/backend/core/agents/shared_context/db.py
@@ -1,0 +1,179 @@
+"""Shared context — SQLite database for agent-contributed entries.
+
+Single shared database (like reminders.db) for cross-agent knowledge.
+Thread safety: single connection, WAL mode, write-lock.
+"""
+
+import logging
+import sqlite3
+import threading
+import uuid
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from core.storage import download_file, upload_file
+
+logger = logging.getLogger(__name__)
+
+CT_TZ = ZoneInfo("America/Chicago")
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent.parent / "data" / "shared"
+DB_PATH = DATA_DIR / "shared_context.db"
+GCS_KEY = "shared/shared_context.db"
+
+_connection: sqlite3.Connection | None = None
+_write_lock = threading.Lock()
+
+
+def get_db() -> sqlite3.Connection:
+    if _connection is None:
+        raise RuntimeError("Shared context DB not initialized — call init_db() first")
+    return _connection
+
+
+def write_lock() -> threading.Lock:
+    return _write_lock
+
+
+def init_db() -> None:
+    """Initialize: restore from GCS if available, create schema."""
+    global _connection
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    if not DB_PATH.exists():
+        download_file(DB_PATH, GCS_KEY)
+
+    _connection = sqlite3.connect(str(DB_PATH), check_same_thread=False)
+    _connection.row_factory = sqlite3.Row
+    _connection.execute("PRAGMA journal_mode=WAL")
+    _connection.execute("PRAGMA busy_timeout=5000")
+
+    _connection.executescript("""
+        CREATE TABLE IF NOT EXISTS shared_entries (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT NOT NULL,
+            category TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            created_by_email TEXT NOT NULL DEFAULT ''
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_shared_entries_agent
+            ON shared_entries(agent_name);
+        CREATE INDEX IF NOT EXISTS idx_shared_entries_category
+            ON shared_entries(category);
+        CREATE INDEX IF NOT EXISTS idx_shared_entries_updated
+            ON shared_entries(updated_at);
+    """)
+    logger.info("Shared context DB initialized at %s", DB_PATH)
+
+
+def backup_to_gcs() -> None:
+    if _connection is not None:
+        try:
+            _connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception as e:
+            logger.warning("WAL checkpoint before shared context backup failed: %s", e)
+    upload_file(DB_PATH, GCS_KEY)
+
+
+# ------------------------------------------------------------------
+# CRUD
+# ------------------------------------------------------------------
+
+def add_entry(
+    agent_name: str,
+    title: str,
+    content: str,
+    category: str = "",
+    created_by_email: str = "",
+) -> dict:
+    """Insert a new shared entry.  Returns the entry dict."""
+    entry_id = str(uuid.uuid4())
+    now = datetime.now(CT_TZ).isoformat()
+    conn = get_db()
+    with _write_lock:
+        conn.execute(
+            """INSERT INTO shared_entries
+                   (id, agent_name, category, title, content, created_at, updated_at, created_by_email)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (entry_id, agent_name, category, title, content, now, now, created_by_email),
+        )
+        conn.commit()
+    return {
+        "id": entry_id,
+        "agent_name": agent_name,
+        "category": category,
+        "title": title,
+        "content": content,
+        "created_at": now,
+        "updated_at": now,
+        "created_by_email": created_by_email,
+    }
+
+
+def list_entries(
+    agent_name: str | None = None,
+    category: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[dict]:
+    """List shared entries, newest first."""
+    conn = get_db()
+    sql = "SELECT * FROM shared_entries WHERE 1=1"
+    params: list = []
+    if agent_name:
+        sql += " AND agent_name = ?"
+        params.append(agent_name)
+    if category:
+        sql += " AND category = ?"
+        params.append(category)
+    sql += " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+    params.extend([limit, offset])
+    rows = conn.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_entry(entry_id: str) -> dict | None:
+    conn = get_db()
+    row = conn.execute("SELECT * FROM shared_entries WHERE id = ?", (entry_id,)).fetchone()
+    return dict(row) if row else None
+
+
+def update_entry(
+    entry_id: str,
+    title: str | None = None,
+    content: str | None = None,
+    category: str | None = None,
+) -> dict | None:
+    """Update fields on an existing entry.  Returns updated entry or None."""
+    conn = get_db()
+    with _write_lock:
+        row = conn.execute("SELECT * FROM shared_entries WHERE id = ?", (entry_id,)).fetchone()
+        if not row:
+            return None
+        now = datetime.now(CT_TZ).isoformat()
+        new_title = title if title is not None else row["title"]
+        new_content = content if content is not None else row["content"]
+        new_category = category if category is not None else row["category"]
+        conn.execute(
+            """UPDATE shared_entries
+               SET title=?, content=?, category=?, updated_at=?
+               WHERE id=?""",
+            (new_title, new_content, new_category, now, entry_id),
+        )
+        conn.commit()
+    updated = get_entry(entry_id)
+    return updated
+
+
+def delete_entry(entry_id: str) -> bool:
+    conn = get_db()
+    with _write_lock:
+        cursor = conn.execute("DELETE FROM shared_entries WHERE id = ?", (entry_id,))
+        conn.commit()
+    return cursor.rowcount > 0

--- a/backend/core/agents/shared_context/router.py
+++ b/backend/core/agents/shared_context/router.py
@@ -1,0 +1,93 @@
+"""Shared context — Admin API endpoints.
+
+Endpoints for managing shared knowledge files and reviewing agent-contributed
+entries.  All endpoints require authentication. Chatty is single-user, so
+the authenticated user has full admin access.
+"""
+
+import logging
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from core.auth import get_current_user
+
+from . import db, service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/api/shared-context",
+    dependencies=[Depends(get_current_user)],
+    tags=["shared-context"],
+)
+
+
+# ── Files ──────────────────────────────────────────────────────────
+
+
+@router.get("/files")
+def list_files():
+    return {"files": service.list_files()}
+
+
+@router.get("/files/{filename}")
+def read_file(filename: str):
+    content = service.read_file(filename)
+    if content is None:
+        raise HTTPException(status_code=404, detail="File not found")
+    return {"filename": filename, "content": content}
+
+
+@router.put("/files/{filename}")
+def write_file(filename: str, body: dict = Body(...)):
+    content = body.get("content", "")
+    if not filename.endswith(".md"):
+        raise HTTPException(status_code=400, detail="Filename must end with .md")
+    if "/" in filename or "\\" in filename or ".." in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+    service.write_file(filename, content)
+    return {"filename": filename, "ok": True}
+
+
+@router.delete("/files/{filename}")
+def delete_file(filename: str):
+    if not service.delete_file(filename):
+        raise HTTPException(status_code=404, detail="File not found")
+    return {"filename": filename, "deleted": True}
+
+
+# ── Entries ────────────────────────────────────────────────────────
+
+
+@router.get("/entries")
+def list_entries(agent: str | None = None, category: str | None = None, limit: int = 100, offset: int = 0):
+    entries = db.list_entries(agent_name=agent, category=category, limit=limit, offset=offset)
+    return {"entries": entries, "count": len(entries)}
+
+
+@router.patch("/entries/{entry_id}")
+def update_entry(entry_id: str, body: dict = Body(...)):
+    updated = db.update_entry(
+        entry_id,
+        title=body.get("title"),
+        content=body.get("content"),
+        category=body.get("category"),
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Entry not found")
+    try:
+        db.backup_to_gcs()
+    except Exception:
+        pass
+    return updated
+
+
+@router.delete("/entries/{entry_id}")
+def delete_entry(entry_id: str):
+    if not db.delete_entry(entry_id):
+        raise HTTPException(status_code=404, detail="Entry not found")
+    try:
+        db.backup_to_gcs()
+    except Exception:
+        pass
+    return {"id": entry_id, "deleted": True}

--- a/backend/core/agents/shared_context/service.py
+++ b/backend/core/agents/shared_context/service.py
@@ -1,0 +1,142 @@
+"""Shared context — File CRUD, manifest builder, and GCS sync helpers.
+
+Manages markdown files in the shared data directory and provides the
+compact manifest string injected into every agent's system prompt.
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from core.storage import upload_config, delete_config
+
+from . import db
+
+logger = logging.getLogger(__name__)
+
+SHARED_DATA_DIR = db.DATA_DIR
+GCS_PREFIX = "shared/"
+
+
+# ------------------------------------------------------------------
+# File CRUD (admin-managed markdown files)
+# ------------------------------------------------------------------
+
+def list_files() -> list[dict]:
+    """List all .md files in the shared directory."""
+    if not SHARED_DATA_DIR.exists():
+        return []
+    files = []
+    for f in sorted(SHARED_DATA_DIR.glob("*.md")):
+        stat = f.stat()
+        content = f.read_text(encoding="utf-8", errors="replace")
+        files.append({
+            "name": f.name,
+            "size_bytes": stat.st_size,
+            "modified": stat.st_mtime,
+            "headline": _first_headline(content),
+        })
+    return files
+
+
+def _safe_filename(filename: str) -> bool:
+    """Validate filename: must be .md, no path separators, no traversal."""
+    if not filename or not filename.endswith(".md"):
+        return False
+    if "/" in filename or "\\" in filename or ".." in filename:
+        return False
+    return True
+
+
+def read_file(filename: str) -> str | None:
+    """Read a shared file.  Returns content or None if not found."""
+    if not _safe_filename(filename):
+        return None
+    path = SHARED_DATA_DIR / filename
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def write_file(filename: str, content: str) -> None:
+    """Create or overwrite a shared file.  Syncs to GCS."""
+    if not _safe_filename(filename):
+        raise ValueError("filename must end with .md and contain no path separators")
+    SHARED_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    path = SHARED_DATA_DIR / filename
+    path.write_text(content, encoding="utf-8")
+    try:
+        upload_config(path, filename, prefix=GCS_PREFIX)
+    except Exception:
+        logger.warning("GCS upload failed for shared/%s", filename, exc_info=True)
+
+
+def delete_file(filename: str) -> bool:
+    """Delete a shared file.  Returns True if it existed."""
+    if not _safe_filename(filename):
+        return False
+    path = SHARED_DATA_DIR / filename
+    if not path.exists():
+        return False
+    path.unlink()
+    try:
+        delete_config(filename, prefix=GCS_PREFIX)
+    except Exception:
+        logger.warning("GCS delete failed for shared/%s", filename, exc_info=True)
+    return True
+
+
+# ------------------------------------------------------------------
+# Manifest for system prompt injection
+# ------------------------------------------------------------------
+
+def get_shared_manifest() -> str:
+    """Return a compact manifest of shared files + recent entries.
+
+    Injected into every agent's system prompt so they know what shared
+    knowledge exists.  Agents call ``read_shared_context`` to get details.
+    """
+    parts: list[str] = []
+
+    # Files
+    files = list_files()
+    if files:
+        parts.append("## Shared Files")
+        for f in files:
+            modified = datetime.fromtimestamp(f["modified"]).strftime("%Y-%m-%d")
+            headline = f["headline"] or f["name"]
+            parts.append(f"- {f['name']} · {headline} · {modified}")
+        parts.append("")
+
+    # Recent entries (last 20)
+    try:
+        entries = db.list_entries(limit=20)
+    except Exception:
+        entries = []
+    if entries:
+        parts.append("## Recent Shared Entries")
+        for e in entries:
+            date_str = e["created_at"][:10] if e.get("created_at") else ""
+            cat = f" ({e['category']})" if e.get("category") else ""
+            parts.append(f"- [{e['agent_name']}, {date_str}] {e['title']}{cat}")
+        parts.append("")
+
+    return "\n".join(parts)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+def _first_headline(content: str) -> str:
+    """Extract a short headline from a markdown file."""
+    if not content:
+        return ""
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("---"):
+            continue
+        if line.startswith("#"):
+            return line.lstrip("#").strip()[:120]
+        return line[:120]
+    return ""

--- a/backend/core/agents/shared_context/tools.py
+++ b/backend/core/agents/shared_context/tools.py
@@ -1,0 +1,75 @@
+"""Shared context — Agent tool handler functions.
+
+Dispatched via ``kind="shared_context"`` in ``ToolRegistry.execute_tool``.
+Read tools receive ``(shared_data_dir, ...)``.
+Write tools receive ``(shared_data_dir, gcs_prefix, agent_name, ...)``.
+"""
+
+import logging
+
+from . import db, service
+
+logger = logging.getLogger(__name__)
+
+
+def list_shared_context(shared_data_dir: str, category: str = "") -> dict:
+    """List available shared files and entries."""
+    files = service.list_files()
+    entries = db.list_entries(category=category or None, limit=50)
+    return {
+        "files": [{"name": f["name"], "headline": f["headline"]} for f in files],
+        "entries": [
+            {
+                "id": e["id"],
+                "agent_name": e["agent_name"],
+                "title": e["title"],
+                "category": e.get("category", ""),
+                "created_at": e["created_at"],
+            }
+            for e in entries
+        ],
+    }
+
+
+def read_shared_context(shared_data_dir: str, filename: str = "", entry_id: str = "") -> dict:
+    """Read a shared file by name or an entry by ID."""
+    if filename:
+        content = service.read_file(filename)
+        if content is None:
+            return {"error": f"Shared file '{filename}' not found"}
+        return {"filename": filename, "content": content}
+
+    if entry_id:
+        entry = db.get_entry(entry_id)
+        if not entry:
+            return {"error": f"Shared entry '{entry_id}' not found"}
+        return {"entry": entry}
+
+    return {"error": "Provide either filename or entry_id"}
+
+
+def write_shared_context(
+    shared_data_dir: str,
+    gcs_prefix: str,
+    agent_name: str,
+    title: str,
+    content: str,
+    category: str = "",
+) -> dict:
+    """Publish a knowledge entry visible to all agents."""
+    if not title or not title.strip():
+        return {"error": "title is required"}
+    if not content or not content.strip():
+        return {"error": "content is required"}
+
+    entry = db.add_entry(
+        agent_name=agent_name,
+        title=title.strip(),
+        content=content.strip(),
+        category=category.strip(),
+    )
+    try:
+        db.backup_to_gcs()
+    except Exception:
+        logger.debug("GCS backup after write_shared_context failed", exc_info=True)
+    return {"id": entry["id"], "ok": True}

--- a/backend/core/agents/tool_config_db.py
+++ b/backend/core/agents/tool_config_db.py
@@ -1,0 +1,115 @@
+"""Chatty — Per-agent tool toggle configuration.
+
+Simple SQLite table that lets users enable/disable tool categories per agent
+without code changes. All agents default to all-enabled.
+"""
+
+import logging
+import sqlite3
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "agent_configs"
+DB_PATH = DATA_DIR / "tool_configs.db"
+
+_connection: sqlite3.Connection | None = None
+_write_lock = threading.Lock()
+
+# Toggle columns — Chatty-specific (no Odoo/DIMM/CRM/etc.)
+TOGGLE_COLUMNS = [
+    "web_enabled",
+    "reports_enabled",
+    "gmail_enabled",
+    "calendar_enabled",
+    "python_tools_enabled",
+    "reminders_enabled",
+    "scheduled_actions_enabled",
+    "memory_enabled",
+    "shared_context_enabled",
+]
+
+
+def get_db() -> sqlite3.Connection:
+    if _connection is None:
+        raise RuntimeError("Tool config DB not initialized — call init_db() first")
+    return _connection
+
+
+def write_lock() -> threading.Lock:
+    return _write_lock
+
+
+def init_db() -> None:
+    """Create schema. All toggles default to 1 (enabled)."""
+    global _connection
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    _connection = sqlite3.connect(str(DB_PATH), check_same_thread=False)
+    _connection.row_factory = sqlite3.Row
+    _connection.execute("PRAGMA journal_mode=WAL")
+    _connection.execute("PRAGMA busy_timeout=5000")
+
+    columns_sql = ", ".join(f"{col} INTEGER NOT NULL DEFAULT 1" for col in TOGGLE_COLUMNS)
+    _connection.executescript(f"""
+        CREATE TABLE IF NOT EXISTS agent_tool_configs (
+            agent_name TEXT PRIMARY KEY,
+            {columns_sql},
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+    """)
+    logger.info("Tool config DB initialized at %s", DB_PATH)
+
+
+def get_config(agent_name: str) -> dict | None:
+    """Get toggle config for an agent.  Returns None if no row exists (use defaults)."""
+    conn = get_db()
+    row = conn.execute(
+        "SELECT * FROM agent_tool_configs WHERE agent_name = ?",
+        (agent_name,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def get_defaults() -> dict[str, int]:
+    """Return the default config (all enabled)."""
+    return {col: 1 for col in TOGGLE_COLUMNS}
+
+
+def update_config(agent_name: str, **fields) -> dict:
+    """Update toggle(s) for an agent.  Creates the row if missing."""
+    conn = get_db()
+    with _write_lock:
+        existing = conn.execute(
+            "SELECT * FROM agent_tool_configs WHERE agent_name = ?",
+            (agent_name,),
+        ).fetchone()
+        if not existing:
+            # Insert with defaults, then update
+            conn.execute(
+                "INSERT INTO agent_tool_configs (agent_name) VALUES (?)",
+                (agent_name,),
+            )
+            conn.commit()
+
+        # Apply requested changes
+        valid_fields = {k: v for k, v in fields.items() if k in TOGGLE_COLUMNS}
+        if valid_fields:
+            set_clause = ", ".join(f"{k} = ?" for k in valid_fields)
+            params = list(valid_fields.values()) + [agent_name]
+            conn.execute(
+                f"UPDATE agent_tool_configs SET {set_clause}, updated_at = datetime('now') WHERE agent_name = ?",
+                params,
+            )
+            conn.commit()
+
+    return get_config(agent_name) or get_defaults()
+
+
+def list_configs() -> list[dict]:
+    """List all agent configs."""
+    conn = get_db()
+    rows = conn.execute("SELECT * FROM agent_tool_configs ORDER BY agent_name").fetchall()
+    return [dict(r) for r in rows]

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -98,6 +98,234 @@ CONTEXT_TOOLS = [
     },
 ]
 
+# ── Memory tools (daily notes, MEMORY.md, FTS5 search, facts) ────────────────
+
+MEMORY_TOOLS = [
+    {
+        "name": "append_daily_note",
+        "description": "Append a timestamped entry to today's daily note. Use this to record significant events, decisions, and information as they happen during conversation.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The content to append (will be timestamped automatically)",
+                },
+                "memory_type": {
+                    "type": "string",
+                    "description": "Optional type tag: decision, preference, problem, milestone, insight, person, task, idea, reference, someday-maybe",
+                },
+            },
+            "required": ["content"],
+        },
+        "kind": "memory",
+        "writes": True,
+        "context_memory": True,
+    },
+    {
+        "name": "read_daily_note",
+        "description": "Read the full contents of a daily note for a specific date.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "description": "Date in YYYY-MM-DD format",
+                },
+            },
+            "required": ["date"],
+        },
+        "kind": "memory",
+        "writes": False,
+        "context_memory": True,
+    },
+    {
+        "name": "list_daily_notes",
+        "description": "List recent daily notes with headlines, newest first.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Max notes to return (default 30)",
+                },
+            },
+            "required": [],
+        },
+        "kind": "memory",
+        "writes": False,
+        "context_memory": True,
+    },
+    {
+        "name": "read_memory",
+        "description": "Read the current MEMORY.md — your living snapshot of key facts.",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        "kind": "memory",
+        "writes": False,
+        "context_memory": True,
+    },
+    {
+        "name": "update_memory",
+        "description": "Overwrite MEMORY.md with new content. Always read_memory first, then write back the full merged snapshot.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The full new MEMORY.md content (replaces entire file)",
+                },
+            },
+            "required": ["content"],
+        },
+        "kind": "memory",
+        "writes": True,
+        "context_memory": True,
+    },
+    {
+        "name": "search_memory",
+        "description": "Full-text search across all your knowledge: daily notes, MEMORY.md, topic files, and facts. Use this to find information you've recorded.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query (natural language or keywords)",
+                },
+                "source_type": {
+                    "type": "string",
+                    "description": "Optional filter: 'daily', 'memory', 'topic', or 'fact'",
+                },
+                "memory_type": {
+                    "type": "string",
+                    "description": "Optional filter by memory type (decision, person, etc.)",
+                },
+                "date_from": {
+                    "type": "string",
+                    "description": "Optional start date (YYYY-MM-DD)",
+                },
+                "date_to": {
+                    "type": "string",
+                    "description": "Optional end date (YYYY-MM-DD)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (default 20, max 100)",
+                },
+            },
+            "required": ["query"],
+        },
+        "kind": "memory",
+        "writes": False,
+        "context_memory": True,
+    },
+    {
+        "name": "add_fact",
+        "description": "Record a temporal fact (entity-relationship triple) in your knowledge base. Facts have validity windows and can be queried later.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "subject": {"type": "string", "description": "The entity (e.g. 'John Smith')"},
+                "predicate": {"type": "string", "description": "The relationship (e.g. 'works at')"},
+                "object": {"type": "string", "description": "The value (e.g. 'Acme Corp')"},
+                "memory_type": {"type": "string", "description": "Optional type: person, decision, etc."},
+                "confidence": {"type": "number", "description": "Confidence 0.0-1.0 (default 1.0)"},
+            },
+            "required": ["subject", "predicate", "object"],
+        },
+        "kind": "memory",
+        "writes": True,
+        "context_memory": True,
+    },
+    {
+        "name": "query_facts",
+        "description": "Query temporal facts by subject, predicate, or point-in-time.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "subject": {"type": "string", "description": "Filter by subject (partial match)"},
+                "predicate": {"type": "string", "description": "Filter by predicate (partial match)"},
+                "as_of": {"type": "string", "description": "Point-in-time view (YYYY-MM-DD)"},
+                "memory_type": {"type": "string", "description": "Filter by memory type"},
+                "include_expired": {"type": "boolean", "description": "Include expired facts (default false)"},
+                "limit": {"type": "integer", "description": "Max results (default 50)"},
+            },
+            "required": [],
+        },
+        "kind": "memory",
+        "writes": False,
+        "context_memory": True,
+    },
+    {
+        "name": "invalidate_fact",
+        "description": "Mark a fact as no longer valid by setting its valid_to date.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "fact_id": {"type": "integer", "description": "The fact ID to invalidate"},
+                "valid_to": {"type": "string", "description": "End date (default: today)"},
+            },
+            "required": ["fact_id"],
+        },
+        "kind": "memory",
+        "writes": True,
+        "context_memory": True,
+    },
+]
+
+# ── Shared context tools ─────────────────────────────────────────────────────
+
+SHARED_CONTEXT_TOOLS = [
+    {
+        "name": "list_shared_context",
+        "description": "List shared knowledge files and entries visible to all agents.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "category": {"type": "string", "description": "Optional category filter"},
+            },
+            "required": [],
+        },
+        "kind": "shared_context",
+        "writes": False,
+        "context_memory": True,
+    },
+    {
+        "name": "read_shared_context",
+        "description": "Read a shared file by name or a shared entry by ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "filename": {"type": "string", "description": "Shared file name (e.g. 'policies.md')"},
+                "entry_id": {"type": "string", "description": "Shared entry UUID"},
+            },
+            "required": [],
+        },
+        "kind": "shared_context",
+        "writes": False,
+        "context_memory": True,
+    },
+    {
+        "name": "write_shared_context",
+        "description": "Publish a knowledge entry visible to all agents. Use for cross-agent information sharing.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Entry title"},
+                "content": {"type": "string", "description": "Entry content (markdown)"},
+                "category": {"type": "string", "description": "Optional category tag"},
+            },
+            "required": ["title", "content"],
+        },
+        "kind": "shared_context",
+        "writes": True,
+        "context_memory": True,
+    },
+]
+
 # ── Gmail tools ───────────────────────────────────────────────────────────────
 
 GMAIL_TOOLS = [
@@ -641,11 +869,17 @@ def get_tool_definitions(
     reports_enabled: bool = True,
     reminders_enabled: bool = True,
     scheduled_actions_enabled: bool = True,
+    memory_enabled: bool = True,
+    shared_context_enabled: bool = True,
     integration_tools: list[dict] | None = None,
     dynamic_real_tools: list[dict] | None = None,
 ) -> list[dict]:
     """Return the full list of tool definitions for the given feature flags."""
     tools = list(CONTEXT_TOOLS)
+    if memory_enabled:
+        tools.extend(MEMORY_TOOLS)
+    if shared_context_enabled:
+        tools.extend(SHARED_CONTEXT_TOOLS)
     if gmail_enabled:
         tools.extend(GMAIL_TOOLS)
     if calendar_enabled:

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -129,20 +129,26 @@ class ToolRegistry:
             search_memory, add_fact, query_facts, invalidate_fact,
         )
 
+        # Memory tools use context_dir (not agent_data_dir) because
+        # ContextManager expects the context directory as data_dir.
+        # Daily notes live at context_dir/daily/, MEMORY.md at context_dir/.
+        ctx_dir = self.context_dir
+        prefix = self.gcs_prefix
+
         if tool_name == "append_daily_note":
-            return append_daily_note(self.agent_data_dir, self.gcs_prefix, args["content"],
+            return append_daily_note(ctx_dir, prefix, args["content"],
                                      date=args.get("date"), memory_type=args.get("memory_type"))
         elif tool_name == "read_daily_note":
-            return read_daily_note(self.agent_data_dir, self.gcs_prefix, args["date"])
+            return read_daily_note(ctx_dir, prefix, args["date"])
         elif tool_name == "list_daily_notes":
-            return list_daily_notes(self.agent_data_dir, self.gcs_prefix, limit=args.get("limit", 30))
+            return list_daily_notes(ctx_dir, prefix, limit=args.get("limit", 30))
         elif tool_name == "read_memory":
-            return read_memory(self.agent_data_dir, self.gcs_prefix)
+            return read_memory(ctx_dir, prefix)
         elif tool_name == "update_memory":
-            return update_memory(self.agent_data_dir, self.gcs_prefix, args["content"])
+            return update_memory(ctx_dir, prefix, args["content"])
         elif tool_name == "search_memory":
             return search_memory(
-                self.agent_data_dir, self.gcs_prefix, args["query"],
+                ctx_dir, prefix, args["query"],
                 source_type=args.get("source_type"),
                 memory_type=args.get("memory_type"),
                 date_from=args.get("date_from"),
@@ -151,13 +157,13 @@ class ToolRegistry:
             )
         elif tool_name == "add_fact":
             return add_fact(
-                self.agent_data_dir, self.gcs_prefix,
+                ctx_dir, prefix,
                 subject=args["subject"], predicate=args["predicate"], object=args["object"],
                 memory_type=args.get("memory_type"), confidence=args.get("confidence", 1.0),
             )
         elif tool_name == "query_facts":
             return query_facts(
-                self.agent_data_dir, self.gcs_prefix,
+                ctx_dir, prefix,
                 subject=args.get("subject"), predicate=args.get("predicate"),
                 as_of=args.get("as_of"), memory_type=args.get("memory_type"),
                 include_expired=args.get("include_expired", False),
@@ -165,7 +171,7 @@ class ToolRegistry:
             )
         elif tool_name == "invalidate_fact":
             return invalidate_fact(
-                self.agent_data_dir, self.gcs_prefix,
+                ctx_dir, prefix,
                 fact_id=args["fact_id"], valid_to=args.get("valid_to"),
             )
         return {"error": f"Unknown memory tool: {tool_name}"}

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -1,8 +1,8 @@
 """
 Chatty — Tool registry and execution dispatcher.
 
-Dispatches tool calls by kind: context, gmail, calendar, web, real_tool,
-report, reminder, scheduled_action, integration.
+Dispatches tool calls by kind: context, memory, shared_context, gmail,
+calendar, web, real_tool, report, reminder, scheduled_action, integration.
 Each agent instance creates its own ToolRegistry with its own context_dir
 and access token.
 """
@@ -45,21 +45,29 @@ class ToolRegistry:
     def __init__(
         self,
         context_dir: str,
+        gcs_prefix: str = "",
         google_access_token: str = "",
         integration_executors: dict | None = None,
         agent_slug: str = "",
+        agent_name: str = "",
         reminder_handlers: dict | None = None,
         scheduled_action_handlers: dict | None = None,
     ):
         self.context_dir = context_dir
+        self.gcs_prefix = gcs_prefix
         self.google_access_token = google_access_token
         self.integration_executors: dict = integration_executors or {}
         self.agent_slug = agent_slug
+        self.agent_name = agent_name
 
         # Derived paths
         agent_data_dir = str(Path(context_dir).parent)
+        self.agent_data_dir = agent_data_dir
         self.real_tools_dir = str(Path(agent_data_dir) / "real_tools")
         self.reports_dir = str(Path(agent_data_dir) / "reports")
+
+        # Shared context data dir
+        self.shared_data_dir = str(Path(agent_data_dir).parent.parent / "shared")
 
         # Injected handlers for reminders and scheduled actions
         self.reminder_handlers: dict = reminder_handlers or {}
@@ -73,6 +81,10 @@ class ToolRegistry:
         try:
             if kind == "context":
                 return self._execute_context(tool_name, tool_args)
+            elif kind == "memory":
+                return self._execute_memory(tool_name, tool_args)
+            elif kind == "shared_context":
+                return self._execute_shared_context(tool_name, tool_args)
             elif kind == "gmail":
                 return self._execute_gmail(tool_name, tool_args)
             elif kind == "calendar":
@@ -107,6 +119,75 @@ class ToolRegistry:
         elif tool_name == "delete_context_file":
             return delete_context_file(self.context_dir, args["filename"])
         return {"error": f"Unknown context tool: {tool_name}"}
+
+    def _execute_memory(self, tool_name: str, args: dict) -> dict:
+        from core.agents.tools.memory_tools import (
+            append_daily_note, read_daily_note, list_daily_notes,
+            read_memory, update_memory,
+        )
+        from core.agents.memory.search_tools import (
+            search_memory, add_fact, query_facts, invalidate_fact,
+        )
+
+        if tool_name == "append_daily_note":
+            return append_daily_note(self.agent_data_dir, self.gcs_prefix, args["content"],
+                                     date=args.get("date"), memory_type=args.get("memory_type"))
+        elif tool_name == "read_daily_note":
+            return read_daily_note(self.agent_data_dir, self.gcs_prefix, args["date"])
+        elif tool_name == "list_daily_notes":
+            return list_daily_notes(self.agent_data_dir, self.gcs_prefix, limit=args.get("limit", 30))
+        elif tool_name == "read_memory":
+            return read_memory(self.agent_data_dir, self.gcs_prefix)
+        elif tool_name == "update_memory":
+            return update_memory(self.agent_data_dir, self.gcs_prefix, args["content"])
+        elif tool_name == "search_memory":
+            return search_memory(
+                self.agent_data_dir, self.gcs_prefix, args["query"],
+                source_type=args.get("source_type"),
+                memory_type=args.get("memory_type"),
+                date_from=args.get("date_from"),
+                date_to=args.get("date_to"),
+                limit=args.get("limit", 20),
+            )
+        elif tool_name == "add_fact":
+            return add_fact(
+                self.agent_data_dir, self.gcs_prefix,
+                subject=args["subject"], predicate=args["predicate"], object=args["object"],
+                memory_type=args.get("memory_type"), confidence=args.get("confidence", 1.0),
+            )
+        elif tool_name == "query_facts":
+            return query_facts(
+                self.agent_data_dir, self.gcs_prefix,
+                subject=args.get("subject"), predicate=args.get("predicate"),
+                as_of=args.get("as_of"), memory_type=args.get("memory_type"),
+                include_expired=args.get("include_expired", False),
+                limit=args.get("limit", 50),
+            )
+        elif tool_name == "invalidate_fact":
+            return invalidate_fact(
+                self.agent_data_dir, self.gcs_prefix,
+                fact_id=args["fact_id"], valid_to=args.get("valid_to"),
+            )
+        return {"error": f"Unknown memory tool: {tool_name}"}
+
+    def _execute_shared_context(self, tool_name: str, args: dict) -> dict:
+        from core.agents.shared_context.tools import (
+            list_shared_context, read_shared_context, write_shared_context,
+        )
+
+        if tool_name == "list_shared_context":
+            return list_shared_context(self.shared_data_dir, category=args.get("category", ""))
+        elif tool_name == "read_shared_context":
+            return read_shared_context(self.shared_data_dir,
+                                       filename=args.get("filename", ""),
+                                       entry_id=args.get("entry_id", ""))
+        elif tool_name == "write_shared_context":
+            return write_shared_context(
+                self.shared_data_dir, self.gcs_prefix, self.agent_name,
+                title=args["title"], content=args["content"],
+                category=args.get("category", ""),
+            )
+        return {"error": f"Unknown shared_context tool: {tool_name}"}
 
     def _execute_gmail(self, tool_name: str, args: dict) -> dict:
         if not self.google_access_token:

--- a/backend/core/agents/tools/memory_tools.py
+++ b/backend/core/agents/tools/memory_tools.py
@@ -1,0 +1,269 @@
+"""Chatty — Memory + daily note tools.
+
+Pure functions for the agent's living MEMORY.md snapshot and per-day daily
+notes. All operations go through ContextManager so local writes and GCS
+sync stay consistent with the rest of the context system.
+
+Handlers take `(data_dir, gcs_prefix, ...)` and build a ContextManager
+internally. Dispatched via `kind="memory"` in ToolRegistry.execute_tool.
+"""
+
+import hashlib
+import json
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from core.agents.context_manager import ContextManager
+from core.agents.memory.types import validate_memory_type, type_tag
+
+logger = logging.getLogger(__name__)
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+CT_TZ = ZoneInfo("America/Chicago")
+
+
+def _make_cm(data_dir: str, gcs_prefix: str) -> ContextManager:
+    return ContextManager(Path(data_dir), gcs_prefix)
+
+
+# ---------------------------------------------------------------------------
+# Write-ahead log for MEMORY.md
+# ---------------------------------------------------------------------------
+
+def _write_wal_entry(data_dir: str, source: str, previous_content: str, new_content_bytes: int) -> None:
+    """Append a WAL entry before a MEMORY.md overwrite.  Fire-and-forget."""
+    try:
+        wal_path = Path(data_dir) / "memory_wal.jsonl"
+        entry = {
+            "timestamp": datetime.now(CT_TZ).isoformat(),
+            "source": source,
+            "previous_hash": hashlib.sha256(previous_content.encode()).hexdigest(),
+            "previous_content": previous_content,
+            "new_bytes": new_content_bytes,
+        }
+        with open(wal_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+    except Exception:
+        logger.debug("Failed to write WAL entry", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Fire-and-forget FTS5 indexing
+# ---------------------------------------------------------------------------
+
+def _maybe_index_memory(data_dir: str, gcs_prefix: str, content: str) -> None:
+    """Update the FTS5 index for MEMORY.md.  Non-critical."""
+    try:
+        from core.agents.memory.db import get_instance
+        db = get_instance(data_dir)
+        if db:
+            db.index_document("memory", "MEMORY.md", "MEMORY.md", content)
+    except Exception:
+        logger.debug("FTS5 index update for MEMORY.md failed", exc_info=True)
+
+
+def _maybe_index_daily(data_dir: str, gcs_prefix: str, note_date: str) -> None:
+    """Re-index today's daily note in FTS5.  Non-critical."""
+    try:
+        from core.agents.memory.db import get_instance
+        db = get_instance(data_dir)
+        if db:
+            cm = _make_cm(data_dir, gcs_prefix)
+            content = cm.read_daily_note(note_date)
+            if content:
+                db.index_document("daily", note_date, note_date, content, date=note_date)
+    except Exception:
+        logger.debug("FTS5 index update for daily note %s failed", note_date, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+def append_daily_note(
+    data_dir: str,
+    gcs_prefix: str,
+    content: str,
+    date: str | None = None,
+    memory_type: str | None = None,
+) -> dict:
+    """Append a timestamped event to today's (or the specified day's) daily note."""
+    if date is not None and not _DATE_RE.match(date):
+        return {"error": f"date must be YYYY-MM-DD, got: {date}"}
+    if not content or not content.strip():
+        return {"error": "content is required"}
+
+    # Prefix content with type tag if a valid memory type is provided
+    validated_type = validate_memory_type(memory_type)
+    if validated_type:
+        content = f"{type_tag(validated_type)} {content}"
+
+    result = _make_cm(data_dir, gcs_prefix).append_daily_note(content, date=date)
+
+    # Fire-and-forget FTS5 indexing
+    note_date = result.get("date") or date
+    if note_date:
+        _maybe_index_daily(data_dir, gcs_prefix, note_date)
+
+    return result
+
+
+def read_daily_note(data_dir: str, gcs_prefix: str, date: str) -> dict:
+    """Read the full contents of a daily note for the given date."""
+    if not _DATE_RE.match(date or ""):
+        return {"error": f"date must be YYYY-MM-DD, got: {date}"}
+    content = _make_cm(data_dir, gcs_prefix).read_daily_note(date)
+    if not content:
+        return {"date": date, "content": "", "exists": False}
+    return {"date": date, "content": content, "exists": True}
+
+
+def list_daily_notes(data_dir: str, gcs_prefix: str, limit: int = 30) -> dict:
+    """List recent daily notes (newest first) with headlines."""
+    try:
+        limit = max(1, min(int(limit), 365))
+    except (TypeError, ValueError):
+        limit = 30
+    notes = _make_cm(data_dir, gcs_prefix).list_daily_notes(limit=limit)
+    return {"notes": notes}
+
+
+def read_memory(data_dir: str, gcs_prefix: str) -> dict:
+    """Return the current MEMORY.md content."""
+    return {"content": _make_cm(data_dir, gcs_prefix).read_memory()}
+
+
+def update_memory(data_dir: str, gcs_prefix: str, content: str) -> dict:
+    """Overwrite MEMORY.md with new content.
+
+    Always include the full desired content — this replaces the file.
+    Agents should typically read_memory first, then write back the merged
+    snapshot.
+    """
+    if content is None:
+        return {"error": "content is required"}
+
+    cm = _make_cm(data_dir, gcs_prefix)
+
+    # WAL: save previous content before overwriting
+    previous = cm.read_memory()
+    _write_wal_entry(data_dir, "tool", previous, len(content.encode("utf-8")))
+
+    cm.write_memory(content)
+
+    # Update FTS5 index
+    _maybe_index_memory(data_dir, gcs_prefix, content)
+
+    return {"filename": "MEMORY.md", "ok": True}
+
+
+def consolidate_memory(
+    data_dir: str,
+    gcs_prefix: str,
+    api_key: str,
+    days: int = 7,
+) -> dict:
+    """Regenerate MEMORY.md by synthesizing the last N days of daily notes.
+
+    Calls Claude Sonnet with the current MEMORY.md + recent daily notes
+    and asks for a tight, bulleted snapshot organized into Key People,
+    Active Projects, Decisions, and Lessons Learned.
+    """
+    try:
+        days = max(1, min(int(days), 90))
+    except (TypeError, ValueError):
+        days = 7
+
+    if not api_key:
+        return {"error": "no API key configured"}
+
+    cm = _make_cm(data_dir, gcs_prefix)
+    current_memory = cm.read_memory()
+    notes = cm.list_daily_notes(limit=days)
+    if not notes and not current_memory:
+        return {"ok": False, "error": "nothing to consolidate — no MEMORY.md and no daily notes"}
+
+    parts: list[str] = []
+    if current_memory:
+        parts.append("## Current MEMORY.md\n\n" + current_memory.strip())
+    for entry in notes:
+        content = cm.read_daily_note(entry["date"])
+        if content:
+            parts.append(f"## Daily note — {entry['date']}\n\n{content.strip()}")
+    corpus = "\n\n---\n\n".join(parts)
+
+    system_prompt = (
+        "You maintain an AI agent's MEMORY.md — a living, bulleted snapshot of the "
+        "most important durable knowledge the agent carries across sessions.\n\n"
+        "Regenerate MEMORY.md by synthesizing the existing MEMORY.md (if any) with "
+        "the recent daily notes below. Output MUST be markdown with exactly these "
+        "four H2 sections, in this order:\n\n"
+        "## Key People\n"
+        "## Active Projects\n"
+        "## Decisions\n"
+        "## Lessons Learned\n\n"
+        "Guidelines:\n"
+        "- Keep it tight. One line per person / project / decision / lesson.\n"
+        "- When synthesizing, weight items by durability:\n"
+        "  - ALWAYS keep: decisions and preferences (these are durable knowledge).\n"
+        "  - Keep if recent (last ~2 weeks): person context, insights, references.\n"
+        "  - Keep if still relevant: milestones, ideas, problems.\n"
+        "  - Drop when resolved: tasks, someday-maybe items.\n"
+        "- If a daily note entry has a [type] tag (e.g. [decision], [task]), use it to "
+        "judge importance per the durability tiers above.\n"
+        "- Drop stale items that haven't been mentioned recently and no longer matter.\n"
+        "- Preserve anything still relevant from the existing MEMORY.md even if it "
+        "wasn't mentioned in the recent daily notes.\n"
+        "- Do NOT wrap the output in triple backticks. Do NOT add preamble or "
+        "explanation — emit ONLY the markdown.\n"
+    )
+
+    user_message = f"Regenerate MEMORY.md from the following material:\n\n{corpus}"
+
+    try:
+        import anthropic
+        client = anthropic.Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=4096,
+            system=system_prompt,
+            messages=[{"role": "user", "content": user_message}],
+        )
+    except Exception as e:
+        logger.warning("consolidate_memory Claude call failed: %s", e)
+        return {"error": f"Claude call failed: {e}"}
+
+    new_memory = ""
+    for block in response.content:
+        if getattr(block, "type", None) == "text":
+            new_memory += block.text
+
+    new_memory = new_memory.strip()
+    if not new_memory:
+        return {"error": "Claude returned empty content"}
+
+    # WAL: save previous content before overwriting
+    _write_wal_entry(data_dir, "consolidation", current_memory, len(new_memory.encode("utf-8")))
+
+    cm.write_memory(new_memory)
+
+    # Update FTS5 index
+    _maybe_index_memory(data_dir, gcs_prefix, new_memory)
+
+    input_tokens = getattr(response.usage, "input_tokens", 0) if hasattr(response, "usage") else 0
+    output_tokens = getattr(response.usage, "output_tokens", 0) if hasattr(response, "usage") else 0
+    logger.info(
+        "consolidate_memory wrote MEMORY.md (%d chars, tokens: %d/%d, days=%d)",
+        len(new_memory), input_tokens, output_tokens, days,
+    )
+    return {
+        "ok": True,
+        "filename": "MEMORY.md",
+        "bytes_written": len(new_memory),
+        "days_synthesized": days,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+    }

--- a/backend/core/providers/anthropic_provider.py
+++ b/backend/core/providers/anthropic_provider.py
@@ -119,10 +119,19 @@ class AnthropicProvider(AIProvider):
             yield {"type": "_turn_complete", "tool_calls": [], "stop_reason": "error"}
             return
 
+        # Extract usage from the final message
+        usage_info = {}
+        if hasattr(final_message, "usage") and final_message.usage:
+            usage_info = {
+                "input_tokens": getattr(final_message.usage, "input_tokens", 0),
+                "output_tokens": getattr(final_message.usage, "output_tokens", 0),
+            }
+
         yield {
             "type": "_turn_complete",
             "tool_calls": tool_calls,
             "stop_reason": stop_reason,
+            "usage": usage_info,
         }
 
     def add_tool_results(

--- a/backend/main.py
+++ b/backend/main.py
@@ -72,9 +72,17 @@ async def lifespan(app: FastAPI):
         init_whatsapp_db()
         logger.info("WhatsApp bridge configured at %s", settings.whatsapp.bridge_url)
 
-    # Initialize reminders + scheduled actions DB
+    # Initialize reminders + scheduled actions DB (also creates dreaming tables)
     from core.agents.reminders.db import init_db as init_reminders_db
     init_reminders_db()
+
+    # Initialize shared context DB
+    from core.agents.shared_context.db import init_db as init_shared_context_db
+    init_shared_context_db()
+
+    # Initialize tool toggle config DB
+    from core.agents.tool_config_db import init_db as init_tool_config_db
+    init_tool_config_db()
 
     # Start APScheduler for reminders and scheduled actions
     from apscheduler.schedulers.background import BackgroundScheduler
@@ -85,8 +93,14 @@ async def lifespan(app: FastAPI):
 
     _scheduler.add_job(process_due_reminders, "interval", seconds=60, id="reminder_heartbeat")
     _scheduler.add_job(process_due_actions, "interval", seconds=60, id="scheduled_actions_processor")
+
+    # Nightly memory/dreaming jobs (run per-agent)
+    from core.agents.scheduled_actions.nightly import run_nightly_jobs
+    _scheduler.add_job(run_nightly_jobs, "cron", hour=23, minute=0, id="nightly_memory_jobs",
+                       timezone="America/Chicago")
+
     _scheduler.start()
-    logger.info("APScheduler started (reminder heartbeat + scheduled actions processor)")
+    logger.info("APScheduler started (reminder heartbeat + scheduled actions + nightly jobs)")
 
     # Log WhatsApp session status on startup
     if settings.whatsapp.is_configured:
@@ -137,6 +151,9 @@ app.include_router(scheduled_actions_router, prefix="/api/scheduled-actions", ta
 app.include_router(setup_router, prefix="/api/setup", tags=["setup"])
 app.include_router(backup_router, prefix="/api/backup", tags=["backup"])
 app.include_router(telegram_router, prefix="/api/telegram", tags=["telegram"])
+
+from core.agents.shared_context.router import router as shared_context_router
+app.include_router(shared_context_router, tags=["shared-context"])
 
 
 @app.get("/api/health")

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -1,7 +1,8 @@
 /**
  * Chatty — AgentPage.
  * Immersive chat with auto-hiding top bar, tool mode selector,
- * collapsible sidebar, and Chat/Knowledge/Reports tabs.
+ * collapsible sidebar, Chat/Knowledge/Reports/Activity tabs,
+ * plan mode toggle, and Train/Improve smart detection.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -13,6 +14,7 @@ import { useScrollDirection } from './hooks/useScrollDirection';
 import { AgentChatPanel } from './components/AgentChatPanel';
 import { AgentContextEditor } from './components/AgentContextEditor';
 import ReportsPanel from './reports/ReportsPanel';
+import AgentActivityPanel from './components/AgentActivityPanel';
 import { ConversationSidebar } from './components/ConversationSidebar';
 import { AvatarPicker } from './components/AvatarPicker';
 import { TelegramSettings } from './components/TelegramSettings';
@@ -30,7 +32,7 @@ interface AgentRow {
   telegram_bot_username: string;
 }
 
-type Tab = 'chat' | 'knowledge' | 'reports' | 'telegram';
+type Tab = 'chat' | 'knowledge' | 'reports' | 'activity' | 'telegram';
 
 const TOOL_MODES: { key: ToolMode; label: string; activeClass: string }[] = [
   { key: 'read-only', label: 'Read Only', activeClass: 'bg-gray-600' },
@@ -95,7 +97,6 @@ export function AgentPage() {
     const wasIncomplete = prevOnboardingComplete.current === false;
     prevOnboardingComplete.current = agent.onboarding_complete;
     if (wasIncomplete && agent.onboarding_complete) {
-      // Exit training mode now that onboarding is done
       if (chat.trainingMode) {
         chat.setTrainingMode(false);
       }
@@ -115,6 +116,9 @@ export function AgentPage() {
     if (chat.trainingMode) {
       chat.setTrainingMode(false);
     }
+    if (chat.planMode) {
+      chat.setPlanMode(false);
+    }
     const msgs = await convs.selectConversation(id);
     chat.loadMessages(msgs, id);
   }
@@ -129,6 +133,8 @@ export function AgentPage() {
     convs.startNewChat();
     if (chat.trainingMode) {
       chat.setTrainingMode(false);
+    } else if (chat.planMode) {
+      chat.setPlanMode(false);
     } else {
       chat.clear();
     }
@@ -136,7 +142,12 @@ export function AgentPage() {
 
   function handleStartOnboarding() {
     convs.startNewChat();
-    chat.setTrainingMode(true);
+    chat.setTrainingMode(true, 'topic');
+  }
+
+  function handleStartImprove() {
+    convs.startNewChat();
+    chat.setTrainingMode(true, 'improve', 'Start improve mode. Review my existing knowledge and help me fill gaps.');
   }
 
   function handleToolModeChange(mode: ToolMode) {
@@ -144,6 +155,13 @@ export function AgentPage() {
       if (!window.confirm(`Enable Power mode? ${agent?.agent_name || 'This agent'} will be able to read and write without asking for confirmation.`)) return;
     }
     chat.setToolMode(mode);
+  }
+
+  function handleTogglePlanMode() {
+    chat.setPlanMode(!chat.planMode);
+    if (!chat.planMode) {
+      convs.startNewChat();
+    }
   }
 
   function handleAvatarComplete() {
@@ -168,12 +186,15 @@ export function AgentPage() {
     .toUpperCase()
     .slice(0, 2);
 
+  // Smart label: "Train" if not onboarded, "Improve" if already complete
+  const trainLabel = agent.onboarding_complete ? `Improve ${agent.agent_name}` : `Train ${agent.agent_name}`;
+
   // Only auto-hide on chat tab; always visible on other tabs
   const showTopBar = activeTab !== 'chat' || topBarVisible;
 
   return (
     <div className="flex flex-col h-screen bg-gray-950 text-white overflow-hidden">
-      {/* Top bar — auto-hides on scroll in chat tab */}
+      {/* Top bar -- auto-hides on scroll in chat tab */}
       <div className={`flex items-center gap-3 px-4 py-3 border-b border-gray-800 bg-gray-950/95 backdrop-blur-sm flex-shrink-0 z-30 transition-all duration-300 ${
         showTopBar ? 'translate-y-0 opacity-100' : '-translate-y-full opacity-0 pointer-events-none'
       }`}>
@@ -182,7 +203,7 @@ export function AgentPage() {
           className="text-gray-400 hover:text-white transition p-1.5 rounded-lg hover:bg-gray-800 text-sm"
           title="Back to dashboard"
         >
-          ←
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" /></svg>
         </button>
 
         <div className="w-8 h-8 rounded-full bg-indigo-600 flex items-center justify-center text-xs font-bold flex-shrink-0 overflow-hidden">
@@ -203,26 +224,53 @@ export function AgentPage() {
           </button>
         )}
 
-        {/* Tool mode selector — hidden on mobile */}
-        <div className="hidden sm:flex items-center bg-gray-800 rounded-full p-0.5 gap-0.5">
-          {TOOL_MODES.map(m => (
-            <button
-              key={m.key}
-              onClick={() => handleToolModeChange(m.key)}
-              className={`px-2 py-0.5 text-xs font-medium rounded-full transition-all ${
-                chat.toolMode === m.key
-                  ? `${m.activeClass} text-white`
-                  : 'text-gray-400 hover:text-white'
-              }`}
-            >
-              {m.label}
-            </button>
-          ))}
-        </div>
+        {/* Tool mode selector -- hidden on mobile, only on chat tab */}
+        {activeTab === 'chat' && (
+          <div className="hidden sm:flex items-center bg-gray-800 rounded-full p-0.5 gap-0.5">
+            {TOOL_MODES.map(m => (
+              <button
+                key={m.key}
+                onClick={() => handleToolModeChange(m.key)}
+                className={`px-2 py-0.5 text-xs font-medium rounded-full transition-all ${
+                  chat.toolMode === m.key
+                    ? `${m.activeClass} text-white`
+                    : 'text-gray-400 hover:text-white'
+                }`}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Plan mode toggle -- only on chat tab */}
+        {activeTab === 'chat' && (
+          <button
+            onClick={handleTogglePlanMode}
+            className={`hidden sm:inline-flex text-xs font-medium rounded-full px-2.5 py-0.5 transition-all ${
+              chat.planMode
+                ? 'bg-teal-700/60 text-teal-200 border border-teal-600/40'
+                : 'bg-gray-800 text-gray-400 hover:text-white border border-gray-700'
+            }`}
+            title={chat.planMode ? 'Exit plan mode' : 'Enter plan mode -- agent proposes a plan before acting'}
+          >
+            {chat.planMode ? 'Plan Mode ON' : 'Plan Mode'}
+          </button>
+        )}
+
+        {/* Train/Improve button -- only on chat tab */}
+        {activeTab === 'chat' && !chat.trainingMode && (
+          <button
+            onClick={agent.onboarding_complete ? handleStartImprove : handleStartOnboarding}
+            className="hidden sm:inline-flex text-xs font-medium rounded-full px-2.5 py-0.5 bg-gray-800 text-gray-400 hover:text-white border border-gray-700 transition"
+          >
+            {trainLabel}
+          </button>
+        )}
 
         {/* Tab switcher */}
         <div className="ml-auto flex items-center bg-gray-800 rounded-lg p-0.5 gap-0.5">
-          {(['chat', 'knowledge', 'reports', 'telegram'] as Tab[]).map(tab => (
+          {(['chat', 'knowledge', 'reports', 'activity', 'telegram'] as Tab[]).map(tab => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
@@ -232,7 +280,7 @@ export function AgentPage() {
                   : 'text-gray-400 hover:text-white'
               }`}
             >
-              {tab === 'chat' ? 'Chat' : tab === 'knowledge' ? 'Knowledge' : tab === 'reports' ? 'Reports' : 'Telegram'}
+              {tab === 'chat' ? 'Chat' : tab === 'knowledge' ? 'Knowledge' : tab === 'reports' ? 'Reports' : tab === 'activity' ? 'Activity' : 'Telegram'}
             </button>
           ))}
         </div>
@@ -243,6 +291,40 @@ export function AgentPage() {
         <div className="px-3 py-1.5 bg-amber-900/30 border-b border-amber-700/40 flex items-center gap-2 flex-shrink-0">
           <span className="text-amber-400 text-xs font-semibold">POWER MODE</span>
           <span className="text-xs text-amber-300">{agent.agent_name} can read and write without confirmation.</span>
+        </div>
+      )}
+
+      {/* Plan mode banner */}
+      {chat.planMode && (
+        <div className="px-3 py-1.5 bg-teal-900/30 border-b border-teal-700/40 flex items-center gap-2 flex-shrink-0">
+          <span className="text-teal-400 text-xs font-semibold">PLAN MODE</span>
+          <span className="text-xs text-teal-300">{agent.agent_name} will propose a plan before taking action.</span>
+          <button
+            onClick={() => chat.setPlanMode(false)}
+            className="ml-auto text-xs text-teal-400 hover:text-teal-200 transition"
+          >
+            Exit
+          </button>
+        </div>
+      )}
+
+      {/* Training mode banner */}
+      {chat.trainingMode && (
+        <div className="px-3 py-1.5 bg-purple-900/30 border-b border-purple-700/40 flex items-center gap-2 flex-shrink-0">
+          <span className="text-purple-400 text-xs font-semibold">
+            {chat.trainingType === 'improve' ? 'IMPROVE MODE' : 'TRAINING MODE'}
+          </span>
+          <span className="text-xs text-purple-300">
+            {chat.trainingType === 'improve'
+              ? `Reviewing and improving ${agent.agent_name}'s knowledge.`
+              : `Teaching ${agent.agent_name} about your business.`}
+          </span>
+          <button
+            onClick={() => chat.setTrainingMode(false)}
+            className="ml-auto text-xs text-purple-400 hover:text-purple-200 transition"
+          >
+            Exit
+          </button>
         </div>
       )}
 
@@ -271,13 +353,23 @@ export function AgentPage() {
               onStop={chat.stop}
               onApprove={chat.approveAction}
               onDeny={chat.denyAction}
+              onApprovePlan={chat.approvePlan}
+              onIteratePlan={chat.iteratePlan}
               scrollRef={scrollRef}
+              contextUsage={chat.contextUsage}
+              toolMode={chat.toolMode}
+              onToolModeChange={handleToolModeChange}
+              agentName={agent.agent_name}
             />
           </>
         ) : activeTab === 'knowledge' ? (
           <AgentContextEditor agentId={agentId!} />
         ) : activeTab === 'reports' ? (
           <ReportsPanel apiPrefix={apiPrefix} />
+        ) : activeTab === 'activity' ? (
+          <div className="flex-1 overflow-y-auto">
+            <AgentActivityPanel apiPrefix={apiPrefix} />
+          </div>
         ) : (
           <div className="flex-1 overflow-y-auto">
             <TelegramSettings

--- a/frontend/src/agent/components/AgentActivityPanel.tsx
+++ b/frontend/src/agent/components/AgentActivityPanel.tsx
@@ -1,0 +1,145 @@
+/**
+ * Chatty — AgentActivityPanel.
+ * Shows recent heartbeat / scheduled activity for an agent.
+ */
+
+import { useState, useEffect } from 'react';
+import { api } from '../../core/api/client';
+
+interface ActivityRecord {
+  id: string;
+  agent: string;
+  action_type: string;
+  started_at: string;
+  status: string;
+  result_summary: string | null;
+  result_full: string | null;
+  tool_calls: { tool: string; args: Record<string, unknown>; result: string; duration_ms: number }[] | null;
+  model_used: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  duration_ms: number;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return String(n);
+}
+
+function timeAgo(iso: string): string {
+  const d = new Date(iso + 'Z');
+  const diff = Date.now() - d.getTime();
+  if (diff < 60000) return 'Just now';
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  return `${Math.floor(diff / 86400000)}d ago`;
+}
+
+export default function AgentActivityPanel({ apiPrefix }: { apiPrefix: string }) {
+  const [records, setRecords] = useState<ActivityRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await api<{ activities: ActivityRecord[] }>(`${apiPrefix}/activity?limit=20`);
+        if (!cancelled) setRecords(result.activities);
+      } catch {
+        // Silently handle -- activity is supplementary
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [apiPrefix]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-gray-500 py-8 justify-center">
+        <div className="animate-spin w-4 h-4 border-2 border-indigo-500 border-t-transparent rounded-full" />
+        Loading activity...
+      </div>
+    );
+  }
+
+  if (records.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-sm text-gray-500">No recent heartbeat activity.</p>
+        <p className="text-xs text-gray-600 mt-1">Actions taken during periodic checks will appear here.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 p-4">
+      <h3 className="text-sm font-semibold text-gray-200 mb-3">Recent Activity</h3>
+      {records.map(rec => (
+        <div key={rec.id} className="border border-gray-700 rounded-lg bg-gray-900">
+          <button
+            onClick={() => setExpanded(expanded === rec.id ? null : rec.id)}
+            className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-gray-800/50 transition-colors rounded-lg"
+          >
+            <div className="w-2 h-2 rounded-full bg-indigo-500 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-gray-200 capitalize">{rec.action_type}</span>
+                <span className="text-xs text-gray-500">{timeAgo(rec.started_at)}</span>
+              </div>
+              {rec.result_summary && (
+                <p className="text-xs text-gray-500 truncate mt-0.5">{rec.result_summary}</p>
+              )}
+            </div>
+            <div className="text-xs text-gray-500 shrink-0 text-right">
+              {rec.duration_ms ? `${(rec.duration_ms / 1000).toFixed(1)}s` : ''}
+              {rec.tool_calls && ` | ${rec.tool_calls.length} tools`}
+            </div>
+            <svg
+              className={`w-4 h-4 text-gray-500 shrink-0 transition-transform ${expanded === rec.id ? 'rotate-180' : ''}`}
+              fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {expanded === rec.id && (
+            <div className="px-4 pb-4 border-t border-gray-700/50">
+              <div className="flex flex-wrap gap-3 mt-3 text-xs text-gray-500">
+                {rec.model_used && <span>Model: {rec.model_used.split('-').slice(-2).join('-')}</span>}
+                <span>Tokens: {formatTokens(rec.input_tokens + rec.output_tokens)}</span>
+                <span>{new Date(rec.started_at + 'Z').toLocaleString()}</span>
+              </div>
+
+              {rec.result_full && (
+                <div className="mt-3">
+                  <div className="text-xs text-gray-400 bg-gray-800/50 px-3 py-2 rounded max-h-40 overflow-auto whitespace-pre-wrap">
+                    {rec.result_full}
+                  </div>
+                </div>
+              )}
+
+              {rec.tool_calls && rec.tool_calls.length > 0 && (
+                <div className="mt-3 space-y-1.5">
+                  {rec.tool_calls.map((tc, i) => (
+                    <div key={i} className="text-xs bg-gray-800/50 px-3 py-2 rounded">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-gray-200">{tc.tool}</span>
+                        <span className="text-gray-500">{tc.duration_ms}ms</span>
+                      </div>
+                      {tc.result && (
+                        <div className="text-gray-500 mt-1 max-h-16 overflow-auto whitespace-pre-wrap">{tc.result}</div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -1,15 +1,17 @@
 /**
  * Chatty — AgentChatPanel.
  * Centered reading column with floating pill input and gradient fade.
- * File upload via paperclip + drag-and-drop.
+ * File upload via paperclip + drag-and-drop. PDF support.
+ * Context usage indicator. Tool mode selector. Help text.
  */
 
 import { useState, useRef, useEffect, useCallback, type RefObject, type KeyboardEvent, type DragEvent, type MouseEvent } from 'react';
-import type { ChatMessage } from '../hooks/useAgentChat';
+import type { ChatMessage, ContextUsage, ToolMode } from '../hooks/useAgentChat';
 import { AgentMessageBubble } from './AgentMessageBubble';
 
-const ALLOWED_EXTENSIONS = new Set(['csv', 'xlsx', 'md', 'txt']);
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_EXTENSIONS = new Set(['csv', 'xlsx', 'md', 'txt', 'pdf']);
+const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1 MB for non-PDF
+const MAX_PDF_SIZE = 10 * 1024 * 1024; // 10 MB for PDF
 const MAX_FILES = 5;
 
 function getExtension(name: string): string {
@@ -23,10 +25,26 @@ interface Props {
   onStop: () => void;
   onApprove?: (msgId: string) => void;
   onDeny?: (msgId: string) => void;
+  onApprovePlan?: (msgId: string) => void;
+  onIteratePlan?: (msgId: string) => void;
   scrollRef?: RefObject<HTMLDivElement | null>;
+  contextUsage?: ContextUsage | null;
+  toolMode?: ToolMode;
+  onToolModeChange?: (mode: ToolMode) => void;
+  agentName?: string;
 }
 
-export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprove, onDeny, scrollRef: externalScrollRef }: Props) {
+const TOOL_MODES: { key: ToolMode; label: string; activeClass: string }[] = [
+  { key: 'read-only', label: 'Read Only', activeClass: 'bg-gray-600' },
+  { key: 'normal', label: 'Normal', activeClass: 'bg-indigo-600' },
+  { key: 'power', label: 'Power', activeClass: 'bg-amber-600' },
+];
+
+export function AgentChatPanel({
+  messages, isStreaming, onSend, onStop, onApprove, onDeny,
+  onApprovePlan, onIteratePlan, scrollRef: externalScrollRef,
+  contextUsage, toolMode, onToolModeChange, agentName,
+}: Props) {
   const [input, setInput] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [dragOver, setDragOver] = useState(false);
@@ -64,8 +82,10 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprov
         errors.push(`${f.name}: unsupported type (.${ext})`);
         continue;
       }
-      if (f.size > MAX_FILE_SIZE) {
-        errors.push(`${f.name}: exceeds 10 MB`);
+      const maxSize = ext === 'pdf' ? MAX_PDF_SIZE : MAX_FILE_SIZE;
+      const maxLabel = ext === 'pdf' ? '10 MB' : '1 MB';
+      if (f.size > maxSize) {
+        errors.push(`${f.name}: exceeds ${maxLabel}`);
         continue;
       }
       if (f.size === 0) {
@@ -136,8 +156,15 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprov
     textareaRef.current?.focus();
   }
 
+  function handleToolModeClick(mode: ToolMode) {
+    if (!onToolModeChange) return;
+    if (mode === 'power') {
+      if (!window.confirm(`Enable Power mode? ${agentName || 'This agent'} will be able to read and write without asking for confirmation.`)) return;
+    }
+    onToolModeChange(mode);
+  }
+
   const isEmpty = messages.length === 0;
-  const showToolCalls = localStorage.getItem('chatty_show_tool_calls') === 'true';
 
   function renderInputBox() {
     return (
@@ -168,28 +195,50 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprov
           />
 
           <div className="flex items-center justify-between px-4 pb-3 pt-1">
-            {/* Paperclip */}
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isStreaming}
-              title="Attach files (CSV, XLSX, MD, TXT)"
-              className="text-gray-500 hover:text-gray-300 disabled:opacity-30 transition p-1"
-            >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              accept=".csv,.xlsx,.md,.txt"
-              className="hidden"
-              onChange={e => {
-                if (e.target.files?.length) {
-                  validateAndAddFiles(Array.from(e.target.files));
-                  e.target.value = '';
-                }
-              }}
-            />
+            {/* Left side: paperclip + tool mode */}
+            <div className="flex items-center gap-2">
+              {/* Paperclip */}
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isStreaming}
+                title="Attach files (CSV, XLSX, MD, TXT, PDF)"
+                className="text-gray-500 hover:text-gray-300 disabled:opacity-30 transition p-1"
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept=".csv,.xlsx,.md,.txt,.pdf"
+                className="hidden"
+                onChange={e => {
+                  if (e.target.files?.length) {
+                    validateAndAddFiles(Array.from(e.target.files));
+                    e.target.value = '';
+                  }
+                }}
+              />
+
+              {/* Inline tool mode selector (visible on sm+) */}
+              {toolMode && onToolModeChange && (
+                <div className="hidden sm:flex items-center bg-gray-900/60 rounded-full p-0.5 gap-0.5">
+                  {TOOL_MODES.map(m => (
+                    <button
+                      key={m.key}
+                      onClick={() => handleToolModeClick(m.key)}
+                      className={`px-2 py-0.5 text-[10px] font-medium rounded-full transition-all ${
+                        toolMode === m.key
+                          ? `${m.activeClass} text-white`
+                          : 'text-gray-500 hover:text-gray-300'
+                      }`}
+                    >
+                      {m.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
 
             <div className="flex gap-2">
               {isStreaming ? (
@@ -211,6 +260,20 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprov
             </div>
           </div>
         </div>
+
+        {/* Help text + context usage */}
+        <p className="text-center text-[10px] text-gray-600 mt-1.5">
+          Enter to send &middot; Shift+Enter for new line
+        </p>
+        {contextUsage && (() => {
+          const pct = Math.round((contextUsage.inputTokens / contextUsage.contextWindow) * 100);
+          const color = pct >= 80 ? 'text-red-400' : pct >= 60 ? 'text-amber-400' : 'text-gray-600';
+          return (
+            <p className={`text-center text-[10px] ${color} mt-0.5`}>
+              {pct}% context used
+            </p>
+          );
+        })()}
       </div>
     );
   }
@@ -229,7 +292,7 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprov
         </div>
       )}
 
-      {/* Messages — centered reading column */}
+      {/* Messages -- centered reading column */}
       <div
         ref={scrollContainerRef}
         className={`flex-1 overflow-y-auto ${isEmpty && !isStreaming ? '' : 'pb-40 sm:pb-48'}`}
@@ -255,7 +318,8 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprov
                 message={msg}
                 onApprove={onApprove}
                 onDeny={onDeny}
-                showToolCalls={showToolCalls}
+                onApprovePlan={onApprovePlan}
+                onIteratePlan={onIteratePlan}
               />
             ))}
           </div>
@@ -269,7 +333,7 @@ export function AgentChatPanel({ messages, isStreaming, onSend, onStop, onApprov
         </div>
       )}
 
-      {/* Floating input — only when messages exist */}
+      {/* Floating input -- only when messages exist */}
       {(!isEmpty || isStreaming) && (
         <div className="absolute bottom-0 inset-x-0 pointer-events-none z-20">
           <div className="h-12 bg-gradient-to-t from-gray-950 to-transparent" />

--- a/frontend/src/agent/components/AgentMessageBubble.tsx
+++ b/frontend/src/agent/components/AgentMessageBubble.tsx
@@ -1,120 +1,151 @@
 /**
  * Chatty — AgentMessageBubble.
  * Claude-style: flat assistant messages with markdown, branded user bubbles.
- * Expandable tool pills with elapsed timer. Confirmation cards for write ops.
+ * Individual expandable tool pills with elapsed timer. Confirmation cards for write ops.
+ * Plan mode cards. Copy button per message.
  */
 
 import { useState, useEffect } from 'react';
-import type { ChatMessage, ToolCallInfo, PendingConfirmation } from '../hooks/useAgentChat';
+import type { ChatMessage, ToolCallInfo, PendingConfirmation, PendingPlan, InlineReport } from '../hooks/useAgentChat';
 import MarkdownContent from './MarkdownContent';
+import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
+import ReportRenderer from '../reports/ReportRenderer';
 
 interface Props {
   message: ChatMessage;
   onApprove?: (msgId: string) => void;
   onDeny?: (msgId: string) => void;
-  showToolCalls?: boolean;
+  onApprovePlan?: (msgId: string) => void;
+  onIteratePlan?: (msgId: string) => void;
 }
 
 const HUNG_THRESHOLD_SEC = 30;
 
-function ToolCallBox({ toolCalls }: { toolCalls: ToolCallInfo[] }) {
-  const [expanded, setExpanded] = useState(false);
-  const [, setTick] = useState(0);
+/* ── Copy Button ─────────────────────────────────────────────────── */
 
-  // Tick for running timers
-  const anyRunning = toolCalls.some(tc => tc.status === 'running');
-  useEffect(() => {
-    if (!anyRunning) return;
-    const id = setInterval(() => setTick(t => t + 1), 500);
-    return () => clearInterval(id);
-  }, [anyRunning]);
+function CopyButton({ copied, onClick }: { copied: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="p-1 text-gray-500 hover:text-gray-300 rounded transition-colors"
+      title={copied ? 'Copied!' : 'Copy message'}
+    >
+      {copied ? (
+        <svg className="w-3.5 h-3.5 text-green-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" />
+          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}
 
-  // Show the latest tool call in the summary line
-  const latest = toolCalls[toolCalls.length - 1];
-  const doneCount = toolCalls.filter(tc => tc.status === 'done').length;
-  const failedCount = toolCalls.filter(tc => tc.status === 'error').length;
-  const runningCount = toolCalls.filter(tc => tc.status === 'running').length;
+/* ── Tool Call Bubble (individual expandable pill) ────────────────── */
 
-  const latestElapsed = latest.status === 'running'
-    ? ((Date.now() - latest.startedAt) / 1000).toFixed(1)
-    : latest.elapsedMs ? (latest.elapsedMs / 1000).toFixed(1) : null;
-  const isHung = latest.status === 'running' && latestElapsed !== null && parseFloat(latestElapsed) >= HUNG_THRESHOLD_SEC;
-
-  const summaryIcon = runningCount > 0 ? '⏳' : failedCount > 0 ? '✗' : '✓';
-  const summaryBg = runningCount > 0
-    ? isHung ? 'bg-red-900/30 border-red-700/40' : 'bg-yellow-900/30 border-yellow-700/40'
-    : failedCount > 0 ? 'bg-red-900/20 border-red-700/30' : 'bg-green-900/20 border-green-700/30';
-  const summaryColor = runningCount > 0
-    ? isHung ? 'text-red-300' : 'text-yellow-300'
-    : failedCount > 0 ? 'text-red-300' : 'text-green-300';
+function ToolCallBubble({ tc, isExpanded, onToggle }: {
+  tc: ToolCallInfo;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const isRunning = tc.status === 'running';
+  const elapsed = isRunning ? Math.round((Date.now() - tc.startedAt) / 1000) : null;
+  const isHung = isRunning && elapsed !== null && elapsed >= HUNG_THRESHOLD_SEC;
 
   return (
-    <div className={`rounded-lg border ${summaryBg} text-xs`}>
-      {/* Summary line — shows latest tool + counts */}
+    <div className="text-xs rounded-lg overflow-hidden bg-gray-800/80 border border-gray-700/60 shadow-sm">
+      {/* Compact header -- always visible, clickable */}
       <button
-        onClick={() => setExpanded(e => !e)}
-        className={`flex items-center gap-2 px-3 py-1.5 w-full text-left ${summaryColor}`}
+        onClick={onToggle}
+        className="w-full flex items-center gap-1.5 px-2.5 py-1.5 transition-opacity cursor-pointer text-gray-400 hover:bg-gray-700/40"
       >
-        <span className={runningCount > 0 ? 'animate-pulse' : ''}>{summaryIcon}</span>
-        <span className="font-mono font-medium">{latest.tool}</span>
-        {toolCalls.length > 1 && (
-          <span className="text-gray-500">
-            {runningCount > 0
-              ? `(${doneCount + failedCount}/${toolCalls.length})`
-              : `(${toolCalls.length} tools)`}
+        {/* Status dot */}
+        {isRunning ? (
+          <span className={`w-2 h-2 rounded-full flex-shrink-0 animate-pulse ${
+            isHung ? 'bg-red-400 ring-2 ring-red-500/40' : 'bg-amber-400'
+          }`} />
+        ) : (
+          <span className="w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />
+        )}
+
+        {/* Tool label */}
+        <span className="truncate text-gray-300">{_toolLabel(tc.tool)}</span>
+
+        {/* Duration / elapsed timer */}
+        {isRunning && elapsed !== null && elapsed > 2 && (
+          <span className={`ml-auto text-[10px] tabular-nums ${
+            isHung ? 'text-red-400 font-semibold' : 'text-gray-500'
+          }`}>
+            {elapsed}s
           </span>
         )}
-        {latestElapsed && (
-          <span className={`ml-auto ${isHung ? 'text-red-400' : 'text-gray-500'}`}>{latestElapsed}s</span>
+        {!isRunning && tc.durationMs != null && (
+          <span className="ml-auto text-[10px] tabular-nums text-gray-500">
+            {tc.durationMs < 1000 ? `${tc.durationMs}ms` : `${(tc.durationMs / 1000).toFixed(1)}s`}
+          </span>
         )}
-        <span className={`text-gray-500 transition ${expanded ? 'rotate-180' : ''}`}>▾</span>
+        {!isRunning && tc.durationMs == null && tc.elapsedMs != null && (
+          <span className="ml-auto text-[10px] tabular-nums text-gray-500">
+            {tc.elapsedMs < 1000 ? `${tc.elapsedMs}ms` : `${(tc.elapsedMs / 1000).toFixed(1)}s`}
+          </span>
+        )}
+
+        {/* Expand/collapse chevron */}
+        <svg
+          className={`w-3 h-3 flex-shrink-0 transition-transform ${isExpanded ? 'rotate-180' : ''} text-gray-500`}
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" />
+        </svg>
       </button>
 
-      {/* Expanded: all tool calls with details */}
-      {expanded && (
-        <div className="border-t border-gray-700/50 px-3 pb-2 space-y-3 max-h-80 overflow-y-auto">
-          {toolCalls.map((tc, i) => {
-            const tcIcon = tc.status === 'running' ? '⏳' : tc.status === 'done' ? '✓' : '✗';
-            const tcColor = tc.status === 'running' ? 'text-yellow-300' : tc.status === 'done' ? 'text-green-300' : 'text-red-300';
-            const tcElapsed = tc.status === 'running'
-              ? ((Date.now() - tc.startedAt) / 1000).toFixed(1)
-              : tc.elapsedMs ? (tc.elapsedMs / 1000).toFixed(1) : null;
+      {/* Expanded detail panel */}
+      {isExpanded && (
+        <div className="px-2.5 pb-2.5 space-y-1.5 border-t border-gray-700/40">
+          {/* Description */}
+          {tc.description && (
+            <p className="text-[11px] mt-1.5 italic text-gray-500">
+              {tc.description}
+            </p>
+          )}
 
-            return (
-              <div key={tc.toolUseId} className="pt-2">
-                <div className={`flex items-center gap-2 ${tcColor}`}>
-                  <span className={tc.status === 'running' ? 'animate-pulse' : ''}>{tcIcon}</span>
-                  <span className="font-mono font-medium">{tc.tool}</span>
-                  {tcElapsed && <span className="ml-auto text-gray-500">{tcElapsed}s</span>}
-                </div>
-                {tc.args && Object.keys(tc.args).length > 0 && (
-                  <div>
-                    <p className="text-gray-500 uppercase text-[10px] tracking-wide mt-1.5 mb-0.5">Args</p>
-                    <pre className="text-gray-300 text-[11px] overflow-auto max-h-24 whitespace-pre-wrap">
-                      {JSON.stringify(tc.args, null, 2)}
-                    </pre>
-                  </div>
-                )}
-                {tc.result !== undefined && tc.status === 'done' && (
-                  <div>
-                    <p className="text-gray-500 uppercase text-[10px] tracking-wide mt-1.5 mb-0.5">Result</p>
-                    <pre className="text-gray-300 text-[11px] overflow-auto max-h-24 whitespace-pre-wrap">
-                      {typeof tc.result === 'string' ? tc.result : JSON.stringify(tc.result, null, 2)}
-                    </pre>
-                  </div>
-                )}
-                {tc.status === 'running' && (
-                  <p className="mt-1 text-[11px] text-gray-500">Waiting for result...</p>
-                )}
-                {i < toolCalls.length - 1 && <div className="border-b border-gray-700/30 mt-2" />}
-              </div>
-            );
-          })}
+          {/* Arguments */}
+          {tc.args && Object.keys(tc.args).length > 0 && (
+            <div>
+              <div className="text-[10px] font-semibold mt-1 text-gray-500 uppercase tracking-wide">Input</div>
+              <pre className="text-[11px] mt-0.5 whitespace-pre-wrap break-all leading-snug max-h-32 overflow-y-auto text-gray-300">
+                {_formatArgs(tc.args)}
+              </pre>
+            </div>
+          )}
+
+          {/* Result */}
+          {tc.result !== undefined && tc.status === 'done' && (
+            <div>
+              <div className="text-[10px] font-semibold text-gray-500 uppercase tracking-wide">Output</div>
+              <pre className="text-[11px] mt-0.5 whitespace-pre-wrap break-all leading-snug max-h-48 overflow-y-auto text-gray-300">
+                {_formatResult(tc.result)}
+              </pre>
+            </div>
+          )}
+
+          {/* Still running */}
+          {isRunning && !tc.result && (
+            <p className={`text-[10px] italic mt-1 ${isHung ? 'text-red-400' : 'text-gray-500'}`}>
+              {isHung ? 'Tool may be stuck...' : 'Waiting for result...'}
+            </p>
+          )}
         </div>
       )}
     </div>
   );
 }
+
+/* ── Confirmation Card ────────────────────────────────────────────── */
 
 function ConfirmationCard({ confirm, onApprove, onDeny }: {
   confirm: PendingConfirmation;
@@ -168,6 +199,71 @@ function ConfirmationCard({ confirm, onApprove, onDeny }: {
   );
 }
 
+/* ── Plan Card ────────────────────────────────────────────────────── */
+
+function PlanCard({ plan, onApprove, onIterate }: {
+  plan: PendingPlan;
+  onApprove?: () => void;
+  onIterate?: () => void;
+}) {
+  const borderColor = plan.status === 'approved'
+    ? 'border-green-700/40 bg-green-900/15'
+    : plan.status === 'iterating'
+    ? 'border-gray-600/40 bg-gray-800/30'
+    : 'border-teal-600/40 bg-teal-900/15';
+
+  return (
+    <div className={`mt-3 rounded-xl border p-4 ${borderColor}`}>
+      <div className="flex items-center gap-2 mb-3">
+        {plan.status === 'pending' && (
+          <svg className="w-4 h-4 text-teal-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <path d="M8 7h8M8 12h8M8 17h4" />
+          </svg>
+        )}
+        {plan.status === 'approved' && (
+          <svg className="w-4 h-4 text-green-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        )}
+        {plan.status === 'iterating' && (
+          <svg className="w-4 h-4 text-gray-400 shrink-0 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 12a9 9 0 11-6.219-8.56" />
+          </svg>
+        )}
+        <span className={`text-xs font-semibold ${
+          plan.status === 'approved' ? 'text-green-300' : plan.status === 'iterating' ? 'text-gray-400' : 'text-teal-300'
+        }`}>
+          {plan.status === 'pending' && 'Proposed Plan'}
+          {plan.status === 'approved' && 'Plan Approved'}
+          {plan.status === 'iterating' && 'Refining Plan...'}
+        </span>
+      </div>
+      <div className="text-sm text-gray-200">
+        <MarkdownContent content={plan.plan} />
+      </div>
+      {plan.status === 'pending' && (
+        <div className="flex gap-2 mt-4 pt-3 border-t border-teal-700/30">
+          <button
+            onClick={onApprove}
+            className="px-4 py-2 text-xs font-medium bg-teal-700/60 text-teal-200 rounded-lg hover:bg-teal-700/80 transition"
+          >
+            Approve & Execute
+          </button>
+          <button
+            onClick={onIterate}
+            className="px-4 py-2 text-xs font-medium bg-gray-700/50 text-gray-300 rounded-lg hover:bg-gray-700/70 transition"
+          >
+            Keep Iterating
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Bouncing Dots ────────────────────────────────────────────────── */
+
 function BouncingDots() {
   return (
     <div className="flex items-center gap-1 py-1">
@@ -182,28 +278,57 @@ function BouncingDots() {
   );
 }
 
-export function AgentMessageBubble({ message, onApprove, onDeny, showToolCalls = false }: Props) {
+/* ── Main Component ───────────────────────────────────────────────── */
+
+export function AgentMessageBubble({ message, onApprove, onDeny, onApprovePlan, onIteratePlan }: Props) {
   const isUser = message.role === 'user';
+  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+  const { copied, copy } = useCopyToClipboard();
+
+  const toggleTool = (toolUseId: string) => {
+    setExpandedTools(prev => {
+      const next = new Set(prev);
+      if (next.has(toolUseId)) next.delete(toolUseId);
+      else next.add(toolUseId);
+      return next;
+    });
+  };
+
+  // Tick every second while any tool is running (for elapsed timer)
+  const hasRunningTool = message.toolCalls?.some(tc => tc.status === 'running');
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!hasRunningTool) return;
+    const interval = setInterval(() => setTick(t => t + 1), 1000);
+    return () => clearInterval(interval);
+  }, [hasRunningTool]);
 
   // ── User message: branded right-aligned bubble ──
   if (isUser) {
     return (
-      <div className="flex justify-end">
-        <div className="max-w-[85%] sm:max-w-[75%]">
-          {message.attachments && message.attachments.length > 0 && (
-            <div className="mb-1.5 flex flex-wrap gap-1 justify-end">
-              {message.attachments.map((att, i) => (
-                <span key={i} className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-500/30 border border-indigo-500/40 rounded text-xs text-indigo-200">
-                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
-                  {att.name}
-                </span>
-              ))}
+      <div>
+        <div className="flex justify-end">
+          <div className="max-w-[85%] sm:max-w-[75%]">
+            {message.attachments && message.attachments.length > 0 && (
+              <div className="mb-1.5 flex flex-wrap gap-1 justify-end">
+                {message.attachments.map((att, i) => (
+                  <span key={i} className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-500/30 border border-indigo-500/40 rounded text-xs text-indigo-200">
+                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+                    {att.name}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="bg-indigo-600 text-white rounded-2xl rounded-br-sm px-5 py-3.5 text-sm leading-relaxed whitespace-pre-wrap break-words">
+              {message.content}
             </div>
-          )}
-          <div className="bg-indigo-600 text-white rounded-2xl rounded-br-sm px-5 py-3.5 text-sm leading-relaxed whitespace-pre-wrap break-words">
-            {message.content}
           </div>
         </div>
+        {message.content && (
+          <div className="flex justify-end mt-1">
+            <CopyButton copied={copied} onClick={() => copy(message.content)} />
+          </div>
+        )}
       </div>
     );
   }
@@ -211,19 +336,35 @@ export function AgentMessageBubble({ message, onApprove, onDeny, showToolCalls =
   // ── Assistant message: flat, no bubble, markdown rendered ──
   return (
     <div className="w-full">
-      {/* Tool calls — single compact box */}
-      {showToolCalls && message.toolCalls && message.toolCalls.length > 0 && (
-        <div className="mb-2">
-          <ToolCallBox toolCalls={message.toolCalls} />
+      {/* Tool calls -- individual expandable pills */}
+      {message.toolCalls && message.toolCalls.length > 0 && (
+        <div className="mb-3 space-y-1.5">
+          {message.toolCalls.map((tc) => (
+            <ToolCallBubble
+              key={tc.toolUseId}
+              tc={tc}
+              isExpanded={expandedTools.has(tc.toolUseId)}
+              onToggle={() => toggleTool(tc.toolUseId)}
+            />
+          ))}
         </div>
       )}
 
       {/* Message content */}
       {message.content ? (
         <MarkdownContent content={message.content} />
-      ) : message.isStreaming ? (
+      ) : message.isStreaming && (!message.toolCalls || message.toolCalls.length === 0) ? (
         <BouncingDots />
       ) : null}
+
+      {/* Inline reports */}
+      {message.reports && message.reports.length > 0 && (
+        <div className="mt-2 space-y-2">
+          {message.reports.map(report => (
+            <ReportRenderer key={report.id} report={report} compact />
+          ))}
+        </div>
+      )}
 
       {/* Confirmation card */}
       {message.pendingConfirm && (
@@ -232,6 +373,22 @@ export function AgentMessageBubble({ message, onApprove, onDeny, showToolCalls =
           onApprove={() => onApprove?.(message.id)}
           onDeny={() => onDeny?.(message.id)}
         />
+      )}
+
+      {/* Plan card */}
+      {message.pendingPlan && (
+        <PlanCard
+          plan={message.pendingPlan}
+          onApprove={() => onApprovePlan?.(message.id)}
+          onIterate={() => onIteratePlan?.(message.id)}
+        />
+      )}
+
+      {/* Copy button */}
+      {message.content && (
+        <div className="mt-1">
+          <CopyButton copied={copied} onClick={() => copy(message.content)} />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/agent/components/AgentMessageBubble.tsx
+++ b/frontend/src/agent/components/AgentMessageBubble.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import type { ChatMessage, ToolCallInfo, PendingConfirmation, PendingPlan, InlineReport } from '../hooks/useAgentChat';
+import type { ChatMessage, ToolCallInfo, PendingConfirmation, PendingPlan } from '../hooks/useAgentChat';
 import MarkdownContent from './MarkdownContent';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import ReportRenderer from '../reports/ReportRenderer';
@@ -20,6 +20,65 @@ interface Props {
 }
 
 const HUNG_THRESHOLD_SEC = 30;
+
+/* ── Helper functions ────────────────────────────────────────────── */
+
+const TOOL_LABELS: Record<string, string> = {
+  list_context_files: 'Listing files',
+  read_context_file: 'Reading file',
+  write_context_file: 'Writing file',
+  append_to_context_file: 'Appending to file',
+  delete_context_file: 'Deleting file',
+  search_memory: 'Searching memory',
+  append_daily_note: 'Adding daily note',
+  read_daily_note: 'Reading daily note',
+  list_daily_notes: 'Listing daily notes',
+  read_memory: 'Reading MEMORY.md',
+  update_memory: 'Updating MEMORY.md',
+  add_fact: 'Recording fact',
+  query_facts: 'Querying facts',
+  invalidate_fact: 'Invalidating fact',
+  search_emails: 'Searching emails',
+  get_email: 'Reading email',
+  get_email_thread: 'Reading thread',
+  list_calendar_events: 'Listing events',
+  get_calendar_event: 'Reading event',
+  search_calendar_events: 'Searching events',
+  web_search: 'Searching web',
+  web_fetch: 'Fetching page',
+  generate_report: 'Generating report',
+  create_reminder: 'Creating reminder',
+  list_reminders: 'Listing reminders',
+  cancel_reminder: 'Cancelling reminder',
+  create_scheduled_action: 'Creating action',
+  list_scheduled_actions: 'Listing actions',
+  list_shared_context: 'Listing shared context',
+  read_shared_context: 'Reading shared context',
+  write_shared_context: 'Writing shared context',
+};
+
+function _toolLabel(name: string): string {
+  return TOOL_LABELS[name] || name.replace(/_/g, ' ');
+}
+
+function _formatArgs(args: Record<string, unknown> | undefined): string {
+  if (!args || Object.keys(args).length === 0) return '(none)';
+  try {
+    return JSON.stringify(args, null, 2);
+  } catch {
+    return String(args);
+  }
+}
+
+function _formatResult(result: unknown): string {
+  if (result === undefined || result === null) return '(none)';
+  if (typeof result === 'string') return result;
+  try {
+    return JSON.stringify(result, null, 2);
+  } catch {
+    return String(result);
+  }
+}
 
 /* ── Copy Button ─────────────────────────────────────────────────── */
 

--- a/frontend/src/agent/components/ConversationSidebar.tsx
+++ b/frontend/src/agent/components/ConversationSidebar.tsx
@@ -3,7 +3,7 @@
  * Collapsible sidebar with conversation list and search.
  */
 
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import type { Conversation } from '../hooks/useConversations';
 
 interface Props {
@@ -27,6 +27,16 @@ export function ConversationSidebar({
   const [collapsed, setCollapsed] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState('');
+  const [localQuery, setLocalQuery] = useState(searchQuery);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const handleSearchChange = useCallback((value: string) => {
+    setLocalQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      onSearch(value);
+    }, 300);
+  }, [onSearch]);
 
   function startEdit(conv: Conversation, e: React.MouseEvent) {
     e.stopPropagation();
@@ -67,8 +77,8 @@ export function ConversationSidebar({
       {/* Search */}
       <div className="px-3 py-2">
         <input
-          value={searchQuery}
-          onChange={e => onSearch(e.target.value)}
+          value={localQuery}
+          onChange={e => handleSearchChange(e.target.value)}
           placeholder="Search conversations..."
           className="w-full bg-gray-800 border border-gray-700 text-sm text-white rounded-lg px-3 py-2 focus:outline-none focus:border-indigo-500"
         />

--- a/frontend/src/agent/components/TelegramSettings.tsx
+++ b/frontend/src/agent/components/TelegramSettings.tsx
@@ -65,7 +65,7 @@ function OnboardingWizard({ agentId, agentName, onUpdate }: {
   const [error, setError] = useState('');
   const [connectedUsername, setConnectedUsername] = useState('');
   const [registrationExpires, setRegistrationExpires] = useState('');
-  const [registrationComplete, setRegistrationComplete] = useState(false);
+  const [, setRegistrationComplete] = useState(false);
 
   const steps: WizardStep[] = ['create-bot', 'paste-token', 'link-account', 'all-set'];
   const currentIndex = steps.indexOf(step);

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -2,23 +2,27 @@
  * Chatty — useAgentChat hook.
  *
  * Streams chat responses via SSE. Handles text, tool_start, tool_args,
- * tool_end, confirm, title_update, done, error events.
+ * tool_end, confirm, plan_ready, usage, report, title_update, done, error events.
  *
- * Supports 3-tier tool mode (read-only / normal / power) with confirmation flow.
+ * Supports 3-tier tool mode (read-only / normal / power) with confirmation flow,
+ * plan mode, training/improve modes, and context usage tracking.
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { getToken } from '../../core/auth/AuthContext';
 
 export type ToolMode = 'read-only' | 'normal' | 'power';
+export type TrainingType = 'topic' | 'improve' | null;
 
 export interface ToolCallInfo {
   tool: string;
   toolUseId: string;
   status: 'running' | 'done' | 'error';
   args?: Record<string, unknown>;
+  description?: string;
   result?: unknown;
   elapsedMs?: number;
+  durationMs?: number;
   startedAt: number;
 }
 
@@ -30,6 +34,19 @@ export interface PendingConfirmation {
   description?: string;
 }
 
+export interface PendingPlan {
+  plan: string;
+  status: 'pending' | 'approved' | 'iterating';
+}
+
+export interface InlineReport {
+  id: string;
+  title: string;
+  subtitle?: string;
+  sections: unknown[];
+  created_at: string;
+}
+
 export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant';
@@ -39,6 +56,13 @@ export interface ChatMessage {
   isStreaming?: boolean;
   attachments?: { name: string; size: number }[];
   pendingConfirm?: PendingConfirmation;
+  pendingPlan?: PendingPlan;
+  reports?: InlineReport[];
+}
+
+export interface ContextUsage {
+  inputTokens: number;
+  contextWindow: number;
 }
 
 interface Options {
@@ -50,16 +74,22 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
   const [isStreaming, setIsStreaming] = useState(false);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [trainingMode, setTrainingModeState] = useState(false);
+  const [trainingType, setTrainingType] = useState<TrainingType>('topic');
+  const [planMode, setPlanModeState] = useState(false);
   const [toolMode, setToolMode] = useState<ToolMode>('normal');
+  const [contextUsage, setContextUsage] = useState<ContextUsage | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const savedToolModeRef = useRef<ToolMode>('normal');
+  const savedToolModeForPlanRef = useRef<ToolMode>('normal');
   const trainingKickoffRef = useRef(false);
+  const trainingKickoffMessageRef = useRef('Start training mode.');
 
   const sendMessage = useCallback(async (text: string, files?: File[], approvedTool?: {
     tool: string;
     args: Record<string, unknown>;
     toolUseId: string;
     result: unknown;
-  }) => {
+  }, overrides?: { tool_mode?: string; plan_mode?: boolean }) => {
     const userMsg: ChatMessage = {
       id: crypto.randomUUID(),
       role: 'user',
@@ -82,7 +112,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
     const history = [...messages, userMsg].map(m => ({ role: m.role, content: m.content }));
 
     // Effective tool mode: training forces power
-    const effectiveMode = trainingMode ? 'power' : toolMode;
+    const effectiveMode = overrides?.tool_mode ?? (trainingMode ? 'power' : toolMode);
 
     abortRef.current = new AbortController();
 
@@ -93,8 +123,10 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
       const payload: Record<string, unknown> = {
         messages: history,
         training_mode: trainingMode,
+        training_type: trainingType,
         conversation_id: conversationId,
         tool_mode: effectiveMode,
+        plan_mode: overrides?.plan_mode ?? planMode,
       };
       if (approvedTool) payload.approved_tool = approvedTool;
 
@@ -172,7 +204,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
                     ...last,
                     toolCalls: [
                       ...(last.toolCalls || []),
-                      { tool: event.tool, toolUseId: event.tool_use_id, status: 'running', startedAt: Date.now() },
+                      { tool: event.tool, toolUseId: event.tool_use_id || crypto.randomUUID(), status: 'running', startedAt: Date.now() },
                     ],
                   };
                 }
@@ -186,7 +218,9 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
                   updated[updated.length - 1] = {
                     ...last,
                     toolCalls: (last.toolCalls || []).map(tc =>
-                      tc.toolUseId === event.tool_use_id ? { ...tc, args: event.args } : tc
+                      tc.toolUseId === event.tool_use_id
+                        ? { ...tc, args: event.args, description: event.description }
+                        : tc
                     ),
                   };
                 }
@@ -204,7 +238,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
                         ? tc.toolUseId === event.tool_use_id
                         : tc.tool === event.tool && tc.status === 'running';
                       return match
-                        ? { ...tc, status: 'done' as const, result: event.result, elapsedMs: event.elapsed_ms }
+                        ? { ...tc, status: 'done' as const, result: event.result, elapsedMs: event.elapsed_ms, durationMs: event.duration_ms }
                         : tc;
                     }),
                   };
@@ -225,6 +259,38 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
                       status: 'pending',
                       description: event.description,
                     },
+                  };
+                }
+                return updated;
+              });
+            } else if (event.type === 'plan_ready' && event.plan) {
+              setMessages(prev => {
+                const updated = [...prev];
+                const last = updated[updated.length - 1];
+                if (last?.role === 'assistant') {
+                  updated[updated.length - 1] = {
+                    ...last,
+                    pendingPlan: {
+                      plan: event.plan,
+                      status: 'pending',
+                    },
+                  };
+                }
+                return updated;
+              });
+            } else if (event.type === 'usage' && event.input_tokens != null && event.context_window != null) {
+              setContextUsage({
+                inputTokens: event.input_tokens,
+                contextWindow: event.context_window,
+              });
+            } else if (event.type === 'report' && event.report) {
+              setMessages(prev => {
+                const updated = [...prev];
+                const last = updated[updated.length - 1];
+                if (last?.role === 'assistant') {
+                  updated[updated.length - 1] = {
+                    ...last,
+                    reports: [...(last.reports || []), event.report],
                   };
                 }
                 return updated;
@@ -264,17 +330,15 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
       setMessages(prev => prev.map(m => m.isStreaming ? { ...m, isStreaming: false } : m));
       abortRef.current = null;
     }
-  }, [messages, trainingMode, toolMode, conversationId, apiPrefix, options]);
+  }, [messages, trainingMode, trainingType, toolMode, planMode, conversationId, apiPrefix, options]);
 
   // ── Approve a pending confirmation ──
   const approveAction = useCallback(async (msgId: string) => {
-    // Find the message with the pending confirm
     const msg = messages.find(m => m.id === msgId);
     if (!msg?.pendingConfirm || msg.pendingConfirm.status !== 'pending') return;
 
     const { tool, args, toolUseId } = msg.pendingConfirm;
 
-    // Mark as approved
     setMessages(prev => prev.map(m =>
       m.id === msgId && m.pendingConfirm
         ? { ...m, pendingConfirm: { ...m.pendingConfirm, status: 'approved' as const } }
@@ -295,7 +359,6 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
       if (!res.ok) throw new Error(`Execute failed: ${res.status}`);
       const result = await res.json();
 
-      // Send follow-up message with approved_tool metadata
       sendMessage(`[Approved] ${tool}`, undefined, { tool, args, toolUseId, result });
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : 'Unknown error';
@@ -314,31 +377,82 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
     ));
   }, []);
 
-  const setTrainingMode = useCallback((on: boolean) => {
+  // ── Training mode ──
+  const setTrainingMode = useCallback((on: boolean, type?: TrainingType, kickoff?: string) => {
     if (on) {
+      savedToolModeRef.current = toolMode;
       setMessages([]);
       setConversationId(null);
+      setTrainingType(type || 'topic');
+      trainingKickoffMessageRef.current = kickoff || 'Start training mode.';
       trainingKickoffRef.current = true;
       setTrainingModeState(true);
     } else {
+      setToolMode(savedToolModeRef.current);
       setMessages([]);
       setConversationId(null);
+      setTrainingType('topic');
       setTrainingModeState(false);
     }
-  }, []);
+  }, [toolMode]);
 
   useEffect(() => {
     if (trainingMode && trainingKickoffRef.current && !isStreaming) {
       trainingKickoffRef.current = false;
-      sendMessage('Hey!');
+      sendMessage(trainingKickoffMessageRef.current);
     }
   }, [trainingMode, isStreaming, sendMessage]);
+
+  // ── Plan mode ──
+  const setPlanMode = useCallback((on: boolean) => {
+    if (on) {
+      savedToolModeForPlanRef.current = toolMode;
+      setMessages([]);
+      setConversationId(null);
+      setPlanModeState(true);
+    } else {
+      setToolMode(savedToolModeForPlanRef.current);
+      setPlanModeState(false);
+    }
+  }, [toolMode]);
+
+  const approvePlan = useCallback((messageId: string) => {
+    const msg = messages.find(m => m.id === messageId);
+    if (!msg?.pendingPlan || msg.pendingPlan.status !== 'pending') return;
+
+    setMessages(prev =>
+      prev.map(m =>
+        m.id === messageId
+          ? { ...m, pendingPlan: { ...m.pendingPlan!, status: 'approved' as const } }
+          : m
+      )
+    );
+
+    // Exit plan mode and execute with power mode override
+    setPlanModeState(false);
+    sendMessage('[Plan approved] Execute the plan now.', undefined, undefined, {
+      tool_mode: 'power',
+      plan_mode: false,
+    });
+  }, [messages, sendMessage]);
+
+  const iteratePlan = useCallback((messageId: string) => {
+    setMessages(prev =>
+      prev.map(m =>
+        m.id === messageId
+          ? { ...m, pendingPlan: { ...m.pendingPlan!, status: 'iterating' as const } }
+          : m
+      )
+    );
+    // Plan mode stays active -- user types feedback
+  }, []);
 
   const stop = useCallback(() => { abortRef.current?.abort(); }, []);
 
   const clear = useCallback(() => {
     setMessages([]);
     setConversationId(null);
+    setContextUsage(null);
   }, []);
 
   const loadMessages = useCallback((msgs: ChatMessage[], id: string) => {
@@ -350,10 +464,16 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
     messages,
     isStreaming,
     conversationId,
+    contextUsage,
     trainingMode,
+    trainingType,
     toolMode,
     setToolMode,
     setTrainingMode,
+    planMode,
+    setPlanMode,
+    approvePlan,
+    iteratePlan,
     sendMessage,
     approveAction,
     denyAction,

--- a/frontend/src/agent/hooks/useCopyToClipboard.ts
+++ b/frontend/src/agent/hooks/useCopyToClipboard.ts
@@ -1,0 +1,19 @@
+import { useState, useCallback, useRef } from 'react';
+
+export function useCopyToClipboard(resetMs = 1500) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const copy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), resetMs);
+    } catch {
+      // Silently fail (e.g. non-secure context)
+    }
+  }, [resetMs]);
+
+  return { copied, copy };
+}

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -146,14 +146,29 @@ export interface ProviderStatus {
   }>;
 }
 
+// Context usage (returned from SSE 'usage' event)
+export interface ContextUsage {
+  inputTokens: number;
+  contextWindow: number;
+}
+
+// Tool mode for 3-tier tool permissions
+export type ToolMode = 'read-only' | 'normal' | 'power';
+
+// Training type for onboarding vs improve flows
+export type TrainingType = 'topic' | 'improve' | null;
+
 // SSE event types
 export type SSEEvent =
   | { type: 'conversation_id'; id: string }
   | { type: 'text'; text: string }
   | { type: 'tool_start'; tool: string; tool_use_id: string }
-  | { type: 'tool_args'; tool: string; tool_use_id: string; args: Record<string, unknown> }
-  | { type: 'tool_end'; tool: string; tool_use_id: string; result: unknown; elapsed_ms: number }
+  | { type: 'tool_args'; tool: string; tool_use_id: string; args: Record<string, unknown>; description?: string }
+  | { type: 'tool_end'; tool: string; tool_use_id: string; result: unknown; elapsed_ms?: number; duration_ms?: number }
   | { type: 'confirm'; tool: string; args: Record<string, unknown>; tool_use_id: string; description: string }
+  | { type: 'plan_ready'; plan: string }
+  | { type: 'usage'; input_tokens: number; context_window: number }
+  | { type: 'report'; report: { id: string; title: string; subtitle?: string; sections: unknown[]; created_at: string } }
   | { type: 'title_update'; title: string; conversation_id: string }
   | { type: 'done' }
   | { type: 'error'; error: string };


### PR DESCRIPTION
## Summary

- **Memory system**: FTS5 full-text search, temporal facts, daily notes, MEMORY.md living snapshot with nightly consolidation, WAL recovery, relevance pre-fetch (BM25-lite scoring)
- **Dreaming system**: context usage tracking, 5-signal file scoring (write recency/frequency, mention frequency, load rate, file age), dormant file archival, load-order optimization via nightly cron
- **Shared context**: cross-agent knowledge sharing via SQLite DB + markdown files, manifest injected into all agent system prompts, admin API endpoints
- **Agent modes**: plan mode (read-only investigation → structured plan → approve/execute), improve mode (post-training knowledge refinement), 3-tier tool modes (read-only/normal/power) with write confirmation gating
- **New SSE events**: `usage` (input/output tokens + context window), `plan_ready` (plan completion), `tool_args.description` (tool descriptions for UI)
- **Frontend UX**: individual expandable tool call pills with elapsed timer + hung detection, plan mode cards with approve/iterate, per-message copy-to-clipboard, context usage indicator (color-coded), tool mode selector, PDF file upload (10MB), activity panel tab, conversation search debounce

Ports all 22 identified features from CAKE OS into Chatty's provider-agnostic architecture. 36 files changed — 19 new files, 17 modified. Backend modules are fully self-contained (stdlib + sqlite3 + anthropic SDK only).

### AI review fixes applied
- Added `_toolLabel`, `_formatArgs`, `_formatResult` helper functions to AgentMessageBubble
- Fixed daily notes path mismatch: memory tools now use `context_dir` (not `agent_data_dir`) so daily notes go to the correct `context/daily/` directory
- Added MemoryDB lazy initialization with LRU cache + FTS5 reindex on first agent access

## Test plan

- [ ] Create a new agent and complete onboarding — verify soul.md and topic files created
- [ ] Send messages and verify daily notes are created (`data/agents/{slug}/context/daily/`)
- [ ] Use `search_memory` tool — verify FTS5 returns ranked results
- [ ] Test `add_fact` / `query_facts` — verify temporal facts persist
- [ ] Enable plan mode — verify read-only enforcement, plan_ready SSE event, approve/iterate flow
- [ ] Enable improve mode — verify knowledge refinement prompt and power mode
- [ ] Test tool modes: read-only (no writes), normal (confirm cards), power (auto-execute)
- [ ] Verify context usage indicator updates after each turn (check SSE `usage` event)
- [ ] Upload a PDF in chat — verify 10MB limit, content extraction
- [ ] Test copy-to-clipboard button on messages
- [ ] Verify expandable tool call pills with elapsed timer and hung detection (30s threshold)
- [ ] Test shared context: write from one agent, verify manifest visible to another
- [ ] Trigger nightly jobs manually — verify daily note summarization and MEMORY.md consolidation
- [ ] Check Activity tab displays heartbeat records