### PR TITLE
Add opt-in TOTP two-factor authentication

### DIFF
--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -1,17 +1,22 @@
 """
 Chatty — Authentication utilities.
 
-Single-user password login with JWT. The login endpoint checks the
-plaintext password from AUTH_PASSWORD env var and returns a signed JWT.
+Single-user password login with JWT. Optional TOTP two-factor authentication.
+The login endpoint checks the password and, if 2FA is enabled, issues a
+short-lived pending token requiring a TOTP code before granting access.
 
 Multi-user Google OAuth is roughed in behind MULTI_USER_ENABLED=false
 for Phase 2.
 """
 
+import hmac
+import time
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Request, HTTPException, status
 from fastapi.responses import JSONResponse
+import bcrypt as _bcrypt
 from jose import JWTError, jwt
 from pydantic import BaseModel
 
@@ -19,12 +24,29 @@ from core.config import settings
 
 router = APIRouter()
 
+PENDING_TOKEN_EXPIRE_MINUTES = 5
+
+# ── Rate limiting (in-memory) ────────────────────────────────────────────────
+
+_login_attempts: dict[str, list[float]] = defaultdict(list)
+
+
+def _check_login_rate(ip: str) -> bool:
+    now = time.time()
+    window = 300  # 5 minutes
+    _login_attempts[ip] = [t for t in _login_attempts[ip] if now - t < window]
+    if len(_login_attempts[ip]) >= 10:
+        return False
+    _login_attempts[ip].append(now)
+    return True
+
 
 # ── JWT helpers ──────────────────────────────────────────────────────────────
 
-def create_access_token(data: dict) -> str:
+def create_access_token(data: dict, expire_minutes: int | None = None) -> str:
     """Create a signed JWT with the given claims and configured expiry."""
-    expire = datetime.now(timezone.utc) + timedelta(minutes=settings.jwt.expire_minutes)
+    minutes = expire_minutes if expire_minutes is not None else settings.jwt.expire_minutes
+    expire = datetime.now(timezone.utc) + timedelta(minutes=minutes)
     to_encode = {**data, "exp": expire}
     return jwt.encode(to_encode, settings.jwt.secret_key, algorithm=settings.jwt.algorithm)
 
@@ -39,7 +61,8 @@ async def get_current_user(request: Request) -> dict:
     FastAPI dependency — extracts and validates the JWT from the
     Authorization: Bearer <token> header.
 
-    Raises 401 if missing, invalid, or expired.
+    Raises 401 if missing, invalid, expired, or if the token is a
+    2FA pending token (which cannot be used for API access).
     """
     auth_header = request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
@@ -59,7 +82,24 @@ async def get_current_user(request: Request) -> dict:
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    if payload.get("purpose") == "2fa_pending":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="2FA verification required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
     return payload
+
+
+# ── Password verification ────────────────────────────────────────────────────
+
+def verify_password(plain: str) -> bool:
+    """Verify password against AUTH_PASSWORD. Supports bcrypt hashes or plaintext."""
+    stored = settings.auth.password
+    if stored.startswith("$2b$") or stored.startswith("$2a$"):
+        return _bcrypt.checkpw(plain.encode(), stored.encode())
+    return hmac.compare_digest(plain, stored)
 
 
 # ── Login endpoint ────────────────────────────────────────────────────────────
@@ -69,13 +109,31 @@ class LoginRequest(BaseModel):
 
 
 @router.post("/login")
-async def login(body: LoginRequest):
-    """Single-user password login. Returns a JWT on success."""
-    if body.password != settings.auth.password:
+async def login(body: LoginRequest, request: Request):
+    """Single-user password login. Returns JWT or 2FA challenge."""
+    client_ip = request.client.host if request.client else "unknown"
+    if not _check_login_rate(client_ip):
+        raise HTTPException(status_code=429, detail="Too many login attempts. Try again in a few minutes.")
+
+    if not verify_password(body.password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect password",
         )
+
+    # Check if 2FA is enabled (lazy import to avoid circular dependency at module load)
+    try:
+        from core.auth_2fa import is_2fa_enabled, is_device_trusted, TRUST_COOKIE_NAME
+    except ImportError:
+        is_2fa_enabled = None
+    if is_2fa_enabled and is_2fa_enabled():
+        trust_token = request.cookies.get(TRUST_COOKIE_NAME, "")
+        if not is_device_trusted(trust_token):
+            pending = create_access_token(
+                {"sub": "user", "purpose": "2fa_pending"},
+                expire_minutes=PENDING_TOKEN_EXPIRE_MINUTES,
+            )
+            return JSONResponse({"requires_2fa": True, "pending_token": pending})
 
     token = create_access_token({"sub": "user", "role": "admin"})
     return JSONResponse({"access_token": token, "token_type": "bearer"})

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -136,8 +136,12 @@ async def login(body: LoginRequest, request: Request):
                 return JSONResponse({"requires_2fa": True, "pending_token": pending})
     except ImportError:
         logger.warning("auth_2fa module not available — 2FA check skipped")
-    except RuntimeError:
-        logger.warning("auth_2fa DB not initialized — 2FA check skipped")
+    except Exception:
+        logger.exception("2FA check failed — blocking login")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service temporarily unavailable",
+        )
 
     token = create_access_token({"sub": "user", "role": "admin"})
     return JSONResponse({"access_token": token, "token_type": "bearer"})

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -124,20 +124,20 @@ async def login(body: LoginRequest, request: Request):
             detail="Incorrect password",
         )
 
-    # Check if 2FA is enabled (lazy import to avoid circular dependency at module load)
     try:
         from core.auth_2fa import is_2fa_enabled, is_device_trusted, TRUST_COOKIE_NAME
+        if is_2fa_enabled():
+            trust_token = request.cookies.get(TRUST_COOKIE_NAME, "")
+            if not is_device_trusted(trust_token):
+                pending = create_access_token(
+                    {"sub": "user", "purpose": "2fa_pending"},
+                    expire_minutes=PENDING_TOKEN_EXPIRE_MINUTES,
+                )
+                return JSONResponse({"requires_2fa": True, "pending_token": pending})
     except ImportError:
         logger.warning("auth_2fa module not available — 2FA check skipped")
-        is_2fa_enabled = None
-    if is_2fa_enabled and is_2fa_enabled():
-        trust_token = request.cookies.get(TRUST_COOKIE_NAME, "")
-        if not is_device_trusted(trust_token):
-            pending = create_access_token(
-                {"sub": "user", "purpose": "2fa_pending"},
-                expire_minutes=PENDING_TOKEN_EXPIRE_MINUTES,
-            )
-            return JSONResponse({"requires_2fa": True, "pending_token": pending})
+    except RuntimeError:
+        logger.warning("auth_2fa DB not initialized — 2FA check skipped")
 
     token = create_access_token({"sub": "user", "role": "admin"})
     return JSONResponse({"access_token": token, "token_type": "bearer"})

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -10,6 +10,7 @@ for Phase 2.
 """
 
 import hmac
+import logging
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -21,6 +22,8 @@ from jose import JWTError, jwt
 from pydantic import BaseModel
 
 from core.config import settings
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -125,6 +128,7 @@ async def login(body: LoginRequest, request: Request):
     try:
         from core.auth_2fa import is_2fa_enabled, is_device_trusted, TRUST_COOKIE_NAME
     except ImportError:
+        logger.warning("auth_2fa module not available — 2FA check skipped")
         is_2fa_enabled = None
     if is_2fa_enabled and is_2fa_enabled():
         trust_token = request.cookies.get(TRUST_COOKIE_NAME, "")

--- a/backend/core/auth_2fa.py
+++ b/backend/core/auth_2fa.py
@@ -235,34 +235,39 @@ def _generate_qr_data_uri(provisioning_uri: str) -> str:
 
 def verify_totp_code(code: str) -> bool:
     """Verify a TOTP code against the stored secret. Returns True on valid code."""
-    config = get_totp_config()
-    if not config or not config["secret_enc"]:
-        return False
+    with _write_lock:
+        config = get_totp_config()
+        if not config or not config["secret_enc"]:
+            return False
 
-    secret = decrypt_value(config["secret_enc"])
-    if not secret:
-        return False
+        secret = decrypt_value(config["secret_enc"])
+        if not secret:
+            return False
 
-    totp = pyotp.TOTP(secret)
-    code_stripped = code.strip()
-    if not totp.verify(code_stripped, valid_window=1):
-        return False
+        totp = pyotp.TOTP(secret)
+        code_stripped = code.strip()
+        if not totp.verify(code_stripped, valid_window=1):
+            return False
 
-    # Find which timeslot the code actually belongs to (could be T-1, T, or T+1)
-    now_ts = totp.timecode(datetime.now(timezone.utc))
-    matched_slot = now_ts
-    for offset in (-1, 0, 1):
-        candidate = now_ts + offset
-        if totp.generate_otp(candidate) == code_stripped:
-            matched_slot = candidate
-            break
+        # Find which timeslot the code actually belongs to (could be T-1, T, or T+1)
+        now_ts = totp.timecode(datetime.now(timezone.utc))
+        matched_slot = now_ts
+        for offset in (-1, 0, 1):
+            candidate = now_ts + offset
+            if totp.generate_otp(candidate) == code_stripped:
+                matched_slot = candidate
+                break
 
-    # Replay prevention: reject if this or a later timeslot was already used
-    if config["last_used_at"] and int(config["last_used_at"]) >= matched_slot:
-        return False
+        # Replay prevention: reject if this or a later timeslot was already used
+        if config["last_used_at"] and int(config["last_used_at"]) >= matched_slot:
+            return False
 
-    update_last_used(str(matched_slot))
-    return True
+        _get_db().execute(
+            "UPDATE totp_config SET last_used_at = ?, updated_at = datetime('now') WHERE id = 1",
+            (str(matched_slot),),
+        )
+        _get_db().commit()
+        return True
 
 
 # ── API request/response models ──────────────────────────────────────────────

--- a/backend/core/auth_2fa.py
+++ b/backend/core/auth_2fa.py
@@ -1,0 +1,409 @@
+"""
+Chatty — Two-factor authentication (TOTP).
+
+Opt-in TOTP via authenticator apps (Google Authenticator, Authy, 1Password).
+Includes backup codes, trusted device cookies, and rate limiting.
+
+Database: data/auth.db (SQLite, same pattern as agents/db.py).
+"""
+
+import base64
+import hashlib
+import io
+import json
+import logging
+import secrets
+import sqlite3
+import string
+import threading
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pyotp
+import qrcode
+import bcrypt as _bcrypt
+from fastapi import APIRouter, Depends, Request, HTTPException, Response, status
+from jose import JWTError
+from pydantic import BaseModel
+
+from core.auth import create_access_token, decode_access_token, get_current_user, verify_password
+from core.config import settings
+from core.encryption import encrypt_value, decrypt_value
+from core.storage import safe_init_sqlite
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+DB_PATH = DATA_DIR / "auth.db"
+GCS_KEY = "auth.db"
+
+_connection: sqlite3.Connection | None = None
+_write_lock = threading.Lock()
+
+TOTP_ISSUER = "Chatty"
+TRUST_COOKIE_NAME = "chatty_2fa_trust"
+TRUST_COOKIE_MAX_AGE = 30 * 24 * 60 * 60  # 30 days in seconds
+BACKUP_CODE_COUNT = 10
+
+router = APIRouter()
+
+
+# ── Rate limiting (in-memory) ────────────────────────────────────────────────
+
+_rate_limits: dict[str, list[float]] = defaultdict(list)
+
+
+def _check_rate_limit(key: str, max_attempts: int, window_seconds: int) -> bool:
+    now = time.time()
+    _rate_limits[key] = [t for t in _rate_limits[key] if now - t < window_seconds]
+    if len(_rate_limits[key]) >= max_attempts:
+        return False
+    _rate_limits[key].append(now)
+    return True
+
+
+# ── Database layer ───────────────────────────────────────────────────────────
+
+def _get_db() -> sqlite3.Connection:
+    if _connection is None:
+        raise RuntimeError("Auth 2FA DB not initialized — call init_db() first")
+    return _connection
+
+
+def _setup_connection() -> None:
+    global _connection
+    _connection = sqlite3.connect(str(DB_PATH), check_same_thread=False)
+    _connection.row_factory = sqlite3.Row
+    _connection.execute("PRAGMA journal_mode=WAL")
+    _connection.execute("PRAGMA foreign_keys=ON")
+    _connection.execute("PRAGMA busy_timeout=5000")
+
+    _connection.executescript("""
+        CREATE TABLE IF NOT EXISTS totp_config (
+            id           INTEGER PRIMARY KEY CHECK (id = 1),
+            enabled      INTEGER NOT NULL DEFAULT 0,
+            secret_enc   TEXT NOT NULL DEFAULT '',
+            backup_codes TEXT NOT NULL DEFAULT '[]',
+            last_used_at TEXT NOT NULL DEFAULT '',
+            created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS trusted_devices (
+            token_hash  TEXT PRIMARY KEY,
+            label       TEXT NOT NULL DEFAULT '',
+            expires_at  TEXT NOT NULL,
+            created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+    """)
+    _connection.commit()
+    logger.info("Auth 2FA DB initialized at %s", DB_PATH)
+
+
+def init_db() -> dict:
+    return safe_init_sqlite(DB_PATH, GCS_KEY, init_fn=_setup_connection)
+
+
+def get_totp_config() -> dict | None:
+    row = _get_db().execute("SELECT * FROM totp_config WHERE id = 1").fetchone()
+    return dict(row) if row else None
+
+
+def is_2fa_enabled() -> bool:
+    config = get_totp_config()
+    return bool(config and config["enabled"])
+
+
+def save_totp_config(secret_enc: str, backup_codes_json: str) -> None:
+    with _write_lock:
+        _get_db().execute(
+            """INSERT INTO totp_config (id, enabled, secret_enc, backup_codes, updated_at)
+               VALUES (1, 1, ?, ?, datetime('now'))
+               ON CONFLICT(id) DO UPDATE SET
+                   enabled = 1, secret_enc = excluded.secret_enc,
+                   backup_codes = excluded.backup_codes,
+                   updated_at = datetime('now')""",
+            (secret_enc, backup_codes_json),
+        )
+        _get_db().commit()
+
+
+def disable_totp() -> None:
+    with _write_lock:
+        _get_db().execute(
+            """UPDATE totp_config SET enabled = 0, secret_enc = '', backup_codes = '[]',
+               last_used_at = '', updated_at = datetime('now') WHERE id = 1"""
+        )
+        _get_db().commit()
+    revoke_all_trusted_devices()
+
+
+def update_last_used(timestamp: str) -> None:
+    with _write_lock:
+        _get_db().execute(
+            "UPDATE totp_config SET last_used_at = ?, updated_at = datetime('now') WHERE id = 1",
+            (timestamp,),
+        )
+        _get_db().commit()
+
+
+def consume_backup_code(code: str) -> bool:
+    normalized = code.strip().upper().replace("-", "").encode()
+    with _write_lock:
+        config = get_totp_config()
+        if not config:
+            return False
+        hashes: list[str] = json.loads(config["backup_codes"])
+        for i, h in enumerate(hashes):
+            if _bcrypt.checkpw(normalized, h.encode()):
+                hashes.pop(i)
+                _get_db().execute(
+                    "UPDATE totp_config SET backup_codes = ?, updated_at = datetime('now') WHERE id = 1",
+                    (json.dumps(hashes),),
+                )
+                _get_db().commit()
+                return True
+    return False
+
+
+def _hash_device_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def add_trusted_device(token: str, label: str, expires_at: str) -> None:
+    token_hash = _hash_device_token(token)
+    with _write_lock:
+        _get_db().execute(
+            "INSERT OR REPLACE INTO trusted_devices (token_hash, label, expires_at) VALUES (?, ?, ?)",
+            (token_hash, label, expires_at),
+        )
+        _get_db().commit()
+
+
+def is_device_trusted(token: str) -> bool:
+    if not token:
+        return False
+    token_hash = _hash_device_token(token)
+    row = _get_db().execute(
+        "SELECT expires_at FROM trusted_devices WHERE token_hash = ?", (token_hash,)
+    ).fetchone()
+    if not row:
+        return False
+    expires = datetime.fromisoformat(row["expires_at"])
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) < expires
+
+
+def revoke_all_trusted_devices() -> None:
+    with _write_lock:
+        _get_db().execute("DELETE FROM trusted_devices")
+        _get_db().commit()
+
+
+def cleanup_expired_devices() -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    with _write_lock:
+        _get_db().execute("DELETE FROM trusted_devices WHERE expires_at < ?", (now,))
+        _get_db().commit()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _generate_backup_codes() -> tuple[list[str], list[str]]:
+    """Generate backup codes. Returns (plaintext_codes, bcrypt_hashes)."""
+    charset = string.ascii_uppercase + string.digits
+    codes = []
+    hashes = []
+    for _ in range(BACKUP_CODE_COUNT):
+        raw = "".join(secrets.choice(charset) for _ in range(8))
+        display = f"{raw[:4]}-{raw[4:]}"
+        codes.append(display)
+        hashes.append(_bcrypt.hashpw(raw.encode(), _bcrypt.gensalt()).decode())
+    return codes, hashes
+
+
+def _generate_qr_data_uri(provisioning_uri: str) -> str:
+    img = qrcode.make(provisioning_uri, box_size=6, border=2)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/png;base64,{b64}"
+
+
+def verify_totp_code(code: str) -> bool:
+    """Verify a TOTP code against the stored secret. Returns True on valid code."""
+    config = get_totp_config()
+    if not config or not config["secret_enc"]:
+        return False
+
+    secret = decrypt_value(config["secret_enc"])
+    if not secret:
+        return False
+
+    totp = pyotp.TOTP(secret)
+    code_stripped = code.strip()
+    if not totp.verify(code_stripped, valid_window=1):
+        return False
+
+    # Find which timeslot the code actually belongs to (could be T-1, T, or T+1)
+    now_ts = totp.timecode(datetime.now(timezone.utc))
+    matched_slot = now_ts
+    for offset in (-1, 0, 1):
+        candidate = now_ts + offset
+        if totp.generate_otp(candidate) == code_stripped:
+            matched_slot = candidate
+            break
+
+    # Replay prevention: reject if this or a later timeslot was already used
+    if config["last_used_at"] and int(config["last_used_at"]) >= matched_slot:
+        return False
+
+    update_last_used(str(matched_slot))
+    return True
+
+
+# ── API request/response models ──────────────────────────────────────────────
+
+class VerifySetupRequest(BaseModel):
+    secret: str
+    code: str
+    password: str
+
+
+class Verify2FARequest(BaseModel):
+    pending_token: str
+    code: str
+    trust_device: bool = False
+
+
+class PasswordConfirmRequest(BaseModel):
+    password: str
+
+
+# ── API endpoints ────────────────────────────────────────────────────────────
+
+@router.get("/auth/2fa/status")
+async def get_2fa_status(user: dict = Depends(get_current_user)):
+    config = get_totp_config()
+    if not config:
+        return {"enabled": False, "has_backup_codes": False, "trusted_device_count": 0}
+
+    backup_hashes = json.loads(config["backup_codes"])
+    device_count = _get_db().execute(
+        "SELECT COUNT(*) as cnt FROM trusted_devices WHERE expires_at > ?",
+        (datetime.now(timezone.utc).isoformat(),),
+    ).fetchone()["cnt"]
+
+    return {
+        "enabled": bool(config["enabled"]),
+        "has_backup_codes": len(backup_hashes) > 0,
+        "backup_code_count": len(backup_hashes),
+        "trusted_device_count": device_count,
+    }
+
+
+@router.post("/auth/2fa/setup")
+async def setup_2fa(user: dict = Depends(get_current_user)):
+    secret = pyotp.random_base32()
+    totp = pyotp.TOTP(secret)
+    provisioning_uri = totp.provisioning_uri(name="user", issuer_name=TOTP_ISSUER)
+    qr_data_uri = _generate_qr_data_uri(provisioning_uri)
+
+    return {
+        "secret": secret,
+        "qr_code_data_uri": qr_data_uri,
+        "provisioning_uri": provisioning_uri,
+    }
+
+
+@router.post("/auth/2fa/verify-setup")
+async def verify_setup(body: VerifySetupRequest, user: dict = Depends(get_current_user)):
+    if not verify_password(body.password):
+        raise HTTPException(status_code=401, detail="Incorrect password")
+
+    totp = pyotp.TOTP(body.secret)
+    if not totp.verify(body.code.strip(), valid_window=1):
+        raise HTTPException(status_code=400, detail="Invalid code. Check your authenticator app and try again.")
+
+    encrypted_secret = encrypt_value(body.secret)
+    plaintext_codes, hashed_codes = _generate_backup_codes()
+    save_totp_config(encrypted_secret, json.dumps(hashed_codes))
+
+    return {"enabled": True, "backup_codes": plaintext_codes}
+
+
+@router.post("/auth/2fa/disable")
+async def disable_2fa(body: PasswordConfirmRequest, user: dict = Depends(get_current_user)):
+    if not verify_password(body.password):
+        raise HTTPException(status_code=401, detail="Incorrect password")
+    disable_totp()
+    return {"disabled": True}
+
+
+@router.post("/auth/2fa/backup-codes/regenerate")
+async def regenerate_backup_codes(body: PasswordConfirmRequest, user: dict = Depends(get_current_user)):
+    if not verify_password(body.password):
+        raise HTTPException(status_code=401, detail="Incorrect password")
+    if not is_2fa_enabled():
+        raise HTTPException(status_code=400, detail="2FA is not enabled")
+
+    plaintext_codes, hashed_codes = _generate_backup_codes()
+    with _write_lock:
+        _get_db().execute(
+            "UPDATE totp_config SET backup_codes = ?, updated_at = datetime('now') WHERE id = 1",
+            (json.dumps(hashed_codes),),
+        )
+        _get_db().commit()
+
+    return {"backup_codes": plaintext_codes}
+
+
+@router.post("/login/verify-2fa")
+async def verify_2fa_login(body: Verify2FARequest, request: Request, response: Response):
+    client_ip = request.client.host if request.client else "unknown"
+    rate_key = f"2fa:{client_ip}"
+    if not _check_rate_limit(rate_key, max_attempts=5, window_seconds=300):
+        raise HTTPException(status_code=429, detail="Too many attempts. Please log in again.")
+
+    # Validate pending token
+    try:
+        payload = decode_access_token(body.pending_token)
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Expired or invalid session. Please log in again.")
+
+    if payload.get("purpose") != "2fa_pending":
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    # Try TOTP code first, then backup code
+    code = body.code.strip()
+    valid = False
+    if len(code.replace("-", "")) == 6 and code.replace("-", "").isdigit():
+        valid = verify_totp_code(code)
+    if not valid:
+        valid = consume_backup_code(code)
+    if not valid:
+        raise HTTPException(status_code=401, detail="Invalid code")
+
+    # Issue real access token
+    token = create_access_token({"sub": "user", "role": "admin"})
+
+    # Set trusted device cookie if requested
+    if body.trust_device:
+        device_token = secrets.token_hex(32)
+        expires_at = (datetime.now(timezone.utc) + timedelta(seconds=TRUST_COOKIE_MAX_AGE)).isoformat()
+        ua = request.headers.get("user-agent", "")
+        label = ua[:100] if ua else "Unknown device"
+        add_trusted_device(device_token, label, expires_at)
+        response.set_cookie(
+            key=TRUST_COOKIE_NAME,
+            value=device_token,
+            max_age=TRUST_COOKIE_MAX_AGE,
+            httponly=True,
+            secure=request.url.scheme == "https",
+            samesite="lax",
+        )
+
+    return {"access_token": token, "token_type": "bearer"}

--- a/backend/core/auth_2fa.py
+++ b/backend/core/auth_2fa.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel
 from core.auth import create_access_token, decode_access_token, get_current_user, verify_password
 from core.config import settings
 from core.encryption import encrypt_value, decrypt_value
-from core.storage import safe_init_sqlite
+from core.storage import safe_backup_sqlite, safe_init_sqlite
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,7 @@ GCS_KEY = "auth.db"
 
 _connection: sqlite3.Connection | None = None
 _write_lock = threading.Lock()
+_backup_mutex = threading.Lock()
 
 TOTP_ISSUER = "Chatty"
 TRUST_COOKIE_NAME = "chatty_2fa_trust"
@@ -104,6 +105,18 @@ def _setup_connection() -> None:
 
 def init_db() -> dict:
     return safe_init_sqlite(DB_PATH, GCS_KEY, init_fn=_setup_connection)
+
+
+def backup_to_gcs() -> None:
+    safe_backup_sqlite(_connection, DB_PATH, GCS_KEY, backup_mutex=_backup_mutex)
+
+
+def _backup_after_mutation() -> None:
+    """Best-effort GCS backup after a 2FA state change."""
+    try:
+        backup_to_gcs()
+    except Exception:
+        pass
 
 
 def get_totp_config() -> dict | None:
@@ -336,6 +349,8 @@ async def verify_setup(body: VerifySetupRequest, user: dict = Depends(get_curren
     encrypted_secret = encrypt_value(body.secret)
     plaintext_codes, hashed_codes = _generate_backup_codes()
     save_totp_config(encrypted_secret, json.dumps(hashed_codes))
+    revoke_all_trusted_devices()
+    _backup_after_mutation()
 
     return {"enabled": True, "backup_codes": plaintext_codes}
 
@@ -345,6 +360,7 @@ async def disable_2fa(body: PasswordConfirmRequest, user: dict = Depends(get_cur
     if not verify_password(body.password):
         raise HTTPException(status_code=401, detail="Incorrect password")
     disable_totp()
+    _backup_after_mutation()
     return {"disabled": True}
 
 
@@ -362,6 +378,7 @@ async def regenerate_backup_codes(body: PasswordConfirmRequest, user: dict = Dep
             (json.dumps(hashed_codes),),
         )
         _get_db().commit()
+    _backup_after_mutation()
 
     return {"backup_codes": plaintext_codes}
 
@@ -411,4 +428,5 @@ async def verify_2fa_login(body: Verify2FARequest, request: Request, response: R
             samesite="lax",
         )
 
+    _backup_after_mutation()
     return {"access_token": token, "token_type": "bearer"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -105,7 +105,7 @@ async def lifespan(app: FastAPI):
         logger.info("WhatsApp bridge configured at %s", settings.whatsapp.bridge_url)
 
     from core.auth_2fa import init_db as init_auth_2fa_db
-    _safe_init("auth_2fa", init_auth_2fa_db)
+    _safe_init("auth_2fa", init_auth_2fa_db, critical=True)
 
     from core.agents.reminders.db import init_db as init_reminders_db
     _safe_init("reminders", init_reminders_db)

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from fastapi.staticfiles import StaticFiles
 
 from core.config import settings
 from core.auth import router as auth_router
+from core.auth_2fa import router as auth_2fa_router
 from core.providers.router import router as providers_router
 from agents.router import router as agents_router
 from branding.router import router as branding_router
@@ -103,6 +104,9 @@ async def lifespan(app: FastAPI):
         _safe_init("whatsapp", init_whatsapp_db)
         logger.info("WhatsApp bridge configured at %s", settings.whatsapp.bridge_url)
 
+    from core.auth_2fa import init_db as init_auth_2fa_db
+    _safe_init("auth_2fa", init_auth_2fa_db)
+
     from core.agents.reminders.db import init_db as init_reminders_db
     _safe_init("reminders", init_reminders_db)
 
@@ -128,6 +132,9 @@ async def lifespan(app: FastAPI):
     from core.agents.scheduled_actions.nightly import run_nightly_jobs
     _scheduler.add_job(run_nightly_jobs, "cron", hour=23, minute=0, id="nightly_memory_jobs",
                        timezone="America/Chicago")
+
+    from core.auth_2fa import cleanup_expired_devices
+    _scheduler.add_job(cleanup_expired_devices, "interval", hours=24, id="2fa_device_cleanup")
 
     _scheduler.start()
     logger.info("APScheduler started (reminder heartbeat + scheduled actions + nightly jobs)")
@@ -214,6 +221,7 @@ app.add_middleware(
 # ── Routes ────────────────────────────────────────────────────────────────────
 
 app.include_router(auth_router, prefix="/api")
+app.include_router(auth_2fa_router, prefix="/api", tags=["auth-2fa"])
 app.include_router(providers_router, prefix="/api/providers", tags=["providers"])
 app.include_router(agents_router, prefix="/api/agents", tags=["agents"])
 app.include_router(branding_router, prefix="/api/branding", tags=["branding"])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,5 @@ pdfplumber
 xlrd
 apscheduler
 croniter
+pyotp
+qrcode[pil]

--- a/frontend/src/core/auth/AuthContext.tsx
+++ b/frontend/src/core/auth/AuthContext.tsx
@@ -1,7 +1,10 @@
 /**
- * Chatty — Password auth context.
+ * Chatty — Password auth context with optional TOTP 2FA.
  *
  * Single-user: authenticates with a password, gets back a JWT.
+ * If 2FA is enabled, login() returns a pending token that must be
+ * verified via verify2fa() before access is granted.
+ *
  * JWT stored in sessionStorage (cleared on browser close).
  * BroadcastChannel syncs login/logout across tabs.
  */
@@ -27,10 +30,15 @@ function migrateToken() {
   }
 }
 
+export type LoginResult =
+  | { success: true }
+  | { requires2fa: true; pendingToken: string };
+
 interface AuthContextType {
   isLoggedIn: boolean;
   loading: boolean;
-  login: (password: string) => Promise<void>;
+  login: (password: string) => Promise<LoginResult>;
+  verify2fa: (pendingToken: string, code: string, trustDevice?: boolean) => Promise<void>;
   logout: () => void;
 }
 
@@ -49,6 +57,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch {
       return false;
     }
+  }, []);
+
+  const _completeLogin = useCallback((token: string) => {
+    sessionStorage.setItem(TOKEN_KEY, token);
+    setIsLoggedIn(true);
+    try {
+      const ch = new BroadcastChannel(CHANNEL_NAME);
+      ch.postMessage({ type: 'login', token });
+      ch.close();
+    } catch { /* noop */ }
   }, []);
 
   useEffect(() => {
@@ -87,7 +105,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => { channel?.close(); };
   }, [validateToken]);
 
-  const login = useCallback(async (password: string) => {
+  const login = useCallback(async (password: string): Promise<LoginResult> => {
     const res = await fetch('/api/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -98,16 +116,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       throw new Error(body.detail || 'Login failed');
     }
     const data = await res.json();
-    sessionStorage.setItem(TOKEN_KEY, data.access_token);
-    setIsLoggedIn(true);
 
-    // Notify other tabs
-    try {
-      const ch = new BroadcastChannel(CHANNEL_NAME);
-      ch.postMessage({ type: 'login', token: data.access_token });
-      ch.close();
-    } catch { /* noop */ }
-  }, []);
+    if (data.requires_2fa) {
+      return { requires2fa: true, pendingToken: data.pending_token };
+    }
+
+    _completeLogin(data.access_token);
+    return { success: true };
+  }, [_completeLogin]);
+
+  const verify2fa = useCallback(async (pendingToken: string, code: string, trustDevice = false) => {
+    const res = await fetch('/api/login/verify-2fa', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pending_token: pendingToken, code, trust_device: trustDevice }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.detail || 'Verification failed');
+    }
+    const data = await res.json();
+    _completeLogin(data.access_token);
+  }, [_completeLogin]);
 
   const logout = useCallback(() => {
     sessionStorage.removeItem(TOKEN_KEY);
@@ -122,7 +152,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ isLoggedIn, loading, login, logout }}>
+    <AuthContext.Provider value={{ isLoggedIn, loading, login, verify2fa, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/dashboard/SecurityTab.tsx
+++ b/frontend/src/dashboard/SecurityTab.tsx
@@ -1,0 +1,424 @@
+import { useState, useEffect, useRef } from 'react';
+import { api } from '../core/api/client';
+
+const mono = (size: number, color = 'rgba(237,240,244,0.38)') => ({
+  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+  fontSize: size, letterSpacing: '0.16em',
+  textTransform: 'uppercase' as const, color,
+});
+
+interface TwoFAStatus {
+  enabled: boolean;
+  has_backup_codes: boolean;
+  backup_code_count: number;
+  trusted_device_count: number;
+}
+
+interface SetupResponse {
+  secret: string;
+  qr_code_data_uri: string;
+  provisioning_uri: string;
+}
+
+type State = 'loading' | 'disabled' | 'showing-qr' | 'show-backup-codes' | 'enabled' | 'disabling' | 'regenerating';
+
+export function SecurityTab() {
+  const [state, setState] = useState<State>('loading');
+  const [status, setStatus] = useState<TwoFAStatus | null>(null);
+  const [setup, setSetup] = useState<SetupResponse | null>(null);
+  const [verifyCode, setVerifyCode] = useState('');
+  const [backupCodes, setBackupCodes] = useState<string[]>([]);
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const codeRef = useRef<HTMLInputElement>(null);
+
+  async function loadStatus() {
+    try {
+      const s = await api<TwoFAStatus>('/api/auth/2fa/status');
+      setStatus(s);
+      setState(s.enabled ? 'enabled' : 'disabled');
+    } catch {
+      setState('disabled');
+    }
+  }
+
+  useEffect(() => { loadStatus(); }, []);
+
+  async function startSetup() {
+    setError('');
+    setSaving(true);
+    try {
+      const resp = await api<SetupResponse>('/api/auth/2fa/setup', { method: 'POST' });
+      setSetup(resp);
+      setState('showing-qr');
+      setTimeout(() => codeRef.current?.focus(), 100);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Setup failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function confirmSetup() {
+    if (!setup) return;
+    setError('');
+    setSaving(true);
+    try {
+      const resp = await api<{ enabled: boolean; backup_codes: string[] }>('/api/auth/2fa/verify-setup', {
+        method: 'POST',
+        body: JSON.stringify({ secret: setup.secret, code: verifyCode, password }),
+      });
+      setBackupCodes(resp.backup_codes);
+      setPassword('');
+      setState('show-backup-codes');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Invalid code');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function disable2fa() {
+    setError('');
+    setSaving(true);
+    try {
+      await api('/api/auth/2fa/disable', {
+        method: 'POST',
+        body: JSON.stringify({ password }),
+      });
+      setPassword('');
+      setState('disabled');
+      setStatus(null);
+      loadStatus();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to disable');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function regenerateCodes() {
+    setError('');
+    setSaving(true);
+    try {
+      const resp = await api<{ backup_codes: string[] }>('/api/auth/2fa/backup-codes/regenerate', {
+        method: 'POST',
+        body: JSON.stringify({ password }),
+      });
+      setBackupCodes(resp.backup_codes);
+      setPassword('');
+      setState('show-backup-codes');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to regenerate');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function copyBackupCodes() {
+    navigator.clipboard.writeText(backupCodes.join('\n')).catch(() => {});
+  }
+
+  function downloadBackupCodes() {
+    const text = `Chatty — Backup Codes\n${'='.repeat(30)}\n\nStore these codes in a safe place.\nEach code can only be used once.\n\n${backupCodes.map((c, i) => `${i + 1}. ${c}`).join('\n')}\n`;
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'chatty-backup-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  const inputStyle = {
+    width: '100%', boxSizing: 'border-box' as const,
+    background: 'rgba(20,24,30,0.78)',
+    border: '1px solid rgba(230,235,242,0.14)',
+    color: '#EDF0F4', borderRadius: 4,
+    padding: '10px 14px', fontSize: 14, outline: 'none',
+  };
+
+  const btnPrimary = {
+    width: '100%', padding: '10px 16px',
+    background: 'var(--color-ch-accent, #C8D1D9)', color: '#0E1013',
+    border: 'none', borderRadius: 4, fontSize: 14, fontWeight: 500,
+    cursor: 'pointer', opacity: saving ? 0.5 : 1,
+  };
+
+  const btnDanger = {
+    ...btnPrimary,
+    background: '#D97757',
+  };
+
+  if (state === 'loading') {
+    return <p style={{ color: 'rgba(237,240,244,0.52)', fontSize: 14 }}>Loading...</p>;
+  }
+
+  // ── Disabled state ──────────────────────────────────────────────────────
+  if (state === 'disabled') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <div>
+          <p style={{ fontSize: 14, color: '#EDF0F4', margin: '0 0 8px' }}>Two-factor authentication</p>
+          <p style={{ fontSize: 13, color: 'rgba(237,240,244,0.52)', margin: 0, lineHeight: 1.6 }}>
+            Add an extra layer of security to your account. You'll need an authenticator app
+            like Google Authenticator, Authy, or 1Password.
+          </p>
+        </div>
+        {error && <p style={{ color: '#D97757', fontSize: 13, margin: 0 }}>{error}</p>}
+        <button onClick={startSetup} disabled={saving} style={btnPrimary}>
+          {saving ? 'Setting up...' : 'Enable two-factor authentication'}
+        </button>
+      </div>
+    );
+  }
+
+  // ── QR code setup ───────────────────────────────────────────────────────
+  if (state === 'showing-qr' && setup) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <div>
+          <p style={{ fontSize: 14, color: '#EDF0F4', margin: '0 0 8px' }}>Scan QR code</p>
+          <p style={{ fontSize: 13, color: 'rgba(237,240,244,0.52)', margin: 0, lineHeight: 1.6 }}>
+            Scan this QR code with your authenticator app, then enter the 6-digit code to confirm.
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}>
+          <img
+            src={setup.qr_code_data_uri}
+            alt="2FA QR Code"
+            style={{ borderRadius: 8, background: '#fff', padding: 8 }}
+          />
+        </div>
+
+        <div>
+          <label style={{ ...mono(9), display: 'block', marginBottom: 6 }}>Manual entry key</label>
+          <div style={{
+            ...inputStyle,
+            fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+            fontSize: 13, letterSpacing: '0.08em', wordBreak: 'break-all',
+            userSelect: 'all', cursor: 'text',
+          }}>
+            {setup.secret}
+          </div>
+        </div>
+
+        <div>
+          <label style={{ ...mono(9), display: 'block', marginBottom: 6 }}>Verification code</label>
+          <input
+            ref={codeRef}
+            type="text"
+            inputMode="numeric"
+            value={verifyCode}
+            onChange={e => setVerifyCode(e.target.value)}
+            placeholder="000000"
+            maxLength={6}
+            autoComplete="one-time-code"
+            style={{
+              ...inputStyle,
+              fontSize: 20, letterSpacing: '0.2em', textAlign: 'center',
+              fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+            }}
+          />
+        </div>
+
+        <div>
+          <label style={{ ...mono(9), display: 'block', marginBottom: 6 }}>Confirm password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            placeholder="Enter your password"
+            style={inputStyle}
+          />
+        </div>
+
+        {error && <p style={{ color: '#D97757', fontSize: 13, margin: 0 }}>{error}</p>}
+
+        <div style={{ display: 'flex', gap: 12 }}>
+          <button
+            onClick={() => { setState('disabled'); setSetup(null); setVerifyCode(''); setPassword(''); setError(''); }}
+            style={{ ...btnPrimary, background: 'transparent', border: '1px solid rgba(230,235,242,0.14)', color: '#EDF0F4' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={confirmSetup}
+            disabled={saving || verifyCode.length < 6 || !password}
+            style={{ ...btnPrimary, opacity: saving || verifyCode.length < 6 || !password ? 0.5 : 1 }}
+          >
+            {saving ? 'Verifying...' : 'Verify & Enable'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Backup codes display ────────────────────────────────────────────────
+  if (state === 'show-backup-codes') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <div>
+          <p style={{ fontSize: 14, color: '#EDF0F4', margin: '0 0 8px' }}>Save your backup codes</p>
+          <p style={{ fontSize: 13, color: '#D97757', margin: 0, lineHeight: 1.6 }}>
+            Save these codes in a safe place. Each code can only be used once.
+            If you lose access to your authenticator app, these are the only way to log in.
+          </p>
+        </div>
+
+        <div style={{
+          background: 'rgba(20,24,30,0.78)',
+          border: '1px solid rgba(230,235,242,0.14)',
+          borderRadius: 8, padding: 20,
+          display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px 24px',
+        }}>
+          {backupCodes.map((code, i) => (
+            <div key={i} style={{
+              fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+              fontSize: 14, color: '#EDF0F4', letterSpacing: '0.08em',
+            }}>
+              {code}
+            </div>
+          ))}
+        </div>
+
+        <div style={{ display: 'flex', gap: 12 }}>
+          <button onClick={copyBackupCodes} style={{ ...btnPrimary, background: 'transparent', border: '1px solid rgba(230,235,242,0.14)', color: '#EDF0F4' }}>
+            Copy all
+          </button>
+          <button onClick={downloadBackupCodes} style={{ ...btnPrimary, background: 'transparent', border: '1px solid rgba(230,235,242,0.14)', color: '#EDF0F4' }}>
+            Download .txt
+          </button>
+        </div>
+
+        <button onClick={() => { loadStatus(); setBackupCodes([]); }} style={btnPrimary}>
+          I've saved my codes
+        </button>
+      </div>
+    );
+  }
+
+  // ── Enabled state ───────────────────────────────────────────────────────
+  if (state === 'enabled') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div>
+            <p style={{ fontSize: 14, color: '#EDF0F4', margin: 0 }}>Two-factor authentication</p>
+            <p style={{ fontSize: 12, color: 'rgba(237,240,244,0.38)', marginTop: 2 }}>
+              {status?.backup_code_count ?? 0} backup codes remaining
+              {status?.trusted_device_count ? ` · ${status.trusted_device_count} trusted device${status.trusted_device_count > 1 ? 's' : ''}` : ''}
+            </p>
+          </div>
+          <div style={{
+            fontSize: 11, fontWeight: 600,
+            padding: '4px 10px', borderRadius: 12,
+            background: 'rgba(76,175,80,0.15)', color: '#66BB6A',
+            fontFamily: "'Inter Tight', system-ui, sans-serif",
+          }}>
+            Enabled
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <button
+            onClick={() => setState('regenerating')}
+            style={{ ...btnPrimary, background: 'transparent', border: '1px solid rgba(230,235,242,0.14)', color: '#EDF0F4' }}
+          >
+            Regenerate backup codes
+          </button>
+          <button
+            onClick={() => setState('disabling')}
+            style={{ ...btnPrimary, background: 'transparent', border: '1px solid rgba(230,235,242,0.14)', color: '#D97757' }}
+          >
+            Disable two-factor authentication
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Disable confirmation ────────────────────────────────────────────────
+  if (state === 'disabling') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <div>
+          <p style={{ fontSize: 14, color: '#EDF0F4', margin: '0 0 8px' }}>Disable two-factor authentication</p>
+          <p style={{ fontSize: 13, color: 'rgba(237,240,244,0.52)', margin: 0, lineHeight: 1.6 }}>
+            Enter your password to confirm. This will also revoke all trusted devices.
+          </p>
+        </div>
+
+        <div>
+          <label style={{ ...mono(9), display: 'block', marginBottom: 6 }}>Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            placeholder="Enter your password"
+            autoFocus
+            style={inputStyle}
+          />
+        </div>
+
+        {error && <p style={{ color: '#D97757', fontSize: 13, margin: 0 }}>{error}</p>}
+
+        <div style={{ display: 'flex', gap: 12 }}>
+          <button
+            onClick={() => { setState('enabled'); setPassword(''); setError(''); }}
+            style={{ ...btnPrimary, background: 'transparent', border: '1px solid rgba(230,235,242,0.14)', color: '#EDF0F4' }}
+          >
+            Cancel
+          </button>
+          <button onClick={disable2fa} disabled={saving || !password} style={{ ...btnDanger, opacity: saving || !password ? 0.5 : 1 }}>
+            {saving ? 'Disabling...' : 'Disable 2FA'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Regenerate backup codes ─────────────────────────────────────────────
+  if (state === 'regenerating') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <div>
+          <p style={{ fontSize: 14, color: '#EDF0F4', margin: '0 0 8px' }}>Regenerate backup codes</p>
+          <p style={{ fontSize: 13, color: 'rgba(237,240,244,0.52)', margin: 0, lineHeight: 1.6 }}>
+            This will replace your existing backup codes. Enter your password to confirm.
+          </p>
+        </div>
+
+        <div>
+          <label style={{ ...mono(9), display: 'block', marginBottom: 6 }}>Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            placeholder="Enter your password"
+            autoFocus
+            style={inputStyle}
+          />
+        </div>
+
+        {error && <p style={{ color: '#D97757', fontSize: 13, margin: 0 }}>{error}</p>}
+
+        <div style={{ display: 'flex', gap: 12 }}>
+          <button
+            onClick={() => { setState('enabled'); setPassword(''); setError(''); }}
+            style={{ ...btnPrimary, background: 'transparent', border: '1px solid rgba(230,235,242,0.14)', color: '#EDF0F4' }}
+          >
+            Cancel
+          </button>
+          <button onClick={regenerateCodes} disabled={saving || !password} style={{ ...btnPrimary, opacity: saving || !password ? 0.5 : 1 }}>
+            {saving ? 'Regenerating...' : 'Regenerate codes'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import type { BrandingConfig } from '../core/types';
 import { ProviderSetup } from '../setup/ProviderSetup';
 import { IntegrationsTab } from './IntegrationsTab';
 import { DataTab } from './DataTab';
+import { SecurityTab } from './SecurityTab';
 
 interface Props {
   branding: BrandingConfig | null;
@@ -11,7 +12,7 @@ interface Props {
   onClose: () => void;
 }
 
-type Tab = 'providers' | 'branding' | 'integrations' | 'chat' | 'data';
+type Tab = 'providers' | 'branding' | 'integrations' | 'chat' | 'data' | 'security';
 
 export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
   const [tab, setTab] = useState<Tab>('providers');
@@ -54,6 +55,7 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
     { id: 'integrations', label: 'Integrations' },
     { id: 'chat', label: 'Chat' },
     { id: 'data', label: 'Data' },
+    { id: 'security', label: 'Security' },
   ];
 
   return (
@@ -226,6 +228,8 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
           )}
 
           {tab === 'data' && <DataTab />}
+
+          {tab === 'security' && <SecurityTab />}
         </div>
       </div>
     </div>

--- a/frontend/src/login/LoginPage.tsx
+++ b/frontend/src/login/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, useEffect, useRef, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../core/auth/AuthContext';
 import { IconWordmark } from '../shared/icons';
@@ -13,21 +13,53 @@ const mono = (size: number, color = 'rgba(237,240,244,0.38)') => ({
 });
 
 export function LoginPage() {
-  const { login } = useAuth();
+  const { login, verify2fa } = useAuth();
   const navigate = useNavigate();
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  async function handleSubmit(e: FormEvent) {
+  // 2FA state
+  const [step, setStep] = useState<'password' | '2fa'>('password');
+  const [pendingToken, setPendingToken] = useState('');
+  const [code, setCode] = useState('');
+  const [useBackupCode, setUseBackupCode] = useState(false);
+  const [trustDevice, setTrustDevice] = useState(false);
+  const codeInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (step === '2fa') codeInputRef.current?.focus();
+  }, [step]);
+
+  async function handlePasswordSubmit(e: FormEvent) {
     e.preventDefault();
     setError('');
     setLoading(true);
     try {
-      await login(password);
-      navigate('/');
+      const result = await login(password);
+      if ('requires2fa' in result) {
+        setPendingToken(result.pendingToken);
+        setStep('2fa');
+      } else {
+        navigate('/');
+      }
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handle2faSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await verify2fa(pendingToken, code, trustDevice);
+      navigate('/');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Verification failed');
+      setCode('');
     } finally {
       setLoading(false);
     }
@@ -130,57 +162,156 @@ export function LoginPage() {
           </div>
         )}
 
-        <form onSubmit={handleSubmit} style={{ maxWidth: 360, width: '100%' }}>
-          <div style={mono(10, 'rgba(237,240,244,0.38)')}>Sign in</div>
-          <h2 style={{
-            fontFamily: "'Fraunces', Georgia, serif",
-            fontSize: isMobile ? 30 : 36, fontWeight: 400, letterSpacing: '-0.02em',
-            lineHeight: 1.05, margin: '10px 0 24px',
-          }}>Welcome back.</h2>
+        {step === 'password' ? (
+          <form onSubmit={handlePasswordSubmit} style={{ maxWidth: 360, width: '100%' }}>
+            <div style={mono(10, 'rgba(237,240,244,0.38)')}>Sign in</div>
+            <h2 style={{
+              fontFamily: "'Fraunces', Georgia, serif",
+              fontSize: isMobile ? 30 : 36, fontWeight: 400, letterSpacing: '-0.02em',
+              lineHeight: 1.05, margin: '10px 0 24px',
+            }}>Welcome back.</h2>
 
-          <div style={{ marginBottom: 22 }}>
-            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
-              <div style={mono(9, 'rgba(237,240,244,0.38)')}>Password</div>
+            <div style={{ marginBottom: 22 }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
+                <div style={mono(9, 'rgba(237,240,244,0.38)')}>Password</div>
+              </div>
+              <input
+                type="password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                placeholder="Enter your password"
+                autoFocus
+                style={{
+                  width: '100%', boxSizing: 'border-box',
+                  border: '1px solid rgba(230,235,242,0.14)',
+                  borderRadius: 4, padding: '12px 14px',
+                  background: 'rgba(20,24,30,0.78)',
+                  fontSize: 16, color: '#EDF0F4',
+                  outline: 'none',
+                  fontFamily: "'Inter Tight', system-ui, sans-serif",
+                }}
+                onFocus={e => { e.target.style.borderColor = 'var(--color-ch-accent, #C8D1D9)'; }}
+                onBlur={e => { e.target.style.borderColor = 'rgba(230,235,242,0.14)'; }}
+              />
             </div>
-            <input
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              placeholder="Enter your password"
-              autoFocus
+
+            {error && (
+              <p style={{ color: '#D97757', fontSize: 13, marginBottom: 16 }}>{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading || !password}
               style={{
-                width: '100%', boxSizing: 'border-box',
-                border: '1px solid rgba(230,235,242,0.14)',
-                borderRadius: 4, padding: '12px 14px',
-                background: 'rgba(20,24,30,0.78)',
-                fontSize: 16, color: '#EDF0F4',
-                outline: 'none',
-                fontFamily: "'Inter Tight', system-ui, sans-serif",
+                width: '100%',
+                background: 'var(--color-ch-accent, #C8D1D9)',
+                color: '#0E1013',
+                border: 'none', fontSize: 14, fontWeight: 500,
+                padding: '13px 16px', borderRadius: 4, cursor: 'pointer',
+                opacity: (loading || !password) ? 0.5 : 1,
               }}
-              onFocus={e => { e.target.style.borderColor = 'var(--color-ch-accent, #C8D1D9)'; }}
-              onBlur={e => { e.target.style.borderColor = 'rgba(230,235,242,0.14)'; }}
-            />
-          </div>
+            >
+              {loading ? 'Signing in...' : 'Continue'}
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={handle2faSubmit} style={{ maxWidth: 360, width: '100%' }}>
+            <div style={mono(10, 'rgba(237,240,244,0.38)')}>Two-factor authentication</div>
+            <h2 style={{
+              fontFamily: "'Fraunces', Georgia, serif",
+              fontSize: isMobile ? 30 : 36, fontWeight: 400, letterSpacing: '-0.02em',
+              lineHeight: 1.05, margin: '10px 0 8px',
+            }}>Verify your identity.</h2>
+            <p style={{ fontSize: 14, color: 'rgba(237,240,244,0.52)', margin: '0 0 24px', lineHeight: 1.5 }}>
+              {useBackupCode
+                ? 'Enter one of your backup codes.'
+                : 'Enter the 6-digit code from your authenticator app.'}
+            </p>
 
-          {error && (
-            <p style={{ color: '#D97757', fontSize: 13, marginBottom: 16 }}>{error}</p>
-          )}
+            <div style={{ marginBottom: 22 }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
+                <div style={mono(9, 'rgba(237,240,244,0.38)')}>{useBackupCode ? 'Backup code' : 'Code'}</div>
+              </div>
+              <input
+                ref={codeInputRef}
+                type="text"
+                inputMode={useBackupCode ? 'text' : 'numeric'}
+                value={code}
+                onChange={e => setCode(e.target.value)}
+                placeholder={useBackupCode ? 'XXXX-XXXX' : '000000'}
+                maxLength={useBackupCode ? 9 : 6}
+                autoComplete="one-time-code"
+                style={{
+                  width: '100%', boxSizing: 'border-box',
+                  border: '1px solid rgba(230,235,242,0.14)',
+                  borderRadius: 4, padding: '12px 14px',
+                  background: 'rgba(20,24,30,0.78)',
+                  fontSize: 20, color: '#EDF0F4',
+                  outline: 'none', letterSpacing: '0.2em', textAlign: 'center',
+                  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                }}
+                onFocus={e => { e.target.style.borderColor = 'var(--color-ch-accent, #C8D1D9)'; }}
+                onBlur={e => { e.target.style.borderColor = 'rgba(230,235,242,0.14)'; }}
+              />
+            </div>
 
-          <button
-            type="submit"
-            disabled={loading || !password}
-            style={{
-              width: '100%',
-              background: 'var(--color-ch-accent, #C8D1D9)',
-              color: '#0E1013',
-              border: 'none', fontSize: 14, fontWeight: 500,
-              padding: '13px 16px', borderRadius: 4, cursor: 'pointer',
-              opacity: (loading || !password) ? 0.5 : 1,
-            }}
-          >
-            {loading ? 'Signing in...' : 'Continue'}
-          </button>
-        </form>
+            <div style={{ marginBottom: 22, display: 'flex', alignItems: 'center', gap: 8 }}>
+              <input
+                type="checkbox"
+                id="trust-device"
+                checked={trustDevice}
+                onChange={e => setTrustDevice(e.target.checked)}
+                style={{ accentColor: 'var(--color-ch-accent, #C8D1D9)' }}
+              />
+              <label htmlFor="trust-device" style={{ fontSize: 13, color: 'rgba(237,240,244,0.52)', cursor: 'pointer' }}>
+                Trust this browser for 30 days
+              </label>
+            </div>
+
+            {error && (
+              <p style={{ color: '#D97757', fontSize: 13, marginBottom: 16 }}>{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading || !code}
+              style={{
+                width: '100%',
+                background: 'var(--color-ch-accent, #C8D1D9)',
+                color: '#0E1013',
+                border: 'none', fontSize: 14, fontWeight: 500,
+                padding: '13px 16px', borderRadius: 4, cursor: 'pointer',
+                opacity: (loading || !code) ? 0.5 : 1,
+              }}
+            >
+              {loading ? 'Verifying...' : 'Verify'}
+            </button>
+
+            <div style={{ marginTop: 16, display: 'flex', justifyContent: 'space-between' }}>
+              <button
+                type="button"
+                onClick={() => { setStep('password'); setError(''); setCode(''); }}
+                style={{
+                  background: 'none', border: 'none', color: 'rgba(237,240,244,0.52)',
+                  fontSize: 13, cursor: 'pointer', padding: 0,
+                }}
+              >
+                &larr; Back
+              </button>
+              <button
+                type="button"
+                onClick={() => { setUseBackupCode(!useBackupCode); setCode(''); setError(''); }}
+                style={{
+                  background: 'none', border: 'none',
+                  color: 'var(--color-ch-accent, #C8D1D9)',
+                  fontSize: 13, cursor: 'pointer', padding: 0,
+                }}
+              >
+                {useBackupCode ? 'Use authenticator code' : 'Use a backup code'}
+              </button>
+            </div>
+          </form>
+        )}
 
         {/* CHATTY letter marks for mobile — auto-cycles tooltips */}
         {isMobile && (


### PR DESCRIPTION
## Summary

- Adds authenticator-app-based 2FA (Google Authenticator, Authy, 1Password) as an optional second security layer via Settings > Security
- Two-step login flow: password validates first, then if 2FA is enabled, a 6-digit TOTP code is required (with "trust this browser for 30 days" option)
- Includes 10 single-use backup codes (bcrypt-hashed), per-IP rate limiting, TOTP replay prevention, and password confirmation on all sensitive 2FA operations (enable, disable, regenerate)

## Security hardening (post-review)

- **Fail-closed auth**: 2FA DB init is `critical=True` — app won't start if auth.db can't initialize. Login returns 503 (not silent fallback) on unexpected 2FA errors.
- **TOCTOU fixes**: Both `verify_totp_code` and `consume_backup_code` wrap read-check-update inside `_write_lock` to prevent concurrent bypass.
- **Replay prevention**: Tracks the actual matched TOTP timeslot (not `datetime.now()`) to prevent cross-boundary replay.
- **Rate-limit key**: Uses client IP (not JWT prefix) to prevent unauthenticated DoS of the 2FA step.
- **Password required everywhere**: `verify-setup`, `disable`, and `regenerate` all require password confirmation.
- **Re-enrollment revokes trust**: Re-enabling 2FA clears all trusted device cookies.
- **GCS backup**: All state-changing operations trigger `backup_to_gcs()` for CONFIG_BUCKET deployments.
- **Constant-time comparison**: Plaintext password check uses `hmac.compare_digest`.

## New files
- `backend/core/auth_2fa.py` — SQLite DB layer, TOTP verification, backup codes, trusted devices, rate limiting, all 2FA API endpoints
- `frontend/src/dashboard/SecurityTab.tsx` — 2FA setup/disable/regenerate UI in settings panel

## Modified files
- `backend/core/auth.py` — Two-phase login flow, bcrypt password support, pending token rejection, fail-closed error handling
- `backend/main.py` — Critical DB init, router mount, scheduler job for device cleanup
- `frontend/src/core/auth/AuthContext.tsx` — `login()` returns `LoginResult`, added `verify2fa()`
- `frontend/src/login/LoginPage.tsx` — 2FA code step after password with backup code toggle
- `frontend/src/dashboard/SettingsPanel.tsx` — Added Security tab

## Test plan
- [ ] Login without 2FA works identically (no regression)
- [ ] Enable 2FA: Settings > Security > Enable → scan QR → enter code + password → see backup codes
- [ ] Login with 2FA: password → pending token → enter TOTP code → logged in
- [ ] Trust device: check "trust this browser" → log out → log in → skips 2FA
- [ ] Backup code: use a backup code instead of TOTP → works once, consumed
- [ ] Disable 2FA: Settings > Security > Disable → re-enter password → 2FA off
- [ ] Re-enable 2FA: trusted devices from prior enrollment are revoked
- [ ] Rate limiting: 5+ wrong codes → 429 response
- [ ] Mobile: test full flow on mobile browser