### PR TITLE
Preserve text selection when highlighting in agent chat

### DIFF
--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -153,6 +153,11 @@ export function AgentChatPanel({
   // Click on messages area refocuses input (unless clicking interactive elements)
   function handleMessagesClick(e: MouseEvent) {
     if ((e.target as HTMLElement).closest?.('button, a, input, textarea, pre, code')) return;
+
+    // Don't steal focus if the user just highlighted text (they probably want to copy it)
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed && selection.toString().length > 0) return;
+
     textareaRef.current?.focus();
   }
 


### PR DESCRIPTION
## Summary
Ports a CAKE OS fix ([commit 493d485](https://github.com/wwilson1017/cake_os/commit/493d485)) that prevents the messages-area click handler from stealing focus on mouse-up at the end of a drag-select. Without this fix, highlighting text in a message wipes the selection before the user can copy it.

## Change
In `AgentChatPanel.tsx#handleMessagesClick`, skip the refocus if `window.getSelection()` has a non-collapsed, non-empty selection.

## Test plan
- [ ] Drag to highlight text inside an agent message
- [ ] Verify the highlight stays visible on mouse-up
- [ ] Verify Cmd+C / right-click → Copy works on the highlighted text
- [ ] Verify clicking an empty area still refocuses the textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)