### PR TITLE
Add Odoo database auto-discovery to setup form

### DIFF
--- a/backend/integrations/odoo/discovery.py
+++ b/backend/integrations/odoo/discovery.py
@@ -1,0 +1,156 @@
+"""Chatty — Odoo database auto-discovery.
+
+Discovers available databases on an Odoo instance using public (unauthenticated)
+endpoints. Tries XML-RPC db.list(), then JSON-RPC /web/database/list, then URL
+inference as a final fallback.
+"""
+
+import ipaddress
+import logging
+import socket
+import xmlrpc.client
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def discover_databases(url: str) -> dict:
+    """Discover available databases on an Odoo instance.
+
+    Returns dict with keys: databases, method, error.
+    """
+    url = _normalize_url(url)
+    if not url:
+        return {"databases": [], "method": None, "error": "Invalid URL"}
+
+    err = _check_ssrf(url)
+    if err:
+        return {"databases": [], "method": None, "error": err}
+
+    # Tier 1: XML-RPC db.list()
+    dbs = _try_xmlrpc_db_list(url)
+    if dbs is not None:
+        return {"databases": dbs, "method": "xmlrpc", "error": None}
+
+    # Tier 2: JSON-RPC /web/database/list
+    dbs = _try_jsonrpc_db_list(url)
+    if dbs is not None:
+        return {"databases": dbs, "method": "jsonrpc", "error": None}
+
+    # Tier 3: URL inference
+    dbs = _infer_from_url(url)
+    if dbs:
+        return {"databases": dbs, "method": "url_inference", "error": None}
+
+    return {
+        "databases": [],
+        "method": None,
+        "error": "Could not discover databases. The instance may have database listing disabled. Please enter the database name manually.",
+    }
+
+
+def _check_ssrf(url: str) -> str | None:
+    """Reject URLs that resolve to private/internal IPs. Returns error message or None."""
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    try:
+        addrs = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return f"Cannot resolve host: {host}"
+    for info in addrs:
+        ip = ipaddress.ip_address(info[4][0])
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+            return "Requests to internal addresses are not allowed"
+    return None
+
+
+def _normalize_url(url: str) -> str:
+    """Strip trailing slashes, ensure https:// prefix."""
+    url = url.strip()
+    if not url:
+        return ""
+    if not url.startswith(("http://", "https://")):
+        url = f"https://{url}"
+    return url.rstrip("/")
+
+
+class _TimeoutTransport(xmlrpc.client.Transport):
+    def __init__(self, timeout: int):
+        super().__init__()
+        self._timeout = timeout
+
+    def make_connection(self, host):
+        conn = super().make_connection(host)
+        conn.timeout = self._timeout
+        return conn
+
+
+class _TimeoutSafeTransport(xmlrpc.client.SafeTransport):
+    def __init__(self, timeout: int):
+        super().__init__()
+        self._timeout = timeout
+
+    def make_connection(self, host):
+        conn = super().make_connection(host)
+        conn.timeout = self._timeout
+        return conn
+
+
+def _try_xmlrpc_db_list(url: str) -> list[str] | None:
+    """Returns None if unavailable."""
+    try:
+        transport = _TimeoutSafeTransport(5) if url.startswith("https") else _TimeoutTransport(5)
+        proxy = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/db", transport=transport)
+        result = proxy.list()
+        if isinstance(result, list):
+            return result
+        return None
+    except xmlrpc.client.Fault:
+        return None
+    except (OSError, socket.timeout, xmlrpc.client.ProtocolError):
+        return None
+    except Exception as e:
+        logger.debug("XML-RPC db.list() failed for %s: %s", url, e)
+        return None
+
+
+def _try_jsonrpc_db_list(url: str) -> list[str] | None:
+    """Returns None if unavailable."""
+    try:
+        resp = httpx.post(
+            f"{url}/web/database/list",
+            json={"jsonrpc": "2.0", "method": "call", "params": {}},
+            timeout=5,
+            follow_redirects=False,
+        )
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        result = data.get("result")
+        if isinstance(result, list):
+            return result
+        return None
+    except (httpx.HTTPError, httpx.InvalidURL, OSError, ValueError):
+        return None
+
+
+def _infer_from_url(url: str) -> list[str]:
+    """Infer database name from URL pattern."""
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+
+    # *.odoo.com — database is the subdomain
+    if host.endswith(".odoo.com") and host != "www.odoo.com":
+        subdomain = host.removesuffix(".odoo.com")
+        if subdomain:
+            return [subdomain]
+
+    # *.odoo.sh — subdomain is a likely prefix
+    if host.endswith(".odoo.sh"):
+        subdomain = host.removesuffix(".odoo.sh")
+        if subdomain:
+            return [subdomain]
+
+    return []

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from core.auth import get_current_user
 from .registry import list_integrations, enable, disable, is_enabled
@@ -23,6 +23,10 @@ router = APIRouter()
 
 
 # ── Setup request models ──────────────────────────────────────────────────────
+
+class OdooDiscoverRequest(BaseModel):
+    url: str = Field(..., max_length=2048)
+
 
 class OdooSetupRequest(BaseModel):
     url: str
@@ -64,6 +68,13 @@ async def disable_integration(name: str, user=Depends(get_current_user)):
         raise HTTPException(status_code=404, detail=f"Unknown integration: {name}")
     disable(name)
     return {"ok": True, "integration": name, "enabled": False}
+
+
+@router.post("/odoo/discover-databases")
+def discover_odoo_databases(body: OdooDiscoverRequest, user=Depends(get_current_user)):
+    """Discover available databases on an Odoo instance (no credentials needed)."""
+    from .odoo.discovery import discover_databases
+    return discover_databases(url=body.url)
 
 
 @router.post("/odoo/setup")

--- a/frontend/src/onboarding/steps/OdooSetupStep.tsx
+++ b/frontend/src/onboarding/steps/OdooSetupStep.tsx
@@ -14,6 +14,43 @@ export function OdooSetupStep({ onComplete, onSkip }: Props) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
+  const [discoveredDbs, setDiscoveredDbs] = useState<string[]>([]);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoveryMethod, setDiscoveryMethod] = useState('');
+  const [manualMode, setManualMode] = useState(false);
+
+  async function discoverDatabases() {
+    if (!url.trim()) return;
+    setDiscovering(true);
+    setError('');
+    setDiscoveredDbs([]);
+    setDiscoveryMethod('');
+    try {
+      const result = await api<{
+        databases: string[];
+        method: string | null;
+        error: string | null;
+      }>('/api/integrations/odoo/discover-databases', {
+        method: 'POST',
+        body: JSON.stringify({ url }),
+      });
+      if (result.databases.length > 0) {
+        setDiscoveredDbs(result.databases);
+        setDiscoveryMethod(result.method || '');
+        setManualMode(false);
+        if (result.databases.length === 1) {
+          setDatabase(result.databases[0]);
+        }
+      } else {
+        setError(result.error || 'No databases found. Please enter the name manually.');
+      }
+    } catch {
+      setError('Could not reach the Odoo instance. Check the URL and try again.');
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
   async function connect() {
     setSaving(true);
     setError('');
@@ -31,6 +68,7 @@ export function OdooSetupStep({ onComplete, onSkip }: Props) {
   }
 
   const isValid = url.trim() && database.trim() && username.trim() && apiKey.trim();
+  const showDropdown = discoveredDbs.length > 0 && !manualMode;
 
   return (
     <div>
@@ -45,25 +83,84 @@ export function OdooSetupStep({ onComplete, onSkip }: Props) {
           <label className="block text-sm text-gray-300 mb-1.5">Odoo URL</label>
           <input
             value={url}
-            onChange={e => setUrl(e.target.value)}
+            onChange={e => {
+              setUrl(e.target.value);
+              if (discoveredDbs.length > 0) {
+                setDiscoveredDbs([]);
+                setDiscoveryMethod('');
+                setDatabase('');
+                setManualMode(false);
+              }
+            }}
             placeholder="https://mycompany.odoo.com"
             className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-amber-500"
           />
-          <p className="text-gray-500 text-xs mt-1">Your Odoo instance URL</p>
+          <div className="flex items-center justify-between mt-1.5">
+            <p className="text-gray-500 text-xs">Your Odoo instance URL</p>
+            <button
+              onClick={discoverDatabases}
+              disabled={discovering || !url.trim()}
+              className="text-amber-400 text-xs hover:text-amber-300 transition disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              {discovering ? 'Searching...' : 'Find my database'}
+            </button>
+          </div>
         </div>
 
         {/* Database */}
         <div>
           <label className="block text-sm text-gray-300 mb-1.5">Database Name</label>
-          <input
-            value={database}
-            onChange={e => setDatabase(e.target.value)}
-            placeholder="mycompany-main"
-            className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-amber-500"
-          />
-          <div className="bg-gray-900 border border-dashed border-gray-700 rounded-lg p-3 mt-2 text-center">
-            <p className="text-gray-500 text-xs">Screenshot: Odoo Settings &rarr; Database Name (coming soon)</p>
-          </div>
+          {showDropdown ? (
+            <>
+              <select
+                value={database}
+                onChange={e => setDatabase(e.target.value)}
+                className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-amber-500 appearance-none"
+              >
+                <option value="">Select a database...</option>
+                {discoveredDbs.map(db => (
+                  <option key={db} value={db}>{db}</option>
+                ))}
+              </select>
+              <div className="flex items-center justify-between mt-1.5">
+                <p className="text-gray-500 text-xs">
+                  {discoveredDbs.length === 1 ? 'Database found' : `${discoveredDbs.length} databases found`}
+                  {discoveryMethod === 'url_inference' && ' (inferred from URL)'}
+                </p>
+                <button
+                  onClick={() => setManualMode(true)}
+                  className="text-gray-500 text-xs hover:text-gray-400 transition"
+                >
+                  Type manually
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <input
+                value={database}
+                onChange={e => setDatabase(e.target.value)}
+                placeholder="mycompany-main"
+                className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-amber-500"
+              />
+              {discoveredDbs.length > 0 && manualMode && (
+                <div className="flex items-center justify-between mt-1.5">
+                  <p className="text-gray-500 text-xs">Enter your database name</p>
+                  <button
+                    onClick={() => setManualMode(false)}
+                    className="text-gray-500 text-xs hover:text-gray-400 transition"
+                  >
+                    Use discovered databases
+                  </button>
+                </div>
+              )}
+              {discoveredDbs.length === 0 && !manualMode && (
+                <p className="text-gray-500 text-xs mt-1.5">
+                  Use "Find my database" above, or enter the name manually
+                </p>
+              )}
+            </>
+          )}
         </div>
 
         {/* Username */}
@@ -88,9 +185,7 @@ export function OdooSetupStep({ onComplete, onSkip }: Props) {
             placeholder="Your Odoo API key"
             className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-amber-500"
           />
-          <div className="bg-gray-900 border border-dashed border-gray-700 rounded-lg p-3 mt-2 text-center">
-            <p className="text-gray-500 text-xs">Screenshot: Odoo Settings &rarr; Users &rarr; API Keys (coming soon)</p>
-          </div>
+          <p className="text-gray-500 text-xs mt-1">Settings &rarr; Users &rarr; your profile &rarr; API Keys tab</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds a "Find my database" button to the Odoo setup form that auto-discovers available databases
- Uses 3-tier fallback: XML-RPC db.list() → JSON-RPC /web/database/list → URL subdomain inference
- Includes SSRF protection, per-connection timeouts (no global socket mutation), and stale-state clearing on URL change

## Test plan
- [ ] Enter a known Odoo URL and click "Find my database" — verify databases appear in dropdown
- [ ] Test with an Odoo.com SaaS URL (e.g., `mycompany.odoo.com`) — verify URL inference fallback works
- [ ] Test with an invalid/unreachable URL — verify graceful error message appears
- [ ] Change URL after discovery — verify previous results are cleared
- [ ] Toggle between dropdown and "Type manually" mode — verify state is preserved correctly
- [ ] Complete full setup flow with a discovered database — verify connection succeeds