### PR TITLE
Telegram group chat support with bot-to-bot conversations

### DIFF
--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -67,6 +67,9 @@ def _setup_connection() -> None:
         ("telegram_enabled", "INTEGER NOT NULL DEFAULT 0"),
         ("telegram_bot_token", "TEXT NOT NULL DEFAULT ''"),
         ("telegram_bot_username", "TEXT NOT NULL DEFAULT ''"),
+        ("telegram_group_enabled", "INTEGER NOT NULL DEFAULT 0"),
+        ("telegram_respond_to_bots", "INTEGER NOT NULL DEFAULT 0"),
+        ("telegram_max_bot_turns", "INTEGER NOT NULL DEFAULT 3"),
         ("whatsapp_session_id", "TEXT NOT NULL DEFAULT ''"),
     ]:
         try:
@@ -145,6 +148,7 @@ UPDATABLE_FIELDS = {
     "onboarding_complete", "provider_override", "model_override",
     "gmail_enabled", "calendar_enabled", "whatsapp_session_id",
     "telegram_enabled", "telegram_bot_token", "telegram_bot_username",
+    "telegram_group_enabled", "telegram_respond_to_bots", "telegram_max_bot_turns",
 }
 
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -192,6 +192,9 @@ class UpdateAgentRequest(BaseModel):
     gmail_enabled: bool | None = None
     calendar_enabled: bool | None = None
     telegram_enabled: bool | None = None
+    telegram_group_enabled: bool | None = None
+    telegram_respond_to_bots: bool | None = None
+    telegram_max_bot_turns: int | None = None
 
 
 class ChatRequest(BaseModel):
@@ -282,7 +285,7 @@ async def update_agent(agent_id: str, body: UpdateAgentRequest, user=Depends(get
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
-    for field in ("onboarding_complete", "gmail_enabled", "calendar_enabled", "telegram_enabled"):
+    for field in ("onboarding_complete", "gmail_enabled", "calendar_enabled", "telegram_enabled", "telegram_group_enabled", "telegram_respond_to_bots"):
         if field in updates:
             updates[field] = int(updates[field])
     agent = agent_db.update_agent(agent_id, **updates)

--- a/backend/core/agents/chat_history/service.py
+++ b/backend/core/agents/chat_history/service.py
@@ -31,7 +31,7 @@ class ChatHistoryService:
         """
         conv_id = str(uuid.uuid4())
         pinned = 1 if source else 0
-        title = {"telegram": "Telegram", "whatsapp": "WhatsApp"}.get(source or "", "New conversation")
+        title = {"telegram": "Telegram", "telegram-group": "Telegram Group", "whatsapp": "WhatsApp"}.get(source or "", "New conversation")
         db = self._db.get_db()
         with self._db.write_lock():
             db.execute(

--- a/backend/integrations/telegram/group.py
+++ b/backend/integrations/telegram/group.py
@@ -1,0 +1,93 @@
+"""Telegram group chat support.
+
+Handles group-specific routing decisions, loop prevention for bot-to-bot
+conversations, and message formatting for group context.
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+RESPONSE_COOLDOWN = 2.0
+
+_lock = threading.Lock()
+_group_states: dict[int, "_GroupState"] = {}
+
+
+@dataclass
+class _GroupState:
+    consecutive_bot_turns: int = 0
+    last_response_times: dict[str, float] = field(default_factory=dict)
+
+
+def _get_state(chat_id: int) -> _GroupState:
+    if chat_id not in _group_states:
+        _group_states[chat_id] = _GroupState()
+    return _group_states[chat_id]
+
+
+def is_group_chat(chat_type: str) -> bool:
+    return chat_type in ("group", "supergroup")
+
+
+def should_respond(
+    chat_id: int,
+    sender_is_bot: bool,
+    sender_username: str,
+    agent: dict,
+) -> tuple[bool, str]:
+    """Decide whether the agent should respond to a group message.
+
+    Returns (should_respond, reason).
+    """
+    if not agent.get("telegram_group_enabled"):
+        return False, "group_disabled"
+
+    bot_username = agent.get("telegram_bot_username", "")
+    if sender_username and bot_username and sender_username.lower() == bot_username.lower():
+        return False, "self_message"
+
+    with _lock:
+        state = _get_state(chat_id)
+
+        if sender_is_bot:
+            if not agent.get("telegram_respond_to_bots"):
+                return False, "bot_messages_disabled"
+            max_turns = agent.get("telegram_max_bot_turns", 3)
+            if state.consecutive_bot_turns >= max_turns:
+                return False, "max_bot_turns"
+
+        agent_id = agent["id"]
+        last = state.last_response_times.get(agent_id, 0)
+        if time.time() - last < RESPONSE_COOLDOWN:
+            return False, "cooldown"
+
+    return True, "ok"
+
+
+def record_human_message(chat_id: int) -> None:
+    with _lock:
+        state = _get_state(chat_id)
+        state.consecutive_bot_turns = 0
+
+
+def record_bot_message(chat_id: int) -> None:
+    with _lock:
+        state = _get_state(chat_id)
+        state.consecutive_bot_turns += 1
+
+
+def record_response(chat_id: int, agent_id: str) -> None:
+    with _lock:
+        state = _get_state(chat_id)
+        state.last_response_times[agent_id] = time.time()
+
+
+def build_group_prefix(
+    group_name: str, sender_name: str, sender_is_bot: bool,
+) -> str:
+    bot_tag = " [bot]" if sender_is_bot else ""
+    return f"[Group: {group_name}] {sender_name}{bot_tag}: "

--- a/backend/integrations/telegram/group.py
+++ b/backend/integrations/telegram/group.py
@@ -33,11 +33,30 @@ def is_group_chat(chat_type: str) -> bool:
     return chat_type in ("group", "supergroup")
 
 
+def is_addressed_to_bot(
+    text: str, entities: list, reply_to_bot_username: str, bot_username: str,
+) -> bool:
+    """Check if a group message is addressed to this bot via @mention or reply."""
+    if not bot_username:
+        return False
+    mention_tag = f"@{bot_username}".lower()
+    for ent in entities:
+        if ent.get("type") == "mention":
+            offset = ent.get("offset", 0)
+            length = ent.get("length", 0)
+            if text[offset:offset + length].lower() == mention_tag:
+                return True
+    if reply_to_bot_username and reply_to_bot_username.lower() == bot_username.lower():
+        return True
+    return False
+
+
 def should_respond(
     chat_id: int,
     sender_is_bot: bool,
     sender_username: str,
     agent: dict,
+    is_addressed: bool = False,
 ) -> tuple[bool, str]:
     """Decide whether the agent should respond to a group message.
 
@@ -50,13 +69,17 @@ def should_respond(
     if sender_username and bot_username and sender_username.lower() == bot_username.lower():
         return False, "self_message"
 
+    # Human messages require @mention or reply-to-bot
+    if not sender_is_bot and not is_addressed:
+        return False, "not_addressed"
+
     with _lock:
         state = _get_state(chat_id)
 
         if sender_is_bot:
             if not agent.get("telegram_respond_to_bots"):
                 return False, "bot_messages_disabled"
-            max_turns = agent.get("telegram_max_bot_turns", 3)
+            max_turns = max(1, agent.get("telegram_max_bot_turns", 3))
             if state.consecutive_bot_turns >= max_turns:
                 return False, "max_bot_turns"
 
@@ -86,8 +109,12 @@ def record_response(chat_id: int, agent_id: str) -> None:
         state.last_response_times[agent_id] = time.time()
 
 
+def _sanitize(text: str) -> str:
+    return text.replace("[", "(").replace("]", ")").replace("\n", " ")
+
+
 def build_group_prefix(
     group_name: str, sender_name: str, sender_is_bot: bool,
 ) -> str:
     bot_tag = " [bot]" if sender_is_bot else ""
-    return f"[Group: {group_name}] {sender_name}{bot_tag}: "
+    return f"[Group: {_sanitize(group_name)}] {_sanitize(sender_name)}{bot_tag}: "

--- a/backend/integrations/telegram/lifecycle.py
+++ b/backend/integrations/telegram/lifecycle.py
@@ -163,12 +163,19 @@ def start_polling(agent_id: str, slug: str, bot_token: str) -> None:
                     chat = message.get("chat", {})
                     from_user = message.get("from", {})
                     chat_id = chat.get("id")
+                    chat_type = chat.get("type", "private")
                     user_id = str(from_user.get("id", ""))
+                    is_bot_sender = from_user.get("is_bot", False)
+                    from_username = from_user.get("username", "")
                     first_name = from_user.get("first_name", "")
                     last_name = from_user.get("last_name", "")
                     sender_name = f"{first_name} {last_name}".strip() or "Unknown"
+                    group_name = chat.get("title", "")
                     if chat_id and user_id:
-                        _safe_process_telegram(slug, user_id, sender_name, message["text"], chat_id)
+                        _safe_process_telegram(
+                            slug, user_id, sender_name, message["text"], chat_id,
+                            chat_type, is_bot_sender, from_username, group_name,
+                        )
             except Exception:
                 logger.exception("Telegram polling error for %s", slug)
                 if not stop_event.is_set():

--- a/backend/integrations/telegram/lifecycle.py
+++ b/backend/integrations/telegram/lifecycle.py
@@ -171,10 +171,16 @@ def start_polling(agent_id: str, slug: str, bot_token: str) -> None:
                     last_name = from_user.get("last_name", "")
                     sender_name = f"{first_name} {last_name}".strip() or "Unknown"
                     group_name = chat.get("title", "")
+                    entities = message.get("entities", [])
+                    reply_to = message.get("reply_to_message")
+                    reply_to_bot_username = ""
+                    if reply_to and reply_to.get("from", {}).get("is_bot"):
+                        reply_to_bot_username = reply_to.get("from", {}).get("username", "")
                     if chat_id and user_id:
                         _safe_process_telegram(
                             slug, user_id, sender_name, message["text"], chat_id,
                             chat_type, is_bot_sender, from_username, group_name,
+                            entities, reply_to_bot_username,
                         )
             except Exception:
                 logger.exception("Telegram polling error for %s", slug)

--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -83,6 +83,13 @@ async def telegram_webhook(agent_slug: str, request: Request):
     sender_name = f"{first_name} {last_name}".strip() or "Unknown"
     group_name = chat.get("title", "")
 
+    # For group mention/reply detection
+    entities = message.get("entities", [])
+    reply_to = message.get("reply_to_message")
+    reply_to_bot_username = ""
+    if reply_to and reply_to.get("from", {}).get("is_bot"):
+        reply_to_bot_username = reply_to.get("from", {}).get("username", "")
+
     if not chat_id or not user_id:
         return {"status": "ok"}
 
@@ -93,7 +100,7 @@ async def telegram_webhook(agent_slug: str, request: Request):
 
     _executor.submit(
         _safe_process_telegram, agent_slug, user_id, sender_name, text, chat_id,
-        chat_type, is_bot, from_username, group_name,
+        chat_type, is_bot, from_username, group_name, entities, reply_to_bot_username,
     )
     return {"status": "ok"}
 
@@ -102,6 +109,7 @@ def _safe_process_telegram(
     agent_slug: str, user_id: str, sender_name: str, message: str, chat_id: int,
     chat_type: str = "private", is_bot: bool = False,
     from_username: str = "", group_name: str = "",
+    entities: list | None = None, reply_to_bot_username: str = "",
 ) -> None:
     """Process a Telegram message in a background thread."""
     from . import group
@@ -124,15 +132,20 @@ def _safe_process_telegram(
 
         # ── Group chat path ──────────────────────────────────────────
         if group.is_group_chat(chat_type):
-            if is_bot:
-                group.record_bot_message(chat_id)
-            else:
+            if not is_bot:
                 group.record_human_message(chat_id)
 
-            ok, reason = group.should_respond(chat_id, is_bot, from_username, agent)
+            bot_username = agent.get("telegram_bot_username", "")
+            is_addressed = group.is_addressed_to_bot(
+                message, entities or [], reply_to_bot_username, bot_username,
+            )
+            ok, reason = group.should_respond(chat_id, is_bot, from_username, agent, is_addressed)
             if not ok:
                 logger.debug("Group skip: chat=%s agent=%s reason=%s", chat_id, agent_slug, reason)
                 return
+
+            if is_bot:
+                group.record_bot_message(chat_id)
 
             loop = asyncio.new_event_loop()
             try:
@@ -149,8 +162,10 @@ def _safe_process_telegram(
             finally:
                 loop.close()
 
-            send_message(chat_id, response, bot_token)
-            group.record_response(chat_id, agent["id"])
+            try:
+                send_message(chat_id, response, bot_token)
+            finally:
+                group.record_response(chat_id, agent["id"])
             return
 
         # ── Private chat path (unchanged) ────────────────────────────

--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -73,30 +73,39 @@ async def telegram_webhook(agent_slug: str, request: Request):
 
     chat = message.get("chat", {})
     chat_id = chat.get("id")
+    chat_type = chat.get("type", "private")
     from_user = message.get("from", {})
     user_id = str(from_user.get("id", ""))
+    is_bot = from_user.get("is_bot", False)
+    from_username = from_user.get("username", "")
     first_name = from_user.get("first_name", "")
     last_name = from_user.get("last_name", "")
     sender_name = f"{first_name} {last_name}".strip() or "Unknown"
+    group_name = chat.get("title", "")
 
     if not chat_id or not user_id:
         return {"status": "ok"}
 
     logger.info(
-        "Telegram webhook: slug=%s user_id=%s name=%s chat_id=%s msg=%s",
-        agent_slug, user_id, sender_name, chat_id, text[:100],
+        "Telegram webhook: slug=%s user_id=%s name=%s chat_id=%s type=%s msg=%s",
+        agent_slug, user_id, sender_name, chat_id, chat_type, text[:100],
     )
 
     _executor.submit(
         _safe_process_telegram, agent_slug, user_id, sender_name, text, chat_id,
+        chat_type, is_bot, from_username, group_name,
     )
     return {"status": "ok"}
 
 
 def _safe_process_telegram(
     agent_slug: str, user_id: str, sender_name: str, message: str, chat_id: int,
+    chat_type: str = "private", is_bot: bool = False,
+    from_username: str = "", group_name: str = "",
 ) -> None:
     """Process a Telegram message in a background thread."""
+    from . import group
+
     bot_token = ""
     try:
         # Resolve slug → agent
@@ -113,6 +122,38 @@ def _safe_process_telegram(
         if not agent.get("telegram_enabled"):
             return
 
+        # ── Group chat path ──────────────────────────────────────────
+        if group.is_group_chat(chat_type):
+            if is_bot:
+                group.record_bot_message(chat_id)
+            else:
+                group.record_human_message(chat_id)
+
+            ok, reason = group.should_respond(chat_id, is_bot, from_username, agent)
+            if not ok:
+                logger.debug("Group skip: chat=%s agent=%s reason=%s", chat_id, agent_slug, reason)
+                return
+
+            loop = asyncio.new_event_loop()
+            try:
+                response = loop.run_until_complete(
+                    service.process_group_message(
+                        chat_id=chat_id,
+                        agent_id=agent["id"],
+                        sender_name=sender_name,
+                        sender_is_bot=is_bot,
+                        group_name=group_name,
+                        message_text=message,
+                    )
+                )
+            finally:
+                loop.close()
+
+            send_message(chat_id, response, bot_token)
+            group.record_response(chat_id, agent["id"])
+            return
+
+        # ── Private chat path (unchanged) ────────────────────────────
         # Check if sender has a mapping
         mapping = state.get_mapping_by_sender("telegram", user_id)
         if not mapping:
@@ -217,6 +258,9 @@ def get_telegram_status(
         "connected": bool(bot_token),
         "enabled": bool(agent.get("telegram_enabled")),
         "bot_username": agent.get("telegram_bot_username", ""),
+        "group_enabled": bool(agent.get("telegram_group_enabled")),
+        "respond_to_bots": bool(agent.get("telegram_respond_to_bots")),
+        "max_bot_turns": agent.get("telegram_max_bot_turns", 3),
     }
 
 

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -191,6 +191,86 @@ async def process_message(
     return response or "I had trouble generating a response. Please try again."
 
 
+async def process_group_message(
+    chat_id: int,
+    agent_id: str,
+    sender_name: str,
+    sender_is_bot: bool,
+    group_name: str,
+    message_text: str,
+) -> str:
+    """Process a group chat message for a specific agent."""
+    from .group import build_group_prefix
+
+    agent = agent_db.get_agent(agent_id)
+    if not agent:
+        return "This agent is no longer available."
+    if not agent.get("telegram_enabled"):
+        return "Telegram messaging is currently disabled for this agent."
+
+    slug = agent["slug"]
+
+    config = build_agent_config(agent)
+    ctx_manager = get_context_manager(slug)
+    chat_service = get_chat_service(slug)
+
+    store = CredentialStore()
+    provider = get_ai_provider(
+        agent_provider=config.provider_override or None,
+        agent_model=config.model_override or None,
+    )
+    if not provider:
+        return "No AI provider is configured. Please set up an AI provider in Settings."
+
+    google_token = ""
+    if config.gmail_enabled or config.calendar_enabled:
+        google_token = store.get_google_token() or ""
+
+    integration_tool_defs, integration_executors = _load_integration_tools()
+
+    reminder_handlers, sa_handlers = _build_agent_handlers(slug)
+    registry = ToolRegistry(
+        context_dir=config.context_dir,
+        google_access_token=google_token,
+        integration_executors=integration_executors,
+        agent_slug=slug,
+        reminder_handlers=reminder_handlers,
+        scheduled_action_handlers=sa_handlers,
+    )
+
+    group_sender_id = f"group:{chat_id}"
+    conv = state.get_or_create_conversation(group_sender_id, agent_id)
+
+    chatty_conv_id = conv.get("chatty_conversation_id")
+    if not chatty_conv_id and chat_service:
+        try:
+            new_conv = chat_service.create_conversation(source="telegram-group")
+            chatty_conv_id = new_conv["id"]
+            state.set_chatty_conversation_id(conv["id"], chatty_conv_id)
+        except Exception as e:
+            logger.warning("Failed to create group chat conversation: %s", e)
+
+    messages = _load_recent_messages(chat_service, chatty_conv_id)
+    prefix = build_group_prefix(group_name, sender_name, sender_is_bot)
+    if not messages:
+        messages = [{"role": "user", "content": prefix + message_text}]
+    else:
+        messages.append({"role": "user", "content": prefix + message_text})
+
+    response = await ai_service.run_sync(
+        config=config,
+        provider=provider,
+        registry=registry,
+        ctx_manager=ctx_manager,
+        messages=messages,
+        chat_service=chat_service,
+        conversation_id=chatty_conv_id,
+        integration_tool_defs=integration_tool_defs or None,
+    )
+
+    return response or "I had trouble generating a response. Please try again."
+
+
 def _load_recent_messages(chat_service, conversation_id: str | None) -> list[dict]:
     """Load recent messages from chat history for conversation context."""
     if not chat_service or not conversation_id:

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -32,6 +32,7 @@ from core.agents.scheduled_actions.tools import (
 from core.agents import ai_service
 
 from . import state
+from .group import build_group_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +201,6 @@ async def process_group_message(
     message_text: str,
 ) -> str:
     """Process a group chat message for a specific agent."""
-    from .group import build_group_prefix
 
     agent = agent_db.get_agent(agent_id)
     if not agent:

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -26,6 +26,9 @@ interface AgentRow {
   telegram_enabled: boolean;
   telegram_bot_token: string;
   telegram_bot_username: string;
+  telegram_group_enabled: boolean;
+  telegram_respond_to_bots: boolean;
+  telegram_max_bot_turns: number;
 }
 
 type Tab = 'chat' | 'knowledge' | 'reports' | 'activity' | 'telegram';
@@ -528,6 +531,9 @@ export function AgentPage() {
               botToken={agent.telegram_bot_token || ''}
               botUsername={agent.telegram_bot_username || ''}
               telegramEnabled={agent.telegram_enabled}
+              groupEnabled={agent.telegram_group_enabled}
+              respondToBots={agent.telegram_respond_to_bots}
+              maxBotTurns={agent.telegram_max_bot_turns ?? 3}
               onUpdate={() => {
                 api<AgentRow>(`/api/agents/${agentId}`).then(setAgent).catch(() => {});
               }}

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -347,7 +347,7 @@ export function AgentChatPanel({
                   {conversationSource?.startsWith('telegram') ? (conversationSource === 'telegram-group' ? 'Telegram Group' : 'Telegram') : 'WhatsApp'}
                 </span>
                 <span style={{ fontSize: 11, color: 'rgba(237,240,244,0.4)' }}>
-                  Messages from {conversationSource === 'telegram' ? 'Telegram' : 'WhatsApp'} appear here
+                  Messages from {conversationSource?.startsWith('telegram') ? 'Telegram' : 'WhatsApp'} appear here
                 </span>
               </div>
             )}

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -336,15 +336,15 @@ export function AgentChatPanel({
               <div style={{
                 display: 'flex', alignItems: 'center', gap: 8,
                 padding: '8px 14px', borderRadius: 8,
-                ...(conversationSource === 'telegram'
+                ...(conversationSource?.startsWith('telegram')
                   ? { background: 'rgba(0,136,204,0.08)', border: '1px solid rgba(0,136,204,0.2)' }
                   : { background: 'rgba(37,211,102,0.08)', border: '1px solid rgba(37,211,102,0.2)' }),
               }}>
                 <span style={{
                   fontSize: 11, fontWeight: 600, letterSpacing: '0.05em',
-                  color: conversationSource === 'telegram' ? '#0088cc' : '#25D366',
+                  color: conversationSource?.startsWith('telegram') ? '#0088cc' : '#25D366',
                 }}>
-                  {conversationSource === 'telegram' ? 'Telegram' : 'WhatsApp'}
+                  {conversationSource?.startsWith('telegram') ? (conversationSource === 'telegram-group' ? 'Telegram Group' : 'Telegram') : 'WhatsApp'}
                 </span>
                 <span style={{ fontSize: 11, color: 'rgba(237,240,244,0.4)' }}>
                   Messages from {conversationSource === 'telegram' ? 'Telegram' : 'WhatsApp'} appear here

--- a/frontend/src/agent/components/ConversationSidebar.tsx
+++ b/frontend/src/agent/components/ConversationSidebar.tsx
@@ -186,11 +186,11 @@ export function ConversationSidebar({
                             textTransform: 'uppercase',
                             padding: '1px 5px', borderRadius: 3,
                             flexShrink: 0,
-                            ...((item as Conversation).source === 'telegram'
+                            ...((item as Conversation).source?.startsWith('telegram')
                               ? { background: 'rgba(0,136,204,0.15)', color: '#0088cc' }
                               : { background: 'rgba(37,211,102,0.15)', color: '#25D366' }),
                           }}>
-                            {(item as Conversation).source === 'telegram' ? 'TG' : 'WA'}
+                            {(item as Conversation).source?.startsWith('telegram') ? 'TG' : 'WA'}
                           </span>
                         )}
                         <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>

--- a/frontend/src/agent/components/TelegramSettings.tsx
+++ b/frontend/src/agent/components/TelegramSettings.tsx
@@ -516,6 +516,7 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
   const [togglingGroup, setTogglingGroup] = useState(false);
   const [togglingBots, setTogglingBots] = useState(false);
   const [localMaxTurns, setLocalMaxTurns] = useState(maxBotTurns);
+  useEffect(() => { setLocalMaxTurns(maxBotTurns); }, [maxBotTurns]);
 
   async function handleToggleGroup() {
     setTogglingGroup(true);
@@ -713,6 +714,7 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
                   value={localMaxTurns}
                   onChange={e => setLocalMaxTurns(parseInt(e.target.value, 10))}
                   onPointerUp={handleMaxBotTurnsSave}
+                  onKeyUp={handleMaxBotTurnsSave}
                   className="w-full accent-[#0088cc]"
                 />
                 <div className="flex justify-between text-gray-600 text-xs">

--- a/frontend/src/agent/components/TelegramSettings.tsx
+++ b/frontend/src/agent/components/TelegramSettings.tsx
@@ -515,6 +515,7 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
   const [resetSuccess, setResetSuccess] = useState(false);
   const [togglingGroup, setTogglingGroup] = useState(false);
   const [togglingBots, setTogglingBots] = useState(false);
+  const [localMaxTurns, setLocalMaxTurns] = useState(maxBotTurns);
 
   async function handleToggleGroup() {
     setTogglingGroup(true);
@@ -538,11 +539,10 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
     } finally { setTogglingBots(false); }
   }
 
-  async function handleMaxBotTurnsChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const val = parseInt(e.target.value, 10);
+  async function handleMaxBotTurnsSave() {
     await api(`/api/agents/${agentId}`, {
       method: 'PUT',
-      body: JSON.stringify({ telegram_max_bot_turns: val }),
+      body: JSON.stringify({ telegram_max_bot_turns: localMaxTurns }),
     });
     onUpdate();
   }
@@ -661,8 +661,8 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
       <div className="bg-gray-800 rounded-xl border border-gray-700 p-4 space-y-4">
         <h3 className="text-white text-sm font-semibold">Group Chats</h3>
         <p className="text-gray-400 text-xs">
-          Allow this bot to participate in Telegram group conversations.
-          Requires BotFather privacy mode to be disabled (send <span className="font-mono bg-gray-700 px-1 rounded">/setprivacy</span> → select <span className="font-mono bg-gray-700 px-1 rounded">@{botUsername}</span> → Disable).
+          Allow this bot to respond in Telegram groups when @mentioned or replied to.
+          Anyone in the group can interact with the agent and its tools.
         </p>
 
         {/* Group enabled toggle */}
@@ -686,7 +686,7 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
             <div className="flex items-center justify-between py-2 border-t border-gray-700">
               <div>
                 <p className="text-white text-sm font-medium">Respond to Other Bots</p>
-                <p className="text-gray-500 text-xs">Allow bot-to-bot conversations in groups</p>
+                <p className="text-gray-500 text-xs">Allow bot-to-bot conversations (requires BotFather <span className="font-mono">/setprivacy</span> → Disable)</p>
               </div>
               <button
                 onClick={handleToggleRespondToBots}
@@ -701,7 +701,7 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
               <div className="py-2 border-t border-gray-700 space-y-2">
                 <div className="flex items-center justify-between">
                   <p className="text-white text-sm font-medium">Max Bot Turns</p>
-                  <span className="text-gray-400 text-sm font-mono">{maxBotTurns}</span>
+                  <span className="text-gray-400 text-sm font-mono">{localMaxTurns}</span>
                 </div>
                 <p className="text-gray-500 text-xs">
                   Maximum consecutive bot-to-bot messages before requiring a human message. Prevents infinite loops.
@@ -710,8 +710,9 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
                   type="range"
                   min={1}
                   max={10}
-                  value={maxBotTurns}
-                  onChange={handleMaxBotTurnsChange}
+                  value={localMaxTurns}
+                  onChange={e => setLocalMaxTurns(parseInt(e.target.value, 10))}
+                  onPointerUp={handleMaxBotTurnsSave}
                   className="w-full accent-[#0088cc]"
                 />
                 <div className="flex justify-between text-gray-600 text-xs">

--- a/frontend/src/agent/components/TelegramSettings.tsx
+++ b/frontend/src/agent/components/TelegramSettings.tsx
@@ -13,6 +13,9 @@ interface Props {
   botToken: string;
   botUsername: string;
   telegramEnabled: boolean;
+  groupEnabled: boolean;
+  respondToBots: boolean;
+  maxBotTurns: number;
   onUpdate: () => void;
 }
 
@@ -27,7 +30,7 @@ interface RegistrationWindow {
 
 const TELEGRAM_BLUE = '#0088cc';
 
-export function TelegramSettings({ agentId, agentName, botToken, botUsername, telegramEnabled, onUpdate }: Props) {
+export function TelegramSettings({ agentId, agentName, botToken, botUsername, telegramEnabled, groupEnabled, respondToBots, maxBotTurns, onUpdate }: Props) {
   // If already connected, show management view
   if (botToken) {
     return (
@@ -36,6 +39,9 @@ export function TelegramSettings({ agentId, agentName, botToken, botUsername, te
         agentName={agentName}
         botUsername={botUsername}
         telegramEnabled={telegramEnabled}
+        groupEnabled={groupEnabled}
+        respondToBots={respondToBots}
+        maxBotTurns={maxBotTurns}
         onUpdate={onUpdate}
       />
     );
@@ -492,11 +498,14 @@ function StepAllSet({ agentName, botUsername }: {
 
 // ── Management View (already connected) ───────────────────────────────────────
 
-function ManagementView({ agentId, agentName, botUsername, telegramEnabled, onUpdate }: {
+function ManagementView({ agentId, agentName, botUsername, telegramEnabled, groupEnabled, respondToBots, maxBotTurns, onUpdate }: {
   agentId: string;
   agentName: string;
   botUsername: string;
   telegramEnabled: boolean;
+  groupEnabled: boolean;
+  respondToBots: boolean;
+  maxBotTurns: number;
   onUpdate: () => void;
 }) {
   const [toggling, setToggling] = useState(false);
@@ -504,6 +513,39 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, onUp
   const [showConfirmDisconnect, setShowConfirmDisconnect] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [resetSuccess, setResetSuccess] = useState(false);
+  const [togglingGroup, setTogglingGroup] = useState(false);
+  const [togglingBots, setTogglingBots] = useState(false);
+
+  async function handleToggleGroup() {
+    setTogglingGroup(true);
+    try {
+      await api(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ telegram_group_enabled: !groupEnabled }),
+      });
+      onUpdate();
+    } finally { setTogglingGroup(false); }
+  }
+
+  async function handleToggleRespondToBots() {
+    setTogglingBots(true);
+    try {
+      await api(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ telegram_respond_to_bots: !respondToBots }),
+      });
+      onUpdate();
+    } finally { setTogglingBots(false); }
+  }
+
+  async function handleMaxBotTurnsChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const val = parseInt(e.target.value, 10);
+    await api(`/api/agents/${agentId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ telegram_max_bot_turns: val }),
+    });
+    onUpdate();
+  }
 
   async function handleToggle() {
     setToggling(true);
@@ -612,6 +654,73 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, onUp
         </button>
         {resetSuccess && (
           <p className="text-green-400 text-xs">Registration window reopened for 10 minutes. Message the bot to link your account.</p>
+        )}
+      </div>
+
+      {/* Group Chats */}
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-4 space-y-4">
+        <h3 className="text-white text-sm font-semibold">Group Chats</h3>
+        <p className="text-gray-400 text-xs">
+          Allow this bot to participate in Telegram group conversations.
+          Requires BotFather privacy mode to be disabled (send <span className="font-mono bg-gray-700 px-1 rounded">/setprivacy</span> → select <span className="font-mono bg-gray-700 px-1 rounded">@{botUsername}</span> → Disable).
+        </p>
+
+        {/* Group enabled toggle */}
+        <div className="flex items-center justify-between py-2 border-t border-gray-700">
+          <div>
+            <p className="text-white text-sm font-medium">Enable Group Chats</p>
+            <p className="text-gray-500 text-xs">Respond to messages in group conversations</p>
+          </div>
+          <button
+            onClick={handleToggleGroup}
+            disabled={togglingGroup}
+            className={`relative w-11 h-6 rounded-full transition ${groupEnabled ? 'bg-[#0088cc]' : 'bg-gray-600'} ${togglingGroup ? 'opacity-50' : ''}`}
+          >
+            <span className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-all ${groupEnabled ? 'left-5' : 'left-0.5'}`} />
+          </button>
+        </div>
+
+        {groupEnabled && (
+          <>
+            {/* Bot-to-bot toggle */}
+            <div className="flex items-center justify-between py-2 border-t border-gray-700">
+              <div>
+                <p className="text-white text-sm font-medium">Respond to Other Bots</p>
+                <p className="text-gray-500 text-xs">Allow bot-to-bot conversations in groups</p>
+              </div>
+              <button
+                onClick={handleToggleRespondToBots}
+                disabled={togglingBots}
+                className={`relative w-11 h-6 rounded-full transition ${respondToBots ? 'bg-[#0088cc]' : 'bg-gray-600'} ${togglingBots ? 'opacity-50' : ''}`}
+              >
+                <span className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-all ${respondToBots ? 'left-5' : 'left-0.5'}`} />
+              </button>
+            </div>
+
+            {respondToBots && (
+              <div className="py-2 border-t border-gray-700 space-y-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-white text-sm font-medium">Max Bot Turns</p>
+                  <span className="text-gray-400 text-sm font-mono">{maxBotTurns}</span>
+                </div>
+                <p className="text-gray-500 text-xs">
+                  Maximum consecutive bot-to-bot messages before requiring a human message. Prevents infinite loops.
+                </p>
+                <input
+                  type="range"
+                  min={1}
+                  max={10}
+                  value={maxBotTurns}
+                  onChange={handleMaxBotTurnsChange}
+                  className="w-full accent-[#0088cc]"
+                />
+                <div className="flex justify-between text-gray-600 text-xs">
+                  <span>1</span>
+                  <span>10</span>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -15,6 +15,9 @@ export interface Agent {
   telegram_enabled: boolean;
   telegram_bot_token?: string;
   telegram_bot_username?: string;
+  telegram_group_enabled: boolean;
+  telegram_respond_to_bots: boolean;
+  telegram_max_bot_turns: number;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -472,6 +472,9 @@ export function IntegrationsTab() {
                           botToken={agent.telegram_bot_token || ''}
                           botUsername={agent.telegram_bot_username || ''}
                           telegramEnabled={agent.telegram_enabled}
+                          groupEnabled={agent.telegram_group_enabled}
+                          respondToBots={agent.telegram_respond_to_bots}
+                          maxBotTurns={agent.telegram_max_bot_turns ?? 3}
                           onUpdate={() => api<{ agents: Agent[] }>('/api/agents').then(data => setAgents(data.agents))}
                         />
                       );


### PR DESCRIPTION
## Summary
- Add Telegram group chat support so agents can participate in group conversations when @mentioned or replied to
- Bot-to-bot conversation mode with configurable turn limits and loop prevention (3-level: self-message filter, consecutive turn counter, response cooldown)
- Three new per-agent settings: group enabled, respond to bots, max bot turns — with dashboard UI (toggles + slider)
- Group conversations get their own shared context (keyed by group chat ID), correct source badges in sidebar and chat view

## Test plan
- [ ] Create two agents with Telegram bots, enable group chats + respond-to-bots on both
- [ ] Create a Telegram group, add both bots, send a message @mentioning one — verify it responds
- [ ] Reply to the bot's message — verify it responds to replies
- [ ] Send a normal message without @mention — verify bot does NOT respond
- [ ] Enable respond-to-bots, disable BotFather privacy on both bots — verify bot-to-bot exchange stops at max turns
- [ ] Send another human message — verify bot-to-bot counter resets
- [ ] Verify private/DM Telegram chats still work identically
- [ ] Verify group conversations show "TG" badge in sidebar and "Telegram Group" label in chat view
- [ ] Toggle settings on/off in dashboard — verify toggles and slider work