### PR TITLE
Fix Ollama crash for models without tool support

### DIFF
--- a/backend/core/providers/ollama_provider.py
+++ b/backend/core/providers/ollama_provider.py
@@ -50,7 +50,10 @@ class OllamaProvider(AIProvider):
 
     async def _recommend_tool_models(self) -> str:
         """Build a recommendation string for tool-capable models."""
-        installed = await self.list_models()
+        try:
+            installed = await self.list_models()
+        except Exception:
+            installed = []
         capable = [m for m in installed if _is_tool_capable(m)]
         if capable:
             model_list = ", ".join(f"**{m}**" for m in capable[:5])

--- a/backend/core/providers/ollama_provider.py
+++ b/backend/core/providers/ollama_provider.py
@@ -19,8 +19,27 @@ from core.providers.openai_compat import (
 
 logger = logging.getLogger(__name__)
 
+TOOL_CAPABLE_FAMILIES = [
+    "llama3.1", "llama3.2", "llama3.3", "llama4",
+    "qwen2.5", "qwen3", "qwen3.5",
+    "mistral", "mistral-nemo", "mistral-small", "mistral-large",
+    "command-r", "command-r-plus",
+    "phi4",
+    "nemotron",
+    "hermes3",
+    "firefunction",
+]
+
+
+def _is_tool_capable(model_name: str) -> bool:
+    """Check if a model name matches a known tool-capable family."""
+    base = model_name.split(":")[0].lower()
+    return any(base == family or base.startswith(family + "-") for family in TOOL_CAPABLE_FAMILIES)
+
 
 class OllamaProvider(AIProvider):
+    _tool_support_cache: dict[str, bool] = {}
+
     def __init__(self, base_url: str = "http://localhost:11434", model: str = ""):
         super().__init__(model=model)
         self.base_url = base_url.rstrip("/")
@@ -28,6 +47,23 @@ class OllamaProvider(AIProvider):
     @property
     def provider_name(self) -> str:
         return "ollama"
+
+    async def _recommend_tool_models(self) -> str:
+        """Build a recommendation string for tool-capable models."""
+        installed = await self.list_models()
+        capable = [m for m in installed if _is_tool_capable(m)]
+        if capable:
+            model_list = ", ".join(f"**{m}**" for m in capable[:5])
+            return (
+                f"{self.model} doesn't support tool calling, which Chatty needs for "
+                f"memory, search, and integrations. "
+                f"Switch to a tool-capable model: {model_list}"
+            )
+        return (
+            f"{self.model} doesn't support tool calling, which Chatty needs for "
+            f"memory, search, and integrations. "
+            f"Install a compatible model: `ollama pull llama3.1` or `ollama pull qwen3.5`"
+        )
 
     async def stream_turn(
         self,
@@ -40,15 +76,37 @@ class OllamaProvider(AIProvider):
             base_url=f"{self.base_url}/v1",
         )
 
+        # Skip tools for models known not to support them
+        model_known_no_tools = OllamaProvider._tool_support_cache.get(self.model) is False
+        effective_tools = [] if model_known_no_tools else tools
+
+        if model_known_no_tools and tools:
+            recommendation = await self._recommend_tool_models()
+            yield {"type": "error", "error": recommendation}
+
+        needs_retry = False
+
         async for event in stream_openai_turn(
             client=client,
             model=self.model,
             messages=messages,
-            tools=tools,
+            tools=effective_tools,
             system_prompt=system_prompt,
             max_tokens=4096,
         ):
-            # Rewrite generic connection error with Ollama-specific message
+            # Detect "does not support tools" and retry without them
+            if (
+                event.get("type") == "error"
+                and "does not support tools" in event.get("error", "")
+                and effective_tools
+            ):
+                OllamaProvider._tool_support_cache[self.model] = False
+                needs_retry = True
+                continue
+
+            if needs_retry:
+                continue
+
             if event.get("type") == "error" and event.get("error") == "connection_error":
                 yield {
                     "type": "error",
@@ -56,6 +114,27 @@ class OllamaProvider(AIProvider):
                 }
             else:
                 yield event
+
+        if needs_retry:
+            logger.info("Model %s does not support tools, retrying without", self.model)
+            recommendation = await self._recommend_tool_models()
+            yield {"type": "error", "error": recommendation}
+
+            async for event in stream_openai_turn(
+                client=client,
+                model=self.model,
+                messages=messages,
+                tools=[],
+                system_prompt=system_prompt,
+                max_tokens=4096,
+            ):
+                if event.get("type") == "error" and event.get("error") == "connection_error":
+                    yield {
+                        "type": "error",
+                        "error": f"Cannot connect to Ollama at {self.base_url}. Is it running? Start with: ollama serve",
+                    }
+                else:
+                    yield event
 
     def add_tool_results(
         self,

--- a/frontend/src/setup/OllamaSetup.tsx
+++ b/frontend/src/setup/OllamaSetup.tsx
@@ -13,7 +13,7 @@ interface OllamaStatus {
 const RECOMMENDED_MODELS = [
   { name: 'qwen3.5:4b', desc: 'Lightweight (3.4 GB) — works on any computer' },
   { name: 'qwen3.5:9b', desc: 'Balanced (6 GB) — best quality for the size' },
-  { name: 'gemma3:12b', desc: 'Quality (8 GB) — needs 16 GB RAM' },
+  { name: 'llama3.1:8b', desc: 'Quality (5 GB) — needs 16 GB RAM' },
 ];
 
 export function OllamaSetup({ onConnected }: Props) {


### PR DESCRIPTION
## Summary

- Catch Ollama's "does not support tools" 400 error, retry without tools, and cache per model so subsequent messages skip the failed round-trip
- Show a clear error recommending tool-capable alternatives from the user's installed models (or suggesting `ollama pull llama3.1` if none are installed)
- Replace `gemma3:12b` with `llama3.1:8b` in the setup recommended models list since gemma3 doesn't support the tool calling Chatty needs

## Test plan

- [ ] Use a non-tool model (e.g., `gemma3:12b`) — should see recommendation error + text-only response instead of a crash
- [ ] Send a second message — should respond immediately (cached, no retry overhead)
- [ ] Switch to a tool-capable model (e.g., `llama3.1`) — should work with full tool support, no warning
- [ ] Check the Ollama setup page — recommended models should all be tool-capable