### PR TITLE
Add logo to README, CRM feature, group chat docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Chatty
+# <img src="docs/chatty-logo.svg" alt="" width="28" /> Chatty
 
-A free, open-source personal AI agent platform built for small business owners.
+A free, open-source browser-based personal AI agent platform built for professionals and small business owners.
 
-Create custom AI agents with their own personality, knowledge, and tools — powered by your own API keys. No SaaS fees, no vendor lock-in. You only pay for the AI usage you consume.
+Create custom AI agents with their own personality, knowledge, and tools — powered by your own API keys or local AI model. No SaaS fees, no vendor lock-in. You only pay for the AI usage you consume.
 
 ## Features
 
 - **Multi-agent** — Create and manage multiple AI agents, each with its own name, personality, and knowledge base
 - **Multi-provider AI** — Anthropic, OpenAI, Google Gemini, Ollama (local models), and Together AI
 - **Brandable** — Upload your logo, company name, and accent color to make it yours
+- **Built-in CRM** — Manage your pipeline: contacts, companies, tasks and deals all with your AI agent
 - **Integrations** — Gmail, Google Calendar, QuickBooks Online, WhatsApp, Telegram
 - **Local-first** — SQLite database, no external services required
 - **One-click deploy** — Deploy to Railway for access from any device

--- a/docs/chatty-logo.svg
+++ b/docs/chatty-logo.svg
@@ -1,0 +1,6 @@
+<svg width="120" height="120" viewBox="-4 -4 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 7.5a7.5 7.5 0 1 0 0 9" stroke="#C8D1D9" stroke-width="3" stroke-linecap="round" />
+  <path d="M18 9.5a5.5 5.5 0 1 0 0 5" stroke="#C8D1D9" stroke-width="1.25" stroke-linecap="round" opacity="0.4" />
+  <path d="M0 12h2.5M16 12h8" stroke="#C8D1D9" stroke-width="1.25" stroke-linecap="round" opacity="0.5" />
+  <circle cx="12" cy="12" r="1.5" fill="#C8D1D9" />
+</svg>


### PR DESCRIPTION
## Summary
- Add Chatty C mark logo inline with the README heading
- Add Built-in CRM as a standalone feature line
- Update tagline to "browser-based" and mention local AI model support
- Add `docs/telegram-group-chat.md` with bot-to-bot group chat setup guide

## Test plan
- [ ] Verify logo renders inline with heading on GitHub
- [ ] Verify README reads well on GitHub