### PR TITLE
Add per-integration permission ceiling for Odoo and QuickBooks

### DIFF
--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -134,7 +134,7 @@ def _load_integration_tools() -> tuple[list[dict], dict]:
             mod = importlib.import_module(module_path)
             defs = getattr(mod, defs_attr, [])
             execs = getattr(mod, "TOOL_EXECUTORS", {})
-            tool_defs.extend(defs)
+            tool_defs.extend({**d, "integration": name} for d in defs)
             executors.update(execs)
         except Exception as e:
             logger.warning("Failed to load integration %s: %s", name, e)
@@ -485,6 +485,9 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
+    from integrations.registry import get_tool_mode
+    integration_tool_modes = {name: get_tool_mode(name) for name in _INTEGRATION_MODULES}
+
     reminder_handlers, sa_handlers = _build_agent_handlers(agent["slug"])
     registry = ToolRegistry(
         context_dir=config.context_dir,
@@ -516,6 +519,7 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
             integration_tool_defs=integration_tool_defs or None,
             tool_mode=tool_mode,
             approved_tool=approved_tool,
+            integration_tool_modes=integration_tool_modes,
         ):
             yield event
 
@@ -842,6 +846,15 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
     writes_map = build_writes_map(tool_defs)
     if not writes_map.get(req.tool, False):
         raise HTTPException(status_code=400, detail="Tool is not a write operation")
+
+    # Enforce integration permission ceiling — reject if integration is set to read-only
+    tool_def = next((t for t in tool_defs if t["name"] == req.tool), None)
+    integ_name = (tool_def or {}).get("integration", "")
+    if integ_name:
+        from integrations.registry import get_tool_mode as _get_tm
+        integ_ceil = _get_tm(integ_name)
+        if integ_ceil == "read-only":
+            raise HTTPException(status_code=403, detail=f"Write operations are disabled for {integ_name} (set to read-only)")
 
     kind_map = {t["name"]: t.get("kind", "context") for t in tool_defs}
     kind = kind_map.get(req.tool, "context")

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -498,6 +498,7 @@ async def chat(
     integration_tool_defs: list[dict] | None = None,
     tool_mode: str = "normal",
     approved_tool: dict | None = None,
+    integration_tool_modes: dict[str, str] | None = None,
 ) -> AsyncGenerator[str, None]:
     """Stream a chat response as SSE events.
 
@@ -518,6 +519,7 @@ async def chat(
         integration_tool_defs: Extra tool definitions from enabled integrations
         tool_mode: 'read-only', 'normal', or 'power'
         approved_tool: Previously confirmed tool execution result to reconstruct
+        integration_tool_modes: Per-integration permission ceilings (e.g. {"odoo": "read-only"})
     """
     # Validate tool_mode
     if tool_mode not in ("read-only", "normal", "power"):
@@ -548,15 +550,27 @@ async def chat(
     writes_map = build_writes_map(tool_defs)
     cm_map = build_context_memory_map(tool_defs)
 
-    # ── Read-only mode: filter out write tools (except context_memory) ──
-    if tool_mode == "read-only":
-        tool_defs = [
-            t for t in tool_defs
-            if not t.get("writes", False) or t.get("context_memory", False)
-        ]
+    # ── Per-tool effective mode (min of chat mode and integration ceiling) ──
+    _MODE_RANK = {"read-only": 0, "normal": 1, "power": 2}
+    _RANK_MODE = {0: "read-only", 1: "normal", 2: "power"}
+    _itm = integration_tool_modes or {}
+    integration_map = {t["name"]: t.get("integration", "") for t in tool_defs}
+
+    def _effective_mode(tname: str) -> str:
+        integ = integration_map.get(tname, "")
+        integ_ceil = _itm.get(integ, "power")
+        return _RANK_MODE[min(_MODE_RANK.get(tool_mode, 1), _MODE_RANK.get(integ_ceil, 1))]
+
+    # ── Filter out write tools whose effective mode is read-only ──
+    tool_defs = [
+        t for t in tool_defs
+        if not t.get("writes", False)
+        or t.get("context_memory", False)
+        or _effective_mode(t["name"]) != "read-only"
+    ]
 
     # Strip internal fields before sending to provider
-    _internal_fields = {"kind", "writes", "context_memory"}
+    _internal_fields = {"kind", "writes", "context_memory", "integration"}
     provider_tools = [{k: v for k, v in t.items() if k not in _internal_fields} for t in tool_defs]
 
     # ── Chat history persistence ──────────────────────────────────────
@@ -828,11 +842,12 @@ async def chat(
                 yield _sse({"type": "done"})
                 return
 
-            # ── Normal mode: intercept write tools (not context_memory) ──
+            # ── Intercept write tools that need approval ──
             is_write = writes_map.get(tool_name, False)
             is_cm = cm_map.get(tool_name, False)
+            eff_mode = _effective_mode(tool_name)
 
-            if tool_mode == "normal" and is_write and not is_cm:
+            if eff_mode == "normal" and is_write and not is_cm:
                 # Get human-readable description
                 tool_desc = next(
                     (t.get("description", tool_name) for t in tool_defs if t["name"] == tool_name),
@@ -920,6 +935,7 @@ async def run_sync(
     chat_service=None,
     conversation_id: str | None = None,
     integration_tool_defs: list[dict] | None = None,
+    integration_tool_modes: dict[str, str] | None = None,
 ) -> str:
     """Run an agent synchronously, returning the final text response.
 
@@ -940,10 +956,22 @@ async def run_sync(
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
     )
+
+    # Apply integration permission ceilings — messaging channels have no approval UI,
+    # so both "read-only" and "normal" ceilings must strip write tools here.
+    _itm = integration_tool_modes or {}
+    if _itm:
+        tool_defs = [
+            t for t in tool_defs
+            if not t.get("writes", False)
+            or t.get("context_memory", False)
+            or _itm.get(t.get("integration", ""), "power") == "power"
+        ]
+
     kind_map = _build_kind_map(tool_defs)
 
     # Strip internal fields before sending to provider
-    _internal_fields = {"kind", "writes", "context_memory"}
+    _internal_fields = {"kind", "writes", "context_memory", "integration"}
     provider_tools = [{k: v for k, v in t.items() if k not in _internal_fields} for t in tool_defs]
 
     # Build system prompt (returns tuple for caching)

--- a/backend/integrations/odoo/tools/accounting_tools.py
+++ b/backend/integrations/odoo/tools/accounting_tools.py
@@ -257,6 +257,7 @@ ACCOUNTING_TOOL_DEFS = [
             "required": ["partner_id", "lines"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_register_payment",
@@ -286,6 +287,7 @@ ACCOUNTING_TOOL_DEFS = [
             "required": ["invoice_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
 ]
 

--- a/backend/integrations/odoo/tools/contacts_tools.py
+++ b/backend/integrations/odoo/tools/contacts_tools.py
@@ -137,6 +137,7 @@ CONTACTS_TOOL_DEFS = [
             "required": ["name"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 4 - odoo_update_partner
     {
@@ -200,6 +201,7 @@ CONTACTS_TOOL_DEFS = [
             "required": ["partner_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 5 - odoo_search_partner_contacts
     {

--- a/backend/integrations/odoo/tools/core_tools.py
+++ b/backend/integrations/odoo/tools/core_tools.py
@@ -254,6 +254,7 @@ CORE_TOOL_DEFS = [
             "required": ["product_id", "qty"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 10 - odoo_update_manufacturing_order
     {
@@ -281,6 +282,7 @@ CORE_TOOL_DEFS = [
             "required": ["mo_name"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 11 - odoo_confirm_manufacturing_order
     {
@@ -297,6 +299,7 @@ CORE_TOOL_DEFS = [
             "required": ["mo_name"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 12 - odoo_update_record
     {
@@ -324,6 +327,7 @@ CORE_TOOL_DEFS = [
             "required": ["model", "record_id", "field_values"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 13 - odoo_execute_action
     {
@@ -354,6 +358,7 @@ CORE_TOOL_DEFS = [
             "required": ["model", "record_id", "action"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 14 - odoo_post_message
     {
@@ -390,6 +395,7 @@ CORE_TOOL_DEFS = [
             "required": ["model", "record_id", "body"],
         },
         "kind": "integration",
+        "writes": True,
     },
 ]
 

--- a/backend/integrations/odoo/tools/crm_tools.py
+++ b/backend/integrations/odoo/tools/crm_tools.py
@@ -174,6 +174,7 @@ CRM_TOOL_DEFS = [
             "required": ["name"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_update_lead",
@@ -222,6 +223,7 @@ CRM_TOOL_DEFS = [
             "required": ["lead_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_update_lead_stage",
@@ -241,6 +243,7 @@ CRM_TOOL_DEFS = [
             "required": ["lead_id", "stage_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_mark_lead_won",
@@ -256,6 +259,7 @@ CRM_TOOL_DEFS = [
             "required": ["lead_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_mark_lead_lost",
@@ -275,6 +279,7 @@ CRM_TOOL_DEFS = [
             "required": ["lead_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_create_crm_activity",
@@ -310,6 +315,7 @@ CRM_TOOL_DEFS = [
             "required": ["lead_id", "activity_type_id", "summary"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_log_lead_note",
@@ -329,6 +335,7 @@ CRM_TOOL_DEFS = [
             "required": ["lead_id", "message"],
         },
         "kind": "integration",
+        "writes": True,
     },
 ]
 

--- a/backend/integrations/odoo/tools/helpdesk_tools.py
+++ b/backend/integrations/odoo/tools/helpdesk_tools.py
@@ -168,6 +168,7 @@ HELPDESK_TOOL_DEFS = [
             "required": ["ticket_id", "stage_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 7 - odoo_assign_ticket
     {
@@ -188,6 +189,7 @@ HELPDESK_TOOL_DEFS = [
             "required": ["ticket_id", "user_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 8 - odoo_post_ticket_message
     {
@@ -216,6 +218,7 @@ HELPDESK_TOOL_DEFS = [
             "required": ["ticket_id", "message"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 9 - odoo_send_ticket_reply
     {
@@ -239,6 +242,7 @@ HELPDESK_TOOL_DEFS = [
             "required": ["ticket_id", "message"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 10 - odoo_send_internal_message
     {
@@ -266,6 +270,7 @@ HELPDESK_TOOL_DEFS = [
             "required": ["partner_id", "subject", "message"],
         },
         "kind": "integration",
+        "writes": True,
     },
 ]
 

--- a/backend/integrations/odoo/tools/maintenance_tools.py
+++ b/backend/integrations/odoo/tools/maintenance_tools.py
@@ -189,6 +189,7 @@ MAINTENANCE_TOOL_DEFS = [
             "required": ["name", "maintenance_type"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 6 - odoo_update_maintenance_request
     {
@@ -233,6 +234,7 @@ MAINTENANCE_TOOL_DEFS = [
             "required": ["request_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
 ]
 

--- a/backend/integrations/odoo/tools/project_tools.py
+++ b/backend/integrations/odoo/tools/project_tools.py
@@ -162,6 +162,7 @@ PROJECT_TOOL_DEFS = [
             "required": ["name", "project_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_update_task",
@@ -212,6 +213,7 @@ PROJECT_TOOL_DEFS = [
             "required": ["task_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     {
         "name": "odoo_log_timesheet",
@@ -240,6 +242,7 @@ PROJECT_TOOL_DEFS = [
             "required": ["task_id", "hours"],
         },
         "kind": "integration",
+        "writes": True,
     },
 ]
 

--- a/backend/integrations/odoo/tools/purchase_tools.py
+++ b/backend/integrations/odoo/tools/purchase_tools.py
@@ -107,6 +107,7 @@ PURCHASE_TOOL_DEFS = [
             "required": ["partner_id", "lines"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 4 - odoo_confirm_purchase_order
     {
@@ -125,6 +126,7 @@ PURCHASE_TOOL_DEFS = [
             "required": ["po_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 5 - odoo_approve_purchase_order
     {
@@ -141,6 +143,7 @@ PURCHASE_TOOL_DEFS = [
             "required": ["po_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 6 - odoo_update_purchase_order
     {
@@ -168,6 +171,7 @@ PURCHASE_TOOL_DEFS = [
             "required": ["po_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 7 - odoo_post_purchase_message
     {
@@ -196,6 +200,7 @@ PURCHASE_TOOL_DEFS = [
             "required": ["po_id", "message"],
         },
         "kind": "integration",
+        "writes": True,
     },
 ]
 

--- a/backend/integrations/odoo/tools/quality_tools.py
+++ b/backend/integrations/odoo/tools/quality_tools.py
@@ -152,6 +152,7 @@ QUALITY_TOOL_DEFS = [
             "required": ["check_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 6 - odoo_fail_quality_check
     {
@@ -171,6 +172,7 @@ QUALITY_TOOL_DEFS = [
             "required": ["check_id"],
         },
         "kind": "integration",
+        "writes": True,
     },
     # 7 - odoo_create_quality_alert
     {
@@ -221,6 +223,7 @@ QUALITY_TOOL_DEFS = [
             "required": ["name"],
         },
         "kind": "integration",
+        "writes": True,
     },
 ]
 

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -127,6 +127,21 @@ def disable(name: str) -> None:
     save_credentials(name, creds)
 
 
+def get_tool_mode(name: str) -> str:
+    """Get the tool_mode ceiling for an integration. Default: 'normal' (approval)."""
+    creds = get_credentials(name)
+    return creds.get("tool_mode", "normal")
+
+
+def set_tool_mode(name: str, mode: str) -> None:
+    """Set the tool_mode ceiling for an integration."""
+    if mode not in ("read-only", "normal", "power"):
+        raise ValueError(f"Invalid tool_mode: {mode}")
+    creds = get_credentials(name)
+    creds["tool_mode"] = mode
+    save_credentials(name, creds)
+
+
 def list_integrations() -> list[dict]:
     """Return all integrations with their status."""
     result = []
@@ -138,5 +153,6 @@ def list_integrations() -> list[dict]:
             "enabled": bool(creds.get("enabled", False)),
             "configured": bool(creds),
             "connection_status": creds.get("connection_status", "ok") if creds else "ok",
+            "tool_mode": creds.get("tool_mode", "normal"),
         })
     return result

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -40,6 +40,10 @@ class BambooHRSetupRequest(BaseModel):
     api_key: str
 
 
+class ToolModeRequest(BaseModel):
+    tool_mode: str
+
+
 # ── Routes ────────────────────────────────────────────────────────────────────
 
 @router.get("")
@@ -68,6 +72,21 @@ async def disable_integration(name: str, user=Depends(get_current_user)):
         raise HTTPException(status_code=404, detail=f"Unknown integration: {name}")
     disable(name)
     return {"ok": True, "integration": name, "enabled": False}
+
+
+@router.post("/{name}/tool-mode")
+async def set_integration_tool_mode(name: str, body: ToolModeRequest, user=Depends(get_current_user)):
+    """Set the tool_mode permission ceiling for an integration."""
+    if name not in ("odoo", "quickbooks"):
+        raise HTTPException(status_code=400, detail="Tool mode is only supported for Odoo and QuickBooks")
+    if body.tool_mode not in ("read-only", "normal", "power"):
+        raise HTTPException(status_code=400, detail=f"Invalid tool_mode: {body.tool_mode}")
+    integrations = {i["id"]: i for i in list_integrations()}
+    if not integrations.get(name, {}).get("configured"):
+        raise HTTPException(status_code=400, detail="Integration must be configured before setting tool mode")
+    from .registry import set_tool_mode
+    set_tool_mode(name, body.tool_mode)
+    return {"ok": True, "integration": name, "tool_mode": body.tool_mode}
 
 
 @router.post("/odoo/discover-databases")

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -67,7 +67,7 @@ def _load_integration_tools() -> tuple[list[dict], dict]:
             mod = importlib.import_module(module_path)
             defs = getattr(mod, defs_attr, [])
             execs = getattr(mod, "TOOL_EXECUTORS", {})
-            tool_defs.extend(defs)
+            tool_defs.extend({**d, "integration": name} for d in defs)
             executors.update(execs)
         except Exception as e:
             logger.warning("Failed to load integration %s: %s", name, e)
@@ -146,6 +146,9 @@ async def process_message(
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
+    from integrations.registry import get_tool_mode
+    integration_tool_modes = {name: get_tool_mode(name) for name in _INTEGRATION_MODULES}
+
     reminder_handlers, sa_handlers = _build_agent_handlers(slug)
     registry = ToolRegistry(
         context_dir=config.context_dir,
@@ -187,6 +190,7 @@ async def process_message(
         chat_service=chat_service,
         conversation_id=chatty_conv_id,
         integration_tool_defs=integration_tool_defs or None,
+        integration_tool_modes=integration_tool_modes,
     )
 
     return response or "I had trouble generating a response. Please try again."
@@ -228,6 +232,9 @@ async def process_group_message(
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
+    from integrations.registry import get_tool_mode
+    integration_tool_modes = {name: get_tool_mode(name) for name in _INTEGRATION_MODULES}
+
     reminder_handlers, sa_handlers = _build_agent_handlers(slug)
     registry = ToolRegistry(
         context_dir=config.context_dir,
@@ -266,6 +273,7 @@ async def process_group_message(
         chat_service=chat_service,
         conversation_id=chatty_conv_id,
         integration_tool_defs=integration_tool_defs or None,
+        integration_tool_modes=integration_tool_modes,
     )
 
     return response or "I had trouble generating a response. Please try again."

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -81,7 +81,7 @@ def _load_integration_tools() -> tuple[list[dict], dict]:
             mod = importlib.import_module(module_path)
             defs = getattr(mod, defs_attr, [])
             execs = getattr(mod, "TOOL_EXECUTORS", {})
-            tool_defs.extend(defs)
+            tool_defs.extend({**d, "integration": name} for d in defs)
             executors.update(execs)
         except Exception as e:
             logger.warning("Failed to load integration %s: %s", name, e)
@@ -182,6 +182,9 @@ def _process_message_locked(
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
+    from integrations.registry import get_tool_mode
+    integration_tool_modes = {name: get_tool_mode(name) for name in _INTEGRATION_MODULES}
+
     reminder_handlers = {
         "create_reminder": lambda **kw: create_reminder_handler(agent_slug, **kw),
         "list_reminders": lambda **kw: list_reminders_handler(agent_slug, **kw),
@@ -211,6 +214,16 @@ def _process_message_locked(
         integration_tools=integration_tool_defs or None,
         dynamic_real_tools=dynamic_real_tools or None,
     )
+
+    # Apply integration permission ceilings — messaging channels have no approval UI,
+    # so both "read-only" and "normal" ceilings must strip write tools here.
+    if integration_tool_modes:
+        tool_defs = [
+            t for t in tool_defs
+            if not t.get("writes", False)
+            or t.get("context_memory", False)
+            or integration_tool_modes.get(t.get("integration", ""), "power") == "power"
+        ]
 
     # 10. Run the agent
     result = run_background_turn(

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -66,6 +66,7 @@ export interface Integration {
   enabled: boolean;
   configured: boolean;
   connection_status?: string;
+  tool_mode?: string;
 }
 
 // CRM types

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -147,8 +147,13 @@ export function IntegrationsTab() {
   }
 
   async function setToolMode(id: string, mode: string) {
-    setIntegrations(prev => prev.map(i => i.id === id ? { ...i, tool_mode: mode } : i));
-    await api(`/api/integrations/${id}/tool-mode`, { method: 'POST', body: JSON.stringify({ tool_mode: mode }) });
+    const prev = integrations.find(i => i.id === id)?.tool_mode || 'normal';
+    setIntegrations(ps => ps.map(i => i.id === id ? { ...i, tool_mode: mode } : i));
+    try {
+      await api(`/api/integrations/${id}/tool-mode`, { method: 'POST', body: JSON.stringify({ tool_mode: mode }) });
+    } catch {
+      setIntegrations(ps => ps.map(i => i.id === id ? { ...i, tool_mode: prev } : i));
+    }
   }
 
   async function setupOdoo() {

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -146,6 +146,11 @@ export function IntegrationsTab() {
     setIntegrations(prev => prev.map(i => i.id === id ? { ...i, enabled: !enabled } : i));
   }
 
+  async function setToolMode(id: string, mode: string) {
+    setIntegrations(prev => prev.map(i => i.id === id ? { ...i, tool_mode: mode } : i));
+    await api(`/api/integrations/${id}/tool-mode`, { method: 'POST', body: JSON.stringify({ tool_mode: mode }) });
+  }
+
   async function setupOdoo() {
     setSaving(true); setError('');
     try {
@@ -356,6 +361,39 @@ export function IntegrationsTab() {
                 )}
               </div>
             </div>
+
+            {/* Permission level selector for Odoo and QuickBooks */}
+            {(integration.id === 'odoo' || integration.id === 'quickbooks') && integration.enabled && integration.configured && integration.connection_status !== 'broken' && (
+              <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span style={{ ...mono(9), whiteSpace: 'nowrap' }}>Permissions</span>
+                <div style={{
+                  display: 'flex', border: '1px solid rgba(230,235,242,0.07)',
+                  borderRadius: 3, overflow: 'hidden',
+                }}>
+                  {([
+                    { key: 'read-only', label: 'Read' },
+                    { key: 'normal', label: 'Approval' },
+                    { key: 'power', label: 'Full Control' },
+                  ] as const).map(m => (
+                    <div
+                      key={m.key}
+                      onClick={() => setToolMode(integration.id, m.key)}
+                      style={{
+                        padding: '3px 10px',
+                        fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                        fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase',
+                        color: (integration.tool_mode || 'normal') === m.key ? '#0E1013' : 'rgba(237,240,244,0.62)',
+                        background: (integration.tool_mode || 'normal') === m.key ? 'var(--color-ch-accent, #C8D1D9)' : 'transparent',
+                        cursor: 'pointer',
+                        transition: 'background 0.15s, color 0.15s',
+                      }}
+                    >
+                      {m.label}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
 
             {error && integration.id === 'quickbooks' && !setupFor && (
               <p style={{ marginTop: 8, color: '#D97757', fontSize: 12 }}>{error}</p>


### PR DESCRIPTION
## Summary

- Adds a persistent **Read / Approval / Full Control** permission selector in Settings > Integrations for Odoo and QuickBooks, acting as a hard ceiling on the chat-level tool mode
- Marks all 35 Odoo write tools with `"writes": True` across 9 tool files (prerequisite — was missing entirely)
- Enforces the ceiling across all execution paths: SSE chat, tool execute endpoint, Telegram, and WhatsApp (messaging channels strip write tools for both read-only and normal ceilings since they can't show approval dialogs)

## Test plan

- [ ] Enable Odoo or QuickBooks in Settings > Integrations — verify permission selector appears after setup
- [ ] Set to **Read** — in chat Power mode, ask agent to create something — verify write tools unavailable
- [ ] Set to **Approval** — in chat Power mode, ask to create something — verify confirmation dialog appears
- [ ] Set to **Full Control** — in chat Power mode — verify tool executes without confirmation
- [ ] Verify chat Read mode still works independently (filters all write tools regardless of integration setting)
- [ ] Verify `POST /api/integrations/odoo/tool-mode` rejects unconfigured integrations