### PR TITLE
Auto-bootstrap shared knowledge on second agent creation

### DIFF
--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -202,11 +202,31 @@ async def create_agent(body: CreateAgentRequest, user=Depends(get_current_user))
     """Create a new agent and seed default context files."""
     if not body.agent_name.strip():
         raise HTTPException(status_code=400, detail="agent_name is required")
+
+    existing_count = len(agent_db.list_agents())
     agent = agent_db.create_agent(body.agent_name.strip(), personality=body.personality)
 
     # Seed default context files (soul.md, identity.md, user.md, bootstrap, guide)
     context_dir = DATA_DIR / agent["slug"] / "context"
     seed_context_files(context_dir, agent["agent_name"])
+
+    # Bootstrap shared knowledge when transitioning from 1 to 2+ agents
+    if existing_count == 1:
+        from core.agents.shared_context.bootstrap import run_bootstrap_sync, should_bootstrap
+        if should_bootstrap():
+            def _bootstrap_thread():
+                try:
+                    run_bootstrap_sync()
+                except Exception:
+                    logger.exception("Shared knowledge bootstrap thread failed")
+
+            import threading
+            threading.Thread(
+                target=_bootstrap_thread,
+                daemon=True,
+                name="shared-knowledge-bootstrap",
+            ).start()
+            logger.info("Shared knowledge bootstrap triggered (2nd agent created)")
 
     return agent
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -210,8 +210,8 @@ async def create_agent(body: CreateAgentRequest, user=Depends(get_current_user))
     context_dir = DATA_DIR / agent["slug"] / "context"
     seed_context_files(context_dir, agent["agent_name"])
 
-    # Bootstrap shared knowledge when transitioning from 1 to 2+ agents
-    if existing_count == 1:
+    # Bootstrap shared knowledge when 2+ agents exist and bootstrap hasn't completed
+    if existing_count >= 1:
         from core.agents.shared_context.bootstrap import run_bootstrap_sync, should_bootstrap
         if should_bootstrap():
             def _bootstrap_thread():

--- a/backend/core/agents/shared_context/bootstrap.py
+++ b/backend/core/agents/shared_context/bootstrap.py
@@ -1,0 +1,219 @@
+"""Shared knowledge bootstrap — auto-populate shared context on second agent creation.
+
+When a second agent is created, reads all existing agents' knowledge files,
+uses AI to extract universally useful facts (user name, company, preferences),
+and writes them as shared context entries. A marker file prevents re-runs.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from . import db
+
+logger = logging.getLogger(__name__)
+
+CT_TZ = ZoneInfo("America/Chicago")
+DATA_DIR = Path(__file__).resolve().parent.parent.parent.parent / "data"
+SHARED_DIR = DATA_DIR / "shared"
+BOOTSTRAP_MARKER = SHARED_DIR / ".bootstrap-complete"
+
+MAX_KNOWLEDGE_CHARS = 50_000
+
+EXTRACTION_PROMPT = """\
+You are analyzing an AI assistant's knowledge files to extract universally useful \
+information that should be shared across all agents in a multi-agent system.
+
+Below are knowledge files from existing agents. Extract facts that ANY agent would \
+benefit from knowing — information about the user, their company, contacts, processes, \
+and preferences.
+
+DO NOT extract:
+- Agent-specific personality traits or identity (soul.md content about the agent itself)
+- Template/placeholder content (e.g., "(figured out during onboarding)", "Not yet discussed")
+- Conversation logs or daily notes details
+- Internal operational notes about the agent's own behavior
+- The agent's name or role
+
+DO extract:
+- User's name, title, timezone, contact preferences
+- Company name, industry, team members, products/services
+- Key contacts and their roles
+- Communication preferences that apply to all agents
+- Business processes and workflows
+- Tools and systems the user works with
+
+Output ONLY a JSON array of entries. Each entry has:
+{
+  "category": one of "user-profile", "company-info", "preferences", "contacts", "processes", "tools-and-systems",
+  "title": "short descriptive title (under 80 chars)",
+  "content": "the extracted information (1-5 sentences, factual)"
+}
+
+If there is nothing meaningful to extract (all templates, no real content), return: []
+
+IMPORTANT: Output ONLY the JSON array, no markdown fences, no commentary."""
+
+
+def should_bootstrap() -> bool:
+    return not BOOTSTRAP_MARKER.exists()
+
+
+def _mark_bootstrap_complete() -> None:
+    SHARED_DIR.mkdir(parents=True, exist_ok=True)
+    BOOTSTRAP_MARKER.write_text(
+        datetime.now(CT_TZ).isoformat(),
+        encoding="utf-8",
+    )
+
+
+def _gather_all_agent_knowledge() -> dict[str, str]:
+    from agents.db import list_agents
+    from core.agents.context_manager import ContextManager
+
+    agents = list_agents()
+    results = {}
+
+    for agent in agents:
+        slug = agent["slug"]
+        context_dir = DATA_DIR / "agents" / slug / "context"
+        if not context_dir.exists():
+            continue
+
+        cm = ContextManager(data_dir=context_dir, gcs_prefix=f"agents/{slug}/context/")
+        text = cm.load_all_context()
+
+        if len(text.strip()) < 500:
+            logger.debug("Skipping agent %s — too little content (%d chars)", slug, len(text))
+            continue
+
+        results[slug] = text
+
+    return results
+
+
+async def _extract_shared_knowledge(knowledge_texts: dict[str, str]) -> list[dict] | None:
+    """Returns list of entries, or None if no AI provider is available."""
+    from core.providers import get_ai_provider
+
+    provider = get_ai_provider()
+    if not provider:
+        logger.warning("No AI provider configured — cannot run shared knowledge bootstrap")
+        return None
+
+    combined = ""
+    for slug, text in knowledge_texts.items():
+        combined += f"\n\n--- Agent: {slug} ---\n\n{text}"
+
+    if len(combined) > MAX_KNOWLEDGE_CHARS:
+        combined = combined[:MAX_KNOWLEDGE_CHARS]
+
+    messages = [{"role": "user", "content": combined}]
+    accumulated_text = ""
+
+    async for event in provider.stream_turn(messages, [], EXTRACTION_PROMPT):
+        etype = event.get("type", "")
+        if etype == "text":
+            accumulated_text += event["text"]
+
+    accumulated_text = accumulated_text.strip()
+    if accumulated_text.startswith("```"):
+        lines = accumulated_text.split("\n")
+        if lines and lines[0].strip().startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        accumulated_text = "\n".join(lines).strip()
+
+    try:
+        entries = json.loads(accumulated_text)
+    except json.JSONDecodeError:
+        logger.error("Failed to parse AI response as JSON: %.200s", accumulated_text)
+        return None
+
+    if not isinstance(entries, list):
+        logger.error("AI response is not a list: %s", type(entries))
+        return None
+
+    valid_categories = {
+        "user-profile", "company-info", "preferences",
+        "contacts", "processes", "tools-and-systems",
+    }
+    validated = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        title = entry.get("title", "").strip()
+        content = entry.get("content", "").strip()
+        category = entry.get("category", "").strip()
+        if not title or not content:
+            continue
+        title = title[:200]
+        content = content[:2000]
+        if category not in valid_categories:
+            category = "user-profile"
+        validated.append({"category": category, "title": title, "content": content})
+
+    return validated
+
+
+def _populate_shared_context(entries: list[dict]) -> int:
+    count = 0
+    for entry in entries:
+        db.add_entry(
+            agent_name="system-bootstrap",
+            title=entry["title"],
+            content=entry["content"],
+            category=entry["category"],
+        )
+        count += 1
+
+    if count > 0:
+        try:
+            db.backup_to_gcs()
+        except Exception as e:
+            logger.warning("GCS backup after bootstrap failed: %s", e)
+
+    return count
+
+
+async def run_bootstrap(force: bool = False) -> dict:
+    if not force and not should_bootstrap():
+        return {"status": "skipped", "reason": "already_complete"}
+
+    if force and BOOTSTRAP_MARKER.exists():
+        BOOTSTRAP_MARKER.unlink()
+
+    knowledge = _gather_all_agent_knowledge()
+    if not knowledge:
+        _mark_bootstrap_complete()
+        return {"status": "complete", "entries_added": 0, "agents_analyzed": 0, "reason": "no_content"}
+
+    entries = await _extract_shared_knowledge(knowledge)
+
+    if entries is None:
+        return {"status": "failed", "reason": "no_provider"}
+
+    count = _populate_shared_context(entries)
+    _mark_bootstrap_complete()
+
+    logger.info("Shared knowledge bootstrap complete: %d entries from %d agents", count, len(knowledge))
+    return {"status": "complete", "entries_added": count, "agents_analyzed": len(knowledge)}
+
+
+def run_bootstrap_sync(force: bool = False) -> dict:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(asyncio.run, run_bootstrap(force))
+            return future.result(timeout=300)
+    else:
+        return asyncio.run(run_bootstrap(force))

--- a/backend/core/agents/shared_context/bootstrap.py
+++ b/backend/core/agents/shared_context/bootstrap.py
@@ -190,8 +190,7 @@ async def run_bootstrap(force: bool = False) -> dict:
 
     knowledge = _gather_all_agent_knowledge()
     if not knowledge:
-        _mark_bootstrap_complete()
-        return {"status": "complete", "entries_added": 0, "agents_analyzed": 0, "reason": "no_content"}
+        return {"status": "skipped", "reason": "no_content"}
 
     entries = await _extract_shared_knowledge(knowledge)
 

--- a/backend/core/agents/shared_context/bootstrap.py
+++ b/backend/core/agents/shared_context/bootstrap.py
@@ -161,6 +161,7 @@ async def _extract_shared_knowledge(knowledge_texts: dict[str, str]) -> list[dic
 
 
 def _populate_shared_context(entries: list[dict]) -> int:
+    db.delete_entries_by_agent("system-bootstrap")
     count = 0
     for entry in entries:
         db.add_entry(

--- a/backend/core/agents/shared_context/db.py
+++ b/backend/core/agents/shared_context/db.py
@@ -177,3 +177,12 @@ def delete_entry(entry_id: str) -> bool:
         cursor = conn.execute("DELETE FROM shared_entries WHERE id = ?", (entry_id,))
         conn.commit()
     return cursor.rowcount > 0
+
+
+def delete_entries_by_agent(agent_name: str) -> int:
+    """Delete all entries for a given agent_name. Returns count deleted."""
+    conn = get_db()
+    with _write_lock:
+        cursor = conn.execute("DELETE FROM shared_entries WHERE agent_name = ?", (agent_name,))
+        conn.commit()
+    return cursor.rowcount

--- a/backend/core/agents/shared_context/router.py
+++ b/backend/core/agents/shared_context/router.py
@@ -91,3 +91,18 @@ def delete_entry(entry_id: str):
     except Exception:
         pass
     return {"id": entry_id, "deleted": True}
+
+
+# ── Bootstrap ─────────────────────────────────────────────────────
+
+
+@router.post("/bootstrap")
+async def bootstrap_shared_knowledge(force: bool = False):
+    """Analyze all agents' knowledge files and populate shared context.
+
+    Extracts universally useful facts (user profile, company info, contacts,
+    preferences) via AI and writes them as shared entries. Runs automatically
+    when the second agent is created; this endpoint allows manual re-runs.
+    """
+    from .bootstrap import run_bootstrap
+    return await run_bootstrap(force=force)


### PR DESCRIPTION
## Summary
- When a second agent is created, automatically analyze existing agents' knowledge files via AI and populate the shared context database with universally useful facts (user name, company info, preferences, contacts)
- New agents immediately see shared knowledge in their system prompt without re-asking basic questions the user already answered during the first agent's onboarding
- Adds `POST /api/shared-context/bootstrap` admin endpoint for manual re-runs with optional `force` param

## Test plan
- [ ] Create first agent, complete onboarding → verify no bootstrap triggers
- [ ] Create second agent → check logs for "Shared knowledge bootstrap triggered"
- [ ] After a few seconds, `GET /api/shared-context/entries` → verify extracted entries appear with `agent_name=system-bootstrap`
- [ ] Open second agent chat → verify shared context manifest includes bootstrapped entries
- [ ] Create third agent → verify bootstrap does NOT re-trigger
- [ ] `POST /api/shared-context/bootstrap?force=true` → verify re-run works
- [ ] Test with no AI provider configured → verify graceful skip with log warning