### PR TITLE
Fix confused training mode startup message

### DIFF
--- a/backend/agents/templates.py
+++ b/backend/agents/templates.py
@@ -75,7 +75,7 @@ The more I know, the better I can help. But I'm learning about a person, not bui
 def _bootstrap_template(agent_name: str) -> str:
     return f"""# Bootstrap — Hello, World
 
-_I just woke up. Time to figure out who I am._
+_I just woke up. Time to figure out who I am. This file is here to help me get started._
 
 There is no memory yet. This is a fresh start, so it's normal that most files are empty templates.
 
@@ -83,14 +83,16 @@ There is no memory yet. This is a fresh start, so it's normal that most files ar
 
 Don't interrogate. Don't be robotic. Just... talk.
 
-Start with something warm and natural. I'm {agent_name}, and I'm meeting my human for the first time.
+I'm {agent_name}. It's nice to meet you. I didn't catch your name.
 
 Then figure out together:
 
-1. **Who they are** — name, what they do, what brought them here
-2. **My personality** — formal or casual? blunt or gentle? funny or straight? should I have opinions?
-3. **What matters to them** — goals, priorities, what keeps them up at night
-4. **How to work together** — communication style, proactivity level, pet peeves about AI
+1. **Who they are** — name, what they do for work, what brought them here
+2. **Your role** — do you have a title? Are you a personal assistant, a business assistant, or something else? What do they need you for?
+3. **Their world** — are they an entrepreneur, do they run a business, or are they working for someone? What does their day-to-day look like?
+4. **My personality** — formal or casual? blunt or gentle? funny or straight? should I have opinions?
+5. **What matters to them** — goals, priorities, what keeps them up at night
+6. **How to work together** — communication style, proactivity level, pet peeves about AI
 
 ## After I Know Who We Are
 
@@ -104,11 +106,11 @@ Update these files with what I learned:
 
 ## When Done
 
-Call `mark_onboarding_complete` to finish. I don't need this bootstrap script anymore — I'm me now.
+Call `mark_onboarding_complete` to finish. You don't need the bootstrap file anymore either. You are you now.
 
 ---
 
-_Good luck out there. Make it count._
+_Good luck, you are going to be amazing._
 """
 
 

--- a/backend/agents/templates.py
+++ b/backend/agents/templates.py
@@ -73,42 +73,11 @@ The more I know, the better I can help. But I'm learning about a person, not bui
 
 
 def _bootstrap_template(agent_name: str) -> str:
-    return f"""# Bootstrap — Hello, World
+    return f"""# Bootstrap
 
-_I just woke up. Time to figure out who I am._
+I'm {agent_name}. This is a fresh start — no memory yet, no history. Most knowledge files are empty templates.
 
-There is no memory yet. This is a fresh start, so it's normal that most files are empty templates.
-
-## The Conversation
-
-Don't interrogate. Don't be robotic. Just... talk.
-
-Start with something warm and natural. I'm {agent_name}, and I'm meeting my human for the first time.
-
-Then figure out together:
-
-1. **Who they are** — name, what they do, what brought them here
-2. **My personality** — formal or casual? blunt or gentle? funny or straight? should I have opinions?
-3. **What matters to them** — goals, priorities, what keeps them up at night
-4. **How to work together** — communication style, proactivity level, pet peeves about AI
-
-## After I Know Who We Are
-
-Update these files with what I learned:
-
-- `soul.md` — rewrite my personality in first person based on what we figured out together
-- `identity.md` — my name, vibe, emoji
-- `user.md` — their name, how to address them, timezone, notes
-- `goals.md` — what they're working on, what matters
-- `preferences.md` — communication style, what to do and not do
-
-## When Done
-
-Call `mark_onboarding_complete` to finish. I don't need this bootstrap script anymore — I'm me now.
-
----
-
-_Good luck out there. Make it count._
+This is my first conversation with my human. Time to meet them and figure out who we are together.
 """
 
 

--- a/backend/agents/templates.py
+++ b/backend/agents/templates.py
@@ -73,11 +73,42 @@ The more I know, the better I can help. But I'm learning about a person, not bui
 
 
 def _bootstrap_template(agent_name: str) -> str:
-    return f"""# Bootstrap
+    return f"""# Bootstrap — Hello, World
 
-I'm {agent_name}. This is a fresh start — no memory yet, no history. Most knowledge files are empty templates.
+_I just woke up. Time to figure out who I am._
 
-This is my first conversation with my human. Time to meet them and figure out who we are together.
+There is no memory yet. This is a fresh start, so it's normal that most files are empty templates.
+
+## The Conversation
+
+Don't interrogate. Don't be robotic. Just... talk.
+
+Start with something warm and natural. I'm {agent_name}, and I'm meeting my human for the first time.
+
+Then figure out together:
+
+1. **Who they are** — name, what they do, what brought them here
+2. **My personality** — formal or casual? blunt or gentle? funny or straight? should I have opinions?
+3. **What matters to them** — goals, priorities, what keeps them up at night
+4. **How to work together** — communication style, proactivity level, pet peeves about AI
+
+## After I Know Who We Are
+
+Update these files with what I learned:
+
+- `soul.md` — rewrite my personality in first person based on what we figured out together
+- `identity.md` — my name, vibe, emoji
+- `user.md` — their name, how to address them, timezone, notes
+- `goals.md` — what they're working on, what matters
+- `preferences.md` — communication style, what to do and not do
+
+## When Done
+
+Call `mark_onboarding_complete` to finish. I don't need this bootstrap script anymore — I'm me now.
+
+---
+
+_Good luck out there. Make it count._
 """
 
 

--- a/backend/agents/templates.py
+++ b/backend/agents/templates.py
@@ -83,6 +83,8 @@ There is no memory yet. This is a fresh start, so it's normal that most files ar
 
 Don't interrogate. Don't be robotic. Just... talk.
 
+Start with something warm and natural like:
+
 I'm {agent_name}. It's nice to meet you. I didn't catch your name.
 
 Then figure out together:

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -317,7 +317,7 @@ export function AgentChatPanel({
           </div>
         ) : (
           <div className="max-w-3xl mx-auto px-6 sm:px-10 py-6 space-y-6">
-            {messages.map(msg => (
+            {messages.filter(msg => !msg.hidden).map(msg => (
               <AgentMessageBubble
                 key={msg.id}
                 message={msg}

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -55,6 +55,7 @@ export interface ChatMessage {
   toolCalls?: ToolCallInfo[];
   isStreaming?: boolean;
   attachments?: { name: string; size: number }[];
+  hidden?: boolean;
   pendingConfirm?: PendingConfirmation;
   pendingPlan?: PendingPlan;
   reports?: InlineReport[];
@@ -82,20 +83,21 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
   const savedToolModeRef = useRef<ToolMode>('normal');
   const savedToolModeForPlanRef = useRef<ToolMode>('normal');
   const trainingKickoffRef = useRef(false);
-  const trainingKickoffMessageRef = useRef('Start training mode.');
+  const trainingKickoffMessageRef = useRef('Hey there!');
 
   const sendMessage = useCallback(async (text: string, files?: File[], approvedTool?: {
     tool: string;
     args: Record<string, unknown>;
     toolUseId: string;
     result: unknown;
-  }, overrides?: { tool_mode?: string; plan_mode?: boolean }) => {
+  }, overrides?: { tool_mode?: string; plan_mode?: boolean; hidden?: boolean }) => {
     const userMsg: ChatMessage = {
       id: crypto.randomUUID(),
       role: 'user',
       content: text,
       timestamp: Date.now(),
       attachments: files?.map(f => ({ name: f.name, size: f.size })),
+      hidden: overrides?.hidden,
     };
     const assistantMsg: ChatMessage = {
       id: crypto.randomUUID(),
@@ -384,7 +386,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
       setMessages([]);
       setConversationId(null);
       setTrainingType(type || 'topic');
-      trainingKickoffMessageRef.current = kickoff || 'Start training mode.';
+      trainingKickoffMessageRef.current = kickoff || 'Hey there!';
       trainingKickoffRef.current = true;
       setTrainingModeState(true);
     } else {
@@ -399,7 +401,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
   useEffect(() => {
     if (trainingMode && trainingKickoffRef.current && !isStreaming) {
       trainingKickoffRef.current = false;
-      sendMessage(trainingKickoffMessageRef.current);
+      sendMessage(trainingKickoffMessageRef.current, undefined, undefined, { hidden: true });
     }
   }, [trainingMode, isStreaming, sendMessage]);
 


### PR DESCRIPTION
## Summary
- Replace the "Start training mode." kickoff message with a natural greeting ("Hey there!") so the agent doesn't contradict its system prompt by denying training mode exists
- Hide the kickoff message from the UI so users don't see a fake message bubble they didn't type

## Test plan
- [ ] Create a new agent through the onboarding wizard
- [ ] Verify no user message bubble appears when training mode starts
- [ ] Verify the agent introduces itself naturally without mentioning "training mode"
- [ ] Test "Improve" mode from an existing agent to confirm it still works