### PR TITLE
Add mechatty.com website and OAuth proxy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ __pycache__/
 .venv/
 venv/
 .claude/
+website/

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ WHATSAPP_BRIDGE_API_KEY=
 # Optional: override webhook verification secret (defaults to WHATSAPP_BRIDGE_API_KEY)
 WHATSAPP_WEBHOOK_SECRET=
 
+# ─── OAuth Proxy ─────────────────────────────────────────────────────────────
+# Universal redirect URI for all deployments (via auth.mechatty.com proxy).
+# When set, the state parameter encodes this instance's callback URL so the
+# proxy knows where to forward the auth code. Leave blank for direct OAuth.
+# OAUTH_REDIRECT_URI=https://auth.mechatty.com/callback
+
 # ─── Server ──────────────────────────────────────────────────────────────────
 # CORS origins (comma-separated). Defaults to localhost dev servers.
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,41 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [master]
+    paths: ['website/**']
+
+concurrency:
+  group: deploy-website
+  cancel-in-progress: true
+
+jobs:
+  deploy-main:
+    name: Deploy mechatty.com
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy main site
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.PAIR_FTP_HOST }}
+          username: ${{ secrets.PAIR_FTP_USER }}
+          password: ${{ secrets.PAIR_FTP_PASSWORD }}
+          protocol: ftp
+          local-dir: website/
+          exclude: |
+            auth/**
+
+  deploy-auth:
+    name: Deploy auth.mechatty.com
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy auth subdomain
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.PAIR_FTP_HOST }}
+          username: ${{ secrets.PAIR_AUTH_FTP_USER }}
+          password: ${{ secrets.PAIR_AUTH_FTP_PASSWORD }}
+          protocol: ftp
+          local-dir: website/auth/

--- a/backend/core/providers/oauth.py
+++ b/backend/core/providers/oauth.py
@@ -195,7 +195,14 @@ def start_oauth_flow(
     verifier, challenge = _generate_pkce() if use_pkce else (None, None)
     flow_id = secrets.token_urlsafe(32)
 
-    auth_url = _build_auth_url(provider, challenge, state=flow_id, scopes=scopes)
+    if os.getenv("OAUTH_REDIRECT_URI"):
+        instance_callback = f"{settings.backend_url}{CALLBACK_PATH}"
+        encoded = base64.urlsafe_b64encode(instance_callback.encode()).rstrip(b"=").decode()
+        state = f"{flow_id}:{encoded}"
+    else:
+        state = flow_id
+
+    auth_url = _build_auth_url(provider, challenge, state=state, scopes=scopes)
 
     _OAUTH_FLOWS[flow_id] = OAuthFlow(
         flow_id=flow_id,

--- a/website/auth/.htaccess
+++ b/website/auth/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine On
+RewriteCond %{HTTPS} off
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+Options -Indexes

--- a/website/auth/callback/index.php
+++ b/website/auth/callback/index.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Chatty OAuth Callback Proxy
+ *
+ * Receives Google's OAuth callback and redirects the auth code to the
+ * originating Chatty instance. The instance's callback URL is encoded
+ * in the state parameter as: {flow_id}:{base64url(callback_url)}
+ */
+
+$ALLOWED_DOMAIN_PATTERNS = [
+    '/^[a-z0-9-]+\.up\.railway\.app$/',
+    '/^localhost$/',
+    '/^127\.0\.0\.1$/',
+];
+
+// ── Read query parameters ───────────────────────────────────────────
+
+$code  = $_GET['code']  ?? '';
+$state = $_GET['state'] ?? '';
+$error = $_GET['error'] ?? '';
+
+if ($error) {
+    $desc = htmlspecialchars($_GET['error_description'] ?? $error, ENT_QUOTES, 'UTF-8');
+    http_response_code(400);
+    die("<!doctype html><html><head><meta charset='utf-8'><title>Connection failed</title>
+    <style>body{font-family:system-ui;background:#0f172a;color:#f1f5f9;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
+    .c{text-align:center;max-width:420px}h1{color:#ef4444;margin:0 0 .75rem}p{color:#cbd5e1}</style></head>
+    <body><div class='c'><h1>Connection failed</h1><p>$desc</p><p>Close this window and try again.</p></div></body></html>");
+}
+
+if (!$code || !$state) {
+    http_response_code(400);
+    die('Missing code or state parameter.');
+}
+
+// ── Decode state ────────────────────────────────────────────────────
+
+$colon = strpos($state, ':');
+if ($colon === false || $colon === 0) {
+    http_response_code(400);
+    die('Malformed state parameter.');
+}
+
+$flow_id     = substr($state, 0, $colon);
+$encoded_url = substr($state, $colon + 1);
+
+if (!$flow_id || !$encoded_url) {
+    http_response_code(400);
+    die('Malformed state parameter.');
+}
+
+// base64url decode (RFC 4648 section 5)
+$callback_url = base64_decode(strtr($encoded_url, '-_', '+/'));
+if (!$callback_url) {
+    http_response_code(400);
+    die('Invalid encoded callback URL.');
+}
+
+// ── Validate the callback URL ───────────────────────────────────────
+
+$parsed = parse_url($callback_url);
+if (!$parsed || empty($parsed['host']) || empty($parsed['scheme']) || empty($parsed['path'])) {
+    http_response_code(400);
+    die('Invalid callback URL.');
+}
+
+$host   = strtolower($parsed['host']);
+$scheme = strtolower($parsed['scheme']);
+$path   = $parsed['path'];
+
+// Scheme check: https required, except localhost
+$is_local = ($host === 'localhost' || $host === '127.0.0.1');
+if ($scheme !== 'https' && !($is_local && $scheme === 'http')) {
+    http_response_code(400);
+    die('Callback URL must use HTTPS.');
+}
+
+// Path check
+if (!str_ends_with($path, '/api/oauth/callback')) {
+    http_response_code(400);
+    die('Invalid callback path.');
+}
+
+// Domain allowlist check
+$domain_ok = false;
+foreach ($ALLOWED_DOMAIN_PATTERNS as $pattern) {
+    if (preg_match($pattern, $host)) {
+        $domain_ok = true;
+        break;
+    }
+}
+if (!$domain_ok) {
+    http_response_code(403);
+    die('Callback domain not allowed.');
+}
+
+// ── Build redirect ──────────────────────────────────────────────────
+
+$params = ['code' => $code, 'state' => $flow_id];
+
+// Forward extra params (scope, realmId, etc.)
+foreach ($_GET as $key => $val) {
+    if (!in_array($key, ['code', 'state', 'error', 'error_description'])) {
+        $params[$key] = $val;
+    }
+}
+
+$redirect = $callback_url . '?' . http_build_query($params);
+
+header('Cache-Control: no-store');
+header('Location: ' . $redirect, true, 302);
+exit;

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,511 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chatty — Free AI Agent Platform for Small Business</title>
+  <meta name="description" content="A free, open-source browser-based personal AI agent platform built for professionals and small business owners. Create custom AI agents powered by your own API keys.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..600&family=Geist:wght@300..600&family=JetBrains+Mono:wght@300..500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<!-- ─── Nav ──────────────────────────────────────────────── -->
+<nav class="nav">
+  <div class="container nav-inner">
+    <a href="#top" class="nav-logo">
+      <svg height="28" viewBox="0 0 180 32" fill="none">
+        <g transform="translate(0, 4)">
+          <path d="M20 7.5a7.5 7.5 0 1 0 0 9" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+          <path d="M18 9.5a5.5 5.5 0 1 0 0 5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.4"/>
+          <path d="M0 12h2.5M16 12h8" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.5"/>
+          <circle cx="12" cy="12" r="1.5" fill="currentColor"/>
+        </g>
+        <text x="32" y="23" font-family="Fraunces, Georgia, serif" font-size="24" font-weight="400" fill="currentColor" letter-spacing="-0.02em">chatty</text>
+      </svg>
+    </a>
+    <div class="nav-links">
+      <a href="#product">Product</a>
+      <a href="#agents">Agents</a>
+      <a href="#integrations">Integrations</a>
+      <a href="#install">Docs</a>
+    </div>
+    <div class="nav-actions">
+      <a href="https://github.com/WWilson1017/chatty" target="_blank" rel="noopener" class="btn btn-outline btn-sm">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.89 1.53 2.34 1.09 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 12 2z"/></svg>
+        GitHub
+      </a>
+      <a href="#install" class="btn btn-primary btn-sm">Get started</a>
+    </div>
+  </div>
+</nav>
+
+<!-- ─── Hero ─────────────────────────────────────────────── -->
+<section id="top" class="hero">
+  <div class="halo"></div>
+  <div class="container hero-inner">
+    <div class="hero-logo-wrap">
+      <div class="hero-logo-glow"></div>
+      <svg class="hero-logo" width="104" height="104" viewBox="0 0 32 32" fill="none">
+        <path d="M26 10a10 10 0 1 0 0 12" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+        <path d="M24 12.5a7 7 0 1 0 0 7" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.4"/>
+        <path d="M3 16h3M21 16h8" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.5"/>
+        <circle cx="16" cy="16" r="1.8" fill="currentColor"/>
+      </svg>
+    </div>
+
+    <h1 class="hero-heading">Your own AI agents,<br><em>on your own machine.</em></h1>
+
+    <p class="hero-sub">A free, open-source browser-based personal AI agent platform built for professionals and small business owners.</p>
+
+    <div class="hero-actions">
+      <a href="#install" class="btn btn-primary">
+        Get started
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+      <a href="https://github.com/WWilson1017/chatty" target="_blank" rel="noopener" class="btn btn-outline">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.89 1.53 2.34 1.09 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 12 2z"/></svg>
+        Star on GitHub
+      </a>
+    </div>
+
+    <div class="hero-meta">Local-first &middot; SQLite &middot; Runs anywhere Python does</div>
+
+    <!-- Product screenshot chrome -->
+    <div class="screenshot-chrome">
+      <div class="chrome-bar">
+        <div class="chrome-dots">
+          <span></span><span></span><span></span>
+        </div>
+        <div class="chrome-url">localhost:8000</div>
+      </div>
+      <div class="screenshot-body">
+        <!-- Simplified dashboard preview -->
+        <div class="dash-preview">
+          <div class="dash-rail">
+            <svg width="22" height="22" viewBox="0 0 32 32" fill="none" style="color: var(--accent)">
+              <path d="M26 10a10 10 0 1 0 0 12" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+              <path d="M24 12.5a7 7 0 1 0 0 7" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.4"/>
+              <circle cx="16" cy="16" r="1.5" fill="currentColor"/>
+            </svg>
+            <div class="rail-sep"></div>
+            <div class="rail-icon active">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12a8 8 0 0 1-8 8 8 8 0 0 1-3.5-.8L4 20.5l1.3-4.5A8 8 0 0 1 4 12a8 8 0 0 1 16 0z"/></svg>
+            </div>
+            <div class="rail-icon">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.5 5 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.5-7a1.9 1.9 0 0 0-1.8-1h-9a1.9 1.9 0 0 0-1.8 1Z"/></svg>
+            </div>
+            <div class="rail-icon">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.9M16 3.1a4 4 0 0 1 0 7.8"/></svg>
+            </div>
+          </div>
+          <div class="dash-main">
+            <div class="dash-topbar">
+              <span class="mono-label">Cheesecake Operations &middot; Thursday, April 18</span>
+            </div>
+            <div class="dash-hero-area">
+              <div class="mono-label" style="margin-bottom: 14px">Vol. IV &middot; Morning edition</div>
+              <div class="dash-greeting">Good morning, Sammy.</div>
+              <div class="dash-subtitle">Your agents handled <span class="gold">34 tasks</span> overnight. Two are working now.</div>
+              <div class="dash-stats">
+                <div class="stat"><span class="mono-label">At work now</span><span class="stat-val">2</span></div>
+                <div class="stat"><span class="mono-label">Tasks today</span><span class="stat-val">34</span></div>
+                <div class="stat"><span class="mono-label">Avg. reply</span><span class="stat-val">12s</span></div>
+                <div class="stat"><span class="mono-label">Pipeline</span><span class="stat-val">$153.9K</span></div>
+              </div>
+            </div>
+            <div class="dash-agents-label">
+              <span class="mono-label">Your agents &middot; 6</span>
+            </div>
+            <div class="dash-grid">
+              <div class="agent-card"><div class="mark mark-P">P</div><div><strong>Penelope</strong><span class="muted">Personal Assistant</span></div></div>
+              <div class="agent-card"><div class="mark mark-A">A</div><div><strong>Arthur</strong><span class="muted">Accounts Payable</span></div></div>
+              <div class="agent-card"><div class="mark mark-R">R</div><div><strong>Rhea</strong><span class="muted">Accounts Receivable</span></div></div>
+              <div class="agent-card"><div class="mark mark-C">C</div><div><strong>Cassian</strong><span class="muted">Customer Service</span></div></div>
+              <div class="agent-card"><div class="mark mark-L">L</div><div><strong>Lior</strong><span class="muted">Inbound Sales</span></div></div>
+              <div class="agent-card"><div class="mark mark-T">T</div><div><strong>Talia</strong><span class="muted">Research Analyst</span></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── Product Showcase ─────────────────────────────────── -->
+<section id="product" class="section">
+  <div class="container">
+    <div class="section-header">
+      <div class="eyebrow">The product</div>
+      <h2>Chat + Tools + <em>Integrated.</em></h2>
+      <p class="section-sub">Your data, tools, and approvals wrap around a single conversation. Nothing feels bolted on because nothing is.</p>
+    </div>
+
+    <div class="showcase-item">
+      <div class="showcase-text">
+        <div class="showcase-label">01 &mdash; Chat</div>
+        <h3>Built to be read, not scrolled.</h3>
+        <p>A centered column, clear typography, and tool calls shown inline as footnotes. Switch between Power and Read modes to change the model without breaking your flow.</p>
+      </div>
+      <div class="showcase-preview">
+        <div class="preview-chat">
+          <div class="preview-topbar"><span>Alba Co. invoice review</span></div>
+          <div class="preview-messages">
+            <div class="msg-user">Arthur, can you look at the Alba Co. invoice that came in this morning?</div>
+            <div class="msg-agent">
+              <div class="mark mark-A mark-sm">A</div>
+              <div class="msg-agent-body">
+                <div class="msg-agent-head"><span class="gold">Arthur</span> <span class="mono-label">9:14 AM</span></div>
+                <p>Good catch. Alba's Q2 invoice came in at <span class="highlight">$18,420</span> &mdash; that's <em>+12.3%</em> over their contracted rate of $16,400.</p>
+                <div class="tool-card">
+                  <div class="tool-head"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6"/></svg> alba_q2_2026.pdf <span class="mono-label">Read</span></div>
+                  <div class="tool-row"><span>Line 1 &middot; base service</span><span>$14,200</span></div>
+                  <div class="tool-row coral"><span>Line 2 &middot; "expedited handling"</span><span>$2,020</span></div>
+                  <div class="tool-row"><span>Line 3 &middot; fuel surcharge</span><span>$2,200</span></div>
+                </div>
+                <div class="msg-actions">
+                  <button class="btn btn-primary btn-xs">Draft dispute</button>
+                  <button class="btn btn-outline btn-xs">Show full PDF</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="showcase-item">
+      <div class="showcase-text">
+        <div class="showcase-label">02 &mdash; CRM</div>
+        <h3>Your agents run your pipeline.</h3>
+        <p>The CRM isn't a separate app &mdash; it's built in. Your agents read it, update it, and manage your deals directly. They log calls, move stages, create tasks, and follow up on stalled opportunities without you lifting a finger.</p>
+      </div>
+      <div class="showcase-preview">
+        <div class="preview-crm">
+          <div class="preview-topbar"><span>CRM</span> <span class="mono-label">/ Pipeline</span></div>
+          <div class="crm-hero">
+            <div class="mono-label">Week of Apr 14 &mdash; 20</div>
+            <div class="crm-total">Pipeline is <span class="gold"><em>$153,900</em></span></div>
+            <div class="crm-sub">across 26 open deals.</div>
+          </div>
+          <div class="crm-stages">
+            <div class="crm-row"><span class="crm-name">Lead</span><div class="crm-bar"><div style="width:38%"></div></div><span class="crm-val">$18.4K</span><span class="mono-label">12 deals</span></div>
+            <div class="crm-row"><span class="crm-name">Qualified</span><div class="crm-bar"><div style="width:62%"></div></div><span class="crm-val">$42.8K</span><span class="mono-label">7 deals</span></div>
+            <div class="crm-row"><span class="crm-name">Proposal</span><div class="crm-bar"><div style="width:88%"></div></div><span class="crm-val">$64.2K</span><span class="mono-label">4 deals</span></div>
+            <div class="crm-row"><span class="crm-name">Negotiation</span><div class="crm-bar"><div style="width:48%"></div></div><span class="crm-val">$28.5K</span><span class="mono-label">3 deals</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="showcase-item">
+      <div class="showcase-text">
+        <div class="showcase-label">03 &mdash; Onboarding</div>
+        <h3>Spin up an agent in a minute.</h3>
+        <p>Pick a role, connect the tools it needs, decide what it should ask before doing. That's it &mdash; you can always refine later.</p>
+      </div>
+      <div class="showcase-preview">
+        <div class="preview-onboarding">
+          <div class="preview-topbar"><span style="color: var(--accent)">
+            <svg height="18" viewBox="0 0 180 32" fill="none"><g transform="translate(0, 4)"><path d="M20 7.5a7.5 7.5 0 1 0 0 9" stroke="currentColor" stroke-width="3" stroke-linecap="round"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/></g><text x="32" y="23" font-family="Fraunces, Georgia, serif" font-size="24" font-weight="400" fill="currentColor" letter-spacing="-0.02em">chatty</text></svg>
+          </span> <span class="mono-label">Step 2 of 4 &middot; Choose a provider</span></div>
+          <div class="onboard-body">
+            <div class="mono-label">Connect your model</div>
+            <div class="onboard-heading">Where does <em class="gold">the thinking</em> happen?</div>
+            <div class="onboard-grid">
+              <div class="provider-card selected"><div class="provider-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></div><div><strong>Anthropic</strong><span class="muted">Claude Sonnet, Opus</span></div></div>
+              <div class="provider-card"><div class="provider-check empty"></div><div><strong>OpenAI</strong><span class="muted">GPT-4o, o1</span></div></div>
+              <div class="provider-card"><div class="provider-check empty"></div><div><strong>Together</strong><span class="muted">Open models, OSS fine-tunes</span></div></div>
+              <div class="provider-card"><div class="provider-check empty"></div><div><strong>Ollama</strong><span class="muted">Run locally, no cloud</span></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="showcase-item">
+      <div class="showcase-text">
+        <div class="showcase-label">04 &mdash; Heartbeat</div>
+        <h3>They work while you sleep.</h3>
+        <p>Agents set their own reminders, run scheduled actions, and consolidate what they've learned &mdash; all in the background. You wake up to work already done.</p>
+      </div>
+      <div class="showcase-preview">
+        <div class="preview-heartbeat">
+          <div class="preview-topbar"><span>Agent Activity</span> <span class="mono-label">Heartbeat</span></div>
+          <div class="heartbeat-body">
+            <div class="heartbeat-section">
+              <div class="mono-label" style="margin-bottom: 12px">Scheduled actions</div>
+              <div class="hb-row">
+                <div class="hb-dot sage"></div>
+                <div class="hb-content">
+                  <div class="hb-title"><span class="mark mark-A" style="width:22px;height:22px;font-size:12px;border-radius:4px">A</span> Arthur</div>
+                  <div class="hb-desc">Ran weekly AP digest &mdash; flagged 2 overdue invoices</div>
+                  <div class="mono-label">Scheduled &middot; Every Monday 8:00 AM</div>
+                </div>
+                <div class="mono-label">6:02 AM</div>
+              </div>
+              <div class="hb-row">
+                <div class="hb-dot sage"></div>
+                <div class="hb-content">
+                  <div class="hb-title"><span class="mark mark-R" style="width:22px;height:22px;font-size:12px;border-radius:4px">R</span> Rhea</div>
+                  <div class="hb-desc">Checked aged receivables &mdash; sent 3 follow-up emails</div>
+                  <div class="mono-label">Scheduled &middot; Daily 7:00 AM</div>
+                </div>
+                <div class="mono-label">7:00 AM</div>
+              </div>
+            </div>
+            <div class="heartbeat-section">
+              <div class="mono-label" style="margin-bottom: 12px">Self-reminders fired</div>
+              <div class="hb-row">
+                <div class="hb-dot gold"></div>
+                <div class="hb-content">
+                  <div class="hb-title"><span class="mark mark-L" style="width:22px;height:22px;font-size:12px;border-radius:4px">L</span> Lior</div>
+                  <div class="hb-desc">Follow up with Ocean View Caf&eacute; on proposal</div>
+                  <div class="mono-label">Self-set &middot; 3 days ago</div>
+                </div>
+                <div class="mono-label">9:00 AM</div>
+              </div>
+            </div>
+            <div class="heartbeat-section">
+              <div class="mono-label" style="margin-bottom: 12px">Dreaming</div>
+              <div class="hb-row">
+                <div class="hb-dot" style="background: var(--ink-dim)"></div>
+                <div class="hb-content">
+                  <div class="hb-desc">Consolidated 4 context files, archived 2 dormant docs</div>
+                  <div class="mono-label">Nightly cycle &middot; All agents</div>
+                </div>
+                <div class="mono-label">3:00 AM</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── Features ─────────────────────────────────────────── -->
+<section class="section section-ruled">
+  <div class="container">
+    <div class="section-header center">
+      <div class="eyebrow">What's inside</div>
+      <h2>Batteries, <em>included.</em></h2>
+      <p class="section-sub">Everything you need to build an agent-driven workspace.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon accent">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12a8 8 0 0 1-8 8 8 8 0 0 1-3.5-.8L4 20.5l1.3-4.5A8 8 0 0 1 4 12a8 8 0 0 1 16 0z"/></svg>
+        </div>
+        <div class="feature-title">Multi-agent</div>
+        <div class="feature-body">Create and manage multiple agents, each with its own name, personality, and knowledge base.</div>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon gold">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M9 4a3 3 0 0 0-3 3v1a3 3 0 0 0-2 5 3 3 0 0 0 2 5v1a3 3 0 0 0 3 3h1V4H9zM15 4a3 3 0 0 1 3 3v1a3 3 0 0 1 2 5 3 3 0 0 1-2 5v1a3 3 0 0 1-3 3h-1V4h1z"/></svg>
+        </div>
+        <div class="feature-title">Multi-provider AI</div>
+        <div class="feature-body">Anthropic, OpenAI, Gemini, Together, or Ollama. Switch models without re-wiring anything.</div>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon accent">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h12a4 4 0 0 1 4 4v12H8a4 4 0 0 1-4-4V4zM4 16a4 4 0 0 1 4-4h12"/></svg>
+        </div>
+        <div class="feature-title">Knowledge</div>
+        <div class="feature-body">Feed an agent your docs, notes, or scraped pages. It cites what it used, you see every source.</div>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon accent">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.9M16 3.1a4 4 0 0 1 0 7.8"/></svg>
+        </div>
+        <div class="feature-title">Built-in CRM</div>
+        <div class="feature-body">Contacts, companies, deals, tasks &mdash; the same store your agents read from. Not a bolt-on.</div>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon gold">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+        </div>
+        <div class="feature-title">Tools &amp; integrations</div>
+        <div class="feature-body">Gmail, Calendar, QuickBooks, WhatsApp, Telegram. Agents use them; you approve what matters.</div>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon accent">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+        </div>
+        <div class="feature-title">Local-first</div>
+        <div class="feature-body">SQLite on disk. Your data never leaves your machine unless you point it somewhere else.</div>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon accent">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v4M12 17v4M3 12h4M17 12h4M5.6 5.6l2.8 2.8M15.6 15.6l2.8 2.8M5.6 18.4l2.8-2.8M15.6 8.4l2.8-2.8"/></svg>
+        </div>
+        <div class="feature-title">Brandable</div>
+        <div class="feature-body">Your logo, your company name, your accent color. Make it yours in a minute.</div>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon accent">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z"/></svg>
+        </div>
+        <div class="feature-title">Deploy anywhere</div>
+        <div class="feature-body">One-click to Railway, or run it on a spare Raspberry Pi. Anywhere Python runs, Chatty runs.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── Agents ───────────────────────────────────────────── -->
+<section id="agents" class="section section-ruled section-elev">
+  <div class="halo halo-sm"></div>
+  <div class="container" style="position:relative;z-index:2">
+    <div class="section-header">
+      <div class="eyebrow">Agents</div>
+      <h2>Start with one, <em>build a team.</em></h2>
+      <p class="section-sub">Pick a template, rename it, reshape it. Each agent gets its own monogram &mdash; a small piece of identity for something doing real work.</p>
+    </div>
+    <div class="agents-grid">
+      <div class="agent-spot"><div class="mark mark-P">P</div><div class="agent-info"><div class="agent-name">Parker</div><div class="muted">Support concierge</div><div class="agent-stats"><span>1,240 tasks</span><span>8 tools</span></div></div></div>
+      <div class="agent-spot"><div class="mark mark-A">A</div><div class="agent-info"><div class="agent-name">Arthur</div><div class="muted">AP controller</div><div class="agent-stats"><span>984 tasks</span><span>6 tools</span></div></div></div>
+      <div class="agent-spot"><div class="mark mark-R">R</div><div class="agent-info"><div class="agent-name">Reed</div><div class="muted">Revenue ops</div><div class="agent-stats"><span>720 tasks</span><span>7 tools</span></div></div></div>
+      <div class="agent-spot"><div class="mark mark-C">C</div><div class="agent-info"><div class="agent-name">Clare</div><div class="muted">Customer research</div><div class="agent-stats"><span>412 tasks</span><span>5 tools</span></div></div></div>
+      <div class="agent-spot"><div class="mark mark-L">L</div><div class="agent-info"><div class="agent-name">Lane</div><div class="muted">Lead qualification</div><div class="agent-stats"><span>1,899 tasks</span><span>4 tools</span></div></div></div>
+      <div class="agent-spot"><div class="mark mark-T">T</div><div class="agent-info"><div class="agent-name">Theo</div><div class="muted">On-call triage</div><div class="agent-stats"><span>260 tasks</span><span>9 tools</span></div></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── Integrations ─────────────────────────────────────── -->
+<section id="integrations" class="section section-ruled">
+  <div class="container">
+    <div class="section-header">
+      <div class="eyebrow">Models &amp; tools</div>
+      <h2>It plugs into<br><em>what you already run.</em></h2>
+      <p class="section-sub">Bring your own keys for any supported provider &mdash; or point Chatty at a local Ollama instance and never pay for a token.</p>
+    </div>
+
+    <div class="featured-grid">
+      <div class="featured-card featured-gold">
+        <div class="featured-glow gold"></div>
+        <div class="featured-top">
+          <svg width="68" height="68" viewBox="0 0 48 48" fill="none" style="color: var(--gold)">
+            <circle cx="24" cy="24" r="22" stroke="currentColor" stroke-width="1.5" opacity="0.3"/>
+            <circle cx="24" cy="24" r="15" stroke="currentColor" stroke-width="1.5" opacity="0.6"/>
+            <text x="24" y="30.5" text-anchor="middle" font-family="Fraunces, serif" font-size="20" font-weight="500" fill="currentColor" font-style="italic">O</text>
+          </svg>
+          <span class="featured-badge gold">Odoo</span>
+        </div>
+        <div class="featured-body">
+          <div class="mono-label">Odoo ERP</div>
+          <div class="featured-tagline">Your whole back-office, <em>at your agent's fingertips.</em></div>
+        </div>
+        <div class="featured-bullets">
+          <div class="bullet gold"><span></span>CRM, helpdesk, sales, purchasing, accounting, quality &mdash; 60+ tools wired in</div>
+          <div class="bullet gold"><span></span>Auto-discovers your databases; works with any self-hosted or cloud Odoo instance</div>
+          <div class="bullet gold"><span></span>Per-agent permissions: read-only to full CRUD, your call</div>
+          <div class="bullet gold"><span></span>Query aged receivables, open tickets, leads, quality alerts &mdash; in plain English</div>
+        </div>
+      </div>
+      <div class="featured-card">
+        <div class="featured-glow"></div>
+        <div class="featured-top">
+          <svg width="68" height="68" viewBox="0 0 48 48" fill="none" style="color: var(--accent)">
+            <circle cx="24" cy="24" r="22" stroke="currentColor" stroke-width="1.5" opacity="0.3"/>
+            <path d="M12 24 35 15l-3 19-7.5-6-4 4 .4-7L12 24z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+            <path d="m16.5 24 13 2.5-8 4.5" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" opacity="0.45"/>
+          </svg>
+          <span class="featured-badge">Telegram</span>
+        </div>
+        <div class="featured-body">
+          <div class="mono-label">Telegram</div>
+          <div class="featured-tagline">Chat with your agents <em>from anywhere.</em></div>
+        </div>
+        <div class="featured-bullets">
+          <div class="bullet"><span></span>Talk to any agent from your phone &mdash; no extra app to install</div>
+          <div class="bullet"><span></span>Full tool access: bookkeeping, CRM, email drafts, all over text</div>
+          <div class="bullet"><span></span>One-to-one or group chats; threads stay in sync with your desktop</div>
+          <div class="bullet"><span></span>Run an ops team that never leaves the group chat</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="also-connected">
+      <div class="mono-label" style="margin-bottom: 18px">Also connected</div>
+      <div class="integrations-grid">
+        <div class="integ-item"><div class="integ-icon">G</div><div><div class="integ-name">Gmail</div><div class="mono-label">Tool</div></div></div>
+        <div class="integ-item"><div class="integ-icon">G</div><div><div class="integ-name">Google Calendar</div><div class="mono-label">Tool</div></div></div>
+        <div class="integ-item"><div class="integ-icon">Q</div><div><div class="integ-name">QuickBooks Online</div><div class="mono-label">Tool</div></div></div>
+        <div class="integ-item"><div class="integ-icon">W</div><div><div class="integ-name">WhatsApp</div><div class="mono-label">Tool</div></div></div>
+        <div class="integ-item"><div class="integ-icon">A</div><div><div class="integ-name">Anthropic</div><div class="mono-label">Model</div></div></div>
+        <div class="integ-item"><div class="integ-icon">O</div><div><div class="integ-name">OpenAI</div><div class="mono-label">Model</div></div></div>
+        <div class="integ-item"><div class="integ-icon">G</div><div><div class="integ-name">Google Gemini</div><div class="mono-label">Model</div></div></div>
+        <div class="integ-item"><div class="integ-icon">T</div><div><div class="integ-name">Together AI</div><div class="mono-label">Model</div></div></div>
+        <div class="integ-item"><div class="integ-icon">O</div><div><div class="integ-name">Ollama</div><div class="mono-label">Model &middot; local</div></div></div>
+      </div>
+    </div>
+
+    <div class="docs-link">
+      <a href="https://github.com/WWilson1017/chatty#features" target="_blank" rel="noopener">
+        See setup docs
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- ─── Install ──────────────────────────────────────────── -->
+<section id="install" class="section section-ruled">
+  <div class="halo halo-sm" style="opacity: 0.3"></div>
+  <div class="container container-sm" style="position:relative;z-index:2">
+    <div class="section-header center">
+      <div class="eyebrow">Get started</div>
+      <h2>Up and running in <em>5 minutes.</em></h2>
+      <p class="section-sub">Three lines. The launcher sets up a virtualenv, installs deps, and starts the server.</p>
+    </div>
+    <div class="code-block">
+      <span class="dim">$ </span>git clone https://github.com/WWilson1017/chatty.git<br>
+      <span class="dim">$ </span>cd chatty<br>
+      <span class="dim">$ </span>python run.py<br>
+      <span class="sage">&rarr; Chatty is running at http://localhost:8000</span>
+    </div>
+    <div class="install-actions">
+      <a href="https://github.com/WWilson1017/chatty" target="_blank" rel="noopener" class="btn btn-primary">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.89 1.53 2.34 1.09 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 12 2z"/></svg>
+        View on GitHub
+      </a>
+      <a href="https://github.com/WWilson1017/chatty#deploy-to-railway" target="_blank" rel="noopener" class="btn btn-outline">
+        One-click deploy to Railway
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+    </div>
+    <div class="install-meta">Requires Python 3.10+ and Node 18+</div>
+  </div>
+</section>
+
+<!-- ─── Footer ───────────────────────────────────────────── -->
+<footer class="footer">
+  <div class="container footer-inner">
+    <div class="footer-left">
+      <svg height="22" viewBox="0 0 180 32" fill="none" style="color: var(--ink)">
+        <g transform="translate(0, 4)">
+          <path d="M20 7.5a7.5 7.5 0 1 0 0 9" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+          <path d="M18 9.5a5.5 5.5 0 1 0 0 5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.4"/>
+          <path d="M0 12h2.5M16 12h8" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.5"/>
+          <circle cx="12" cy="12" r="1.5" fill="currentColor"/>
+        </g>
+        <text x="32" y="23" font-family="Fraunces, Georgia, serif" font-size="24" font-weight="400" fill="currentColor" letter-spacing="-0.02em">chatty</text>
+      </svg>
+      <span class="mono-label">MIT &middot; free forever</span>
+    </div>
+    <div class="footer-links">
+      <a href="https://github.com/WWilson1017/chatty" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://github.com/WWilson1017/chatty#quick-start" target="_blank" rel="noopener">Docs</a>
+      <a href="https://github.com/WWilson1017/chatty/issues" target="_blank" rel="noopener">Issues</a>
+      <a href="https://github.com/WWilson1017/chatty/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+      <a href="https://github.com/WWilson1017/chatty/blob/main/LICENSE" target="_blank" rel="noopener">License</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,902 @@
+/* ─── Tokens (Aurelia / Slate) ──────────────────────────── */
+:root {
+  --bg:          #0A0C0F;
+  --bg-elev:     #11141A;
+  --bg-card:     rgba(20,24,30,0.78);
+  --bg-raised:   rgba(34,40,48,0.55);
+  --line:        rgba(230,235,242,0.07);
+  --line-strong: rgba(230,235,242,0.14);
+  --ink:         #EDF0F4;
+  --ink-mute:    rgba(237,240,244,0.62);
+  --ink-dim:     rgba(237,240,244,0.38);
+  --accent:      #C8D1D9;
+  --accent-soft: rgba(200,209,217,0.12);
+  --accent-ink:  #0E1013;
+  --accent-glow: rgba(200,209,217,0.18);
+  --gold:        #D4A85A;
+  --gold-soft:   rgba(212,168,90,0.10);
+  --sage:        #8EA589;
+  --coral:       #D97757;
+  --display:     "Fraunces", "Source Serif 4", Georgia, serif;
+  --sans:        "Geist", "Inter Tight", system-ui, sans-serif;
+  --mono:        "JetBrains Mono", ui-monospace, monospace;
+}
+
+/* ─── Reset ─────────────────────────────────────────────── */
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+html, body { background: var(--bg); }
+body {
+  font-family: var(--sans);
+  color: var(--ink);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+::selection { background: rgba(200,209,217,0.25); }
+img, svg { display: block; }
+a { color: inherit; }
+
+/* ─── Layout ────────────────────────────────────────────── */
+.container { max-width: 1180px; margin: 0 auto; padding: 0 40px; }
+.container-sm { max-width: 900px; }
+
+/* ─── Shared ────────────────────────────────────────────── */
+.mono-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-bottom: 18px;
+}
+.muted { color: var(--ink-mute); }
+.dim   { color: var(--ink-dim); }
+.gold  { color: var(--gold); }
+.sage  { color: var(--sage); }
+.coral { color: var(--coral); }
+em { font-style: italic; }
+
+/* ─── Buttons ───────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--sans);
+  font-size: 15px;
+  font-weight: 500;
+  text-decoration: none;
+  padding: 12px 22px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.15s;
+  letter-spacing: -0.005em;
+}
+.btn:hover { opacity: 0.85; }
+.btn-primary { background: var(--accent); color: var(--accent-ink); }
+.btn-outline { background: transparent; color: var(--ink); border: 1px solid var(--line-strong); }
+.btn-sm { font-size: 15px; font-weight: 400; padding: 9px 16px; }
+.btn-xs { font-size: 13px; padding: 7px 14px; font-weight: 500; }
+
+/* ─── Nav ───────────────────────────────────────────────── */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(10,12,15,0.72);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--line);
+}
+.nav-inner {
+  height: 80px;
+  display: flex;
+  align-items: center;
+  gap: 40px;
+}
+.nav-logo {
+  color: var(--ink);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+}
+.nav-logo svg { display: block; }
+.nav-links {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 34px;
+}
+.nav-links a {
+  font-size: 16px;
+  text-decoration: none;
+  letter-spacing: -0.005em;
+}
+.nav-actions { display: flex; gap: 12px; align-items: center; }
+
+/* ─── Halo ──────────────────────────────────────────────── */
+.halo {
+  position: absolute;
+  top: -260px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1200px;
+  height: 600px;
+  pointer-events: none;
+  opacity: 0.55;
+  background: radial-gradient(ellipse at center, var(--accent-glow) 0%, rgba(200,209,217,0.04) 40%, transparent 70%);
+  filter: blur(80px);
+}
+.halo-sm { width: 900px; height: 450px; top: -100px; opacity: 0.35; }
+
+/* ─── Hero ──────────────────────────────────────────────── */
+.hero {
+  position: relative;
+  padding: 60px 0 60px;
+  overflow: hidden;
+}
+.hero-inner { position: relative; z-index: 2; text-align: center; }
+.hero-logo-wrap {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 28px;
+  position: relative;
+  color: var(--accent);
+}
+.hero-logo-glow {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: 180px; height: 180px;
+  background: radial-gradient(circle, var(--accent-glow) 0%, transparent 65%);
+  filter: blur(20px);
+  pointer-events: none;
+}
+.hero-logo { position: relative; display: block; margin: 0 auto; }
+
+.hero-heading {
+  font-family: var(--display);
+  font-size: 72px;
+  font-weight: 400;
+  letter-spacing: -0.035em;
+  line-height: 0.98;
+  margin: 0 auto;
+  max-width: 920px;
+}
+.hero-heading em { color: var(--gold); }
+.hero-sub {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-mute);
+  margin: 14px auto 0;
+  max-width: 720px;
+}
+.hero-sub:first-of-type { margin-top: 24px; }
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 32px;
+}
+.hero-meta {
+  margin-top: 28px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--ink-dim);
+  text-transform: uppercase;
+}
+
+/* ─── Screenshot chrome ─────────────────────────────────── */
+.screenshot-chrome {
+  margin-top: 56px;
+  margin-left: -20px;
+  margin-right: -20px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--bg-elev);
+  box-shadow: 0 40px 120px -30px rgba(0,0,0,0.6), 0 0 0 1px var(--line);
+}
+.chrome-bar {
+  height: 36px;
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-card);
+}
+.chrome-dots { display: flex; gap: 8px; }
+.chrome-dots span {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  background: rgba(237,240,244,0.14);
+}
+.chrome-url {
+  flex: 1;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-dim);
+  letter-spacing: 0.14em;
+}
+.screenshot-body { height: 560px; overflow: hidden; }
+
+/* ─── Dashboard preview ─────────────────────────────────── */
+.dash-preview {
+  display: flex;
+  height: 100%;
+  background: var(--bg);
+  position: relative;
+}
+.dash-rail {
+  width: 56px;
+  border-right: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 14px 0;
+  gap: 6px;
+}
+.rail-sep {
+  width: 22px; height: 1px;
+  background: var(--line);
+  margin: 8px 0;
+}
+.rail-icon {
+  padding: 9px;
+  color: rgba(237,240,244,0.78);
+  border-radius: 4px;
+}
+.rail-icon.active {
+  background: var(--accent-soft);
+  color: var(--ink);
+  border-left: 2px solid var(--accent);
+  padding-left: 7px;
+}
+.dash-main { flex: 1; display: flex; flex-direction: column; }
+.dash-topbar {
+  height: 44px;
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+.dash-hero-area {
+  padding: 36px 36px 24px;
+  border-bottom: 1px solid var(--line);
+}
+.dash-greeting {
+  font-family: var(--display);
+  font-size: 42px;
+  font-weight: 400;
+  letter-spacing: -0.028em;
+  line-height: 1.02;
+}
+.dash-subtitle {
+  font-family: var(--display);
+  font-size: 18px;
+  font-style: italic;
+  color: var(--ink-mute);
+  margin-top: 10px;
+  letter-spacing: -0.01em;
+}
+.dash-stats {
+  display: flex;
+  gap: 40px;
+  margin-top: 24px;
+  padding-top: 18px;
+  border-top: 1px dashed var(--line);
+}
+.stat { display: flex; flex-direction: column; gap: 6px; }
+.stat-val {
+  font-family: var(--display);
+  font-size: 22px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.dash-agents-label { padding: 16px 36px 10px; }
+.dash-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  padding: 0 36px 36px;
+}
+.agent-card {
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 14px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+.agent-card strong {
+  font-family: var(--display);
+  font-size: 17px;
+  letter-spacing: -0.015em;
+  display: block;
+  font-weight: 400;
+}
+.agent-card .muted { font-size: 11px; display: block; margin-top: 1px; }
+
+/* ─── Agent monograms ───────────────────────────────────── */
+.mark {
+  width: 44px; height: 44px;
+  border-radius: 8px;
+  font-family: var(--display);
+  font-weight: 500;
+  font-size: 23px;
+  letter-spacing: -0.025em;
+  color: #0f1114;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.3), inset 0 -1px 0 rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.25);
+}
+.mark::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255,255,255,0.22) 0%, rgba(255,255,255,0.22) 35%, rgba(255,255,255,0) 35.5%);
+  pointer-events: none;
+}
+.mark-sm { width: 30px; height: 30px; font-size: 16px; border-radius: 6px; }
+.mark-P { background: linear-gradient(160deg, oklch(0.74 0.13 160) 0%, oklch(0.56 0.12 160) 60%, oklch(0.46 0.10 160) 100%); }
+.mark-A { background: linear-gradient(160deg, oklch(0.74 0.13 210) 0%, oklch(0.56 0.12 210) 60%, oklch(0.46 0.10 210) 100%); }
+.mark-R { background: linear-gradient(160deg, oklch(0.74 0.13 40)  0%, oklch(0.56 0.12 40)  60%, oklch(0.46 0.10 40)  100%); }
+.mark-C { background: linear-gradient(160deg, oklch(0.74 0.13 140) 0%, oklch(0.56 0.12 140) 60%, oklch(0.46 0.10 140) 100%); }
+.mark-L { background: linear-gradient(160deg, oklch(0.74 0.13 245) 0%, oklch(0.56 0.12 245) 60%, oklch(0.46 0.10 245) 100%); }
+.mark-T { background: linear-gradient(160deg, oklch(0.74 0.13 10)  0%, oklch(0.56 0.12 10)  60%, oklch(0.46 0.10 10)  100%); }
+
+/* ─── Sections ──────────────────────────────────────────── */
+.section { padding: 140px 0 120px; position: relative; overflow: hidden; }
+.section-ruled { border-top: 1px solid var(--line); }
+.section-elev { background: var(--bg-elev); }
+.section-header { margin-bottom: 56px; max-width: 900px; }
+.section-header.center { text-align: center; max-width: 760px; margin-left: auto; margin-right: auto; }
+.section-header h2 {
+  font-family: var(--display);
+  font-size: 52px;
+  font-weight: 400;
+  letter-spacing: -0.028em;
+  line-height: 1.05;
+}
+.section-sub {
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--ink-mute);
+  margin-top: 20px;
+  max-width: 620px;
+}
+.section-header.center .section-sub { margin-left: auto; margin-right: auto; }
+
+/* ─── Showcase ──────────────────────────────────────────── */
+.showcase-item {
+  display: grid;
+  grid-template-columns: 1fr 1.6fr;
+  gap: 60px;
+  align-items: center;
+  margin-top: 100px;
+}
+.showcase-item:first-of-type { margin-top: 0; }
+.showcase-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: var(--gold);
+  text-transform: uppercase;
+  margin-bottom: 20px;
+}
+.showcase-text h3 {
+  font-family: var(--display);
+  font-size: 38px;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+}
+.showcase-text p {
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--ink-mute);
+  margin-top: 18px;
+}
+.showcase-preview {
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 30px 80px -20px rgba(0,0,0,0.5);
+  height: 520px;
+  background: var(--bg);
+}
+
+/* ─── Preview: Chat ─────────────────────────────────────── */
+.preview-chat { display: flex; flex-direction: column; height: 100%; }
+.preview-topbar {
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--display);
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.preview-messages {
+  flex: 1;
+  overflow: hidden;
+  padding: 28px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.msg-user {
+  align-self: flex-end;
+  max-width: 78%;
+  padding: 11px 16px;
+  background: var(--accent-soft);
+  border: 1px solid var(--line-strong);
+  border-radius: 10px 10px 3px 10px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.msg-agent { display: flex; gap: 12px; }
+.msg-agent-body { flex: 1; }
+.msg-agent-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px; }
+.msg-agent-head .gold { font-family: var(--display); font-size: 14px; }
+.msg-agent-body p { font-size: 14px; line-height: 1.6; margin-bottom: 12px; }
+.msg-agent-body em { font-family: var(--display); }
+.highlight {
+  color: var(--gold);
+  background: var(--gold-soft);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.tool-card {
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 14px;
+  margin-bottom: 12px;
+}
+.tool-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+.tool-head svg { color: var(--gold); flex-shrink: 0; display: inline-block; vertical-align: middle; }
+.tool-head .mono-label { margin-left: auto; }
+.tool-row {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.85;
+  color: var(--ink-mute);
+}
+.tool-row span:last-child { color: var(--ink); }
+.tool-row.coral, .tool-row.coral span:last-child { color: var(--coral); }
+.msg-actions { display: flex; gap: 8px; }
+
+/* ─── Preview: CRM ──────────────────────────────────────── */
+.preview-crm { display: flex; flex-direction: column; height: 100%; }
+.crm-hero { padding: 28px 28px 22px; }
+.crm-hero .mono-label { margin-bottom: 10px; }
+.crm-total {
+  font-family: var(--display);
+  font-size: 38px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.02;
+}
+.crm-sub { font-size: 20px; color: var(--ink-mute); margin-top: 4px; }
+.crm-stages { padding: 0 28px; border-top: 1px solid var(--line); }
+.crm-row {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: 120px 1fr 90px 70px;
+  gap: 16px;
+  align-items: center;
+}
+.crm-name {
+  font-family: var(--display);
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+.crm-bar {
+  height: 2px;
+  background: var(--line);
+  position: relative;
+}
+.crm-bar div {
+  position: absolute;
+  top: 0; left: 0; bottom: 0;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--gold) 100%);
+}
+.crm-val {
+  font-family: var(--display);
+  font-size: 16px;
+  font-weight: 400;
+  text-align: right;
+  letter-spacing: -0.01em;
+}
+
+/* ─── Preview: Onboarding ───────────────────────────────── */
+.preview-onboarding { display: flex; flex-direction: column; height: 100%; }
+.onboard-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 32px;
+}
+.onboard-heading {
+  font-family: var(--display);
+  font-size: 36px;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  margin: 12px 0 28px;
+}
+.onboard-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.provider-card {
+  padding: 16px;
+  border: 1px solid var(--line);
+  background: var(--bg-card);
+  border-radius: 6px;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+.provider-card.selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.provider-card strong {
+  font-family: var(--display);
+  font-size: 17px;
+  letter-spacing: -0.01em;
+  display: block;
+  font-weight: 400;
+}
+.provider-card .muted { font-size: 12px; display: block; margin-top: 2px; }
+.provider-check {
+  width: 26px; height: 26px;
+  border-radius: 4px;
+  background: rgba(245,239,227,0.06);
+  border: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--accent);
+}
+.provider-check.empty { color: var(--ink-dim); }
+
+/* ─── Preview: Heartbeat ────────────────────────────────── */
+.preview-heartbeat { display: flex; flex-direction: column; height: 100%; }
+.heartbeat-body { flex: 1; padding: 24px; overflow: hidden; }
+.heartbeat-section {
+  padding-bottom: 20px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--line);
+}
+.heartbeat-section:last-child { border-bottom: none; margin-bottom: 0; }
+.hb-row {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 10px 0;
+}
+.hb-row:not(:last-child) { border-bottom: 1px solid var(--line); }
+.hb-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  margin-top: 6px;
+  flex-shrink: 0;
+}
+.hb-dot.sage { background: var(--sage); box-shadow: 0 0 6px var(--sage); }
+.hb-dot.gold { background: var(--gold); box-shadow: 0 0 6px var(--gold); }
+.hb-content { flex: 1; }
+.hb-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--display);
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+.hb-desc { font-size: 13px; color: var(--ink-mute); line-height: 1.45; margin-bottom: 4px; }
+.hb-row > .mono-label { white-space: nowrap; margin-top: 4px; }
+
+/* ─── Features grid ─────────────────────────────────────── */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.feature-card {
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+.feature-icon {
+  width: 36px; height: 36px;
+  border-radius: 6px;
+  background: var(--accent-soft);
+  border: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+.feature-icon.accent { color: var(--ink); }
+.feature-icon.gold { color: var(--gold); }
+.feature-title {
+  font-family: var(--display);
+  font-size: 19px;
+  letter-spacing: -0.015em;
+  margin-bottom: 8px;
+}
+.feature-body {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink-mute);
+}
+
+/* ─── Agents section ────────────────────────────────────── */
+.agents-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.agent-spot {
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg-card);
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+}
+.agent-spot .mark { width: 52px; height: 52px; font-size: 27px; }
+.agent-info { flex: 1; padding-top: 2px; }
+.agent-name {
+  font-family: var(--display);
+  font-size: 20px;
+  letter-spacing: -0.015em;
+}
+.agent-info .muted { font-size: 13px; margin-top: 2px; display: block; }
+.agent-stats {
+  display: flex;
+  gap: 18px;
+  margin-top: 16px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: var(--ink-dim);
+  text-transform: uppercase;
+}
+
+/* ─── Integrations ──────────────────────────────────────── */
+.featured-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 60px;
+}
+.featured-card {
+  padding: 36px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: var(--bg-elev);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.featured-glow {
+  position: absolute;
+  top: -80px; right: -80px;
+  width: 260px; height: 260px;
+  background: radial-gradient(circle, var(--accent-glow) 0%, transparent 65%);
+  filter: blur(40px);
+  pointer-events: none;
+}
+.featured-glow.gold {
+  background: radial-gradient(circle, rgba(230,183,98,0.2) 0%, transparent 65%);
+}
+.featured-top {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.featured-badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  text-transform: uppercase;
+  padding: 5px 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: 100px;
+}
+.featured-badge.gold {
+  color: var(--gold);
+  border-color: rgba(230,183,98,0.35);
+}
+.featured-body { position: relative; }
+.featured-tagline {
+  font-family: var(--display);
+  font-size: 30px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin-top: 10px;
+}
+.featured-bullets {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+}
+.bullet {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  font-size: 14px;
+  color: var(--ink-mute);
+  line-height: 1.55;
+}
+.bullet span {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: 8px;
+  flex-shrink: 0;
+}
+.bullet.gold span { background: var(--gold); }
+.also-connected { margin-top: 60px; }
+.integrations-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.integ-item {
+  padding: 20px 22px;
+  background: var(--bg-card);
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+.integ-icon {
+  width: 34px; height: 34px;
+  border-radius: 4px;
+  background: var(--accent-soft);
+  border: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--display);
+  font-size: 15px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+.integ-name { font-size: 14px; }
+.integ-item .mono-label { margin-top: 3px; }
+.docs-link { margin-top: 24px; text-align: right; }
+.docs-link a {
+  font-size: 14px;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-bottom: 1px solid var(--line-strong);
+  padding-bottom: 3px;
+}
+.docs-link a svg { display: inline-block; }
+
+/* ─── Install ───────────────────────────────────────────── */
+.code-block {
+  background: #060708;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 16px 20px;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.7;
+  overflow: auto;
+}
+.install-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 40px;
+  flex-wrap: wrap;
+}
+.install-meta {
+  margin-top: 24px;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--ink-dim);
+  text-transform: uppercase;
+}
+
+/* ─── Footer ────────────────────────────────────────────── */
+.footer {
+  border-top: 1px solid var(--line);
+  padding: 48px 0 36px;
+}
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+.footer-left { display: flex; align-items: center; gap: 16px; }
+.footer-left svg { display: block; }
+.footer-links { display: flex; gap: 22px; }
+.footer-links a {
+  font-size: 13px;
+  color: var(--ink-mute);
+  text-decoration: none;
+}
+.footer-links a:hover { color: var(--ink); }
+
+/* ─── Responsive ────────────────────────────────────────── */
+@media (max-width: 1024px) {
+  .features-grid { grid-template-columns: repeat(2, 1fr); }
+  .showcase-item { grid-template-columns: 1fr; gap: 40px; }
+  .showcase-preview { height: 420px; }
+  .hero-heading { font-size: 56px; }
+  .section-header h2 { font-size: 40px; }
+}
+@media (max-width: 768px) {
+  .container { padding: 0 20px; }
+  .nav-links { display: none; }
+  .hero-heading { font-size: 42px; }
+  .hero-sub { font-size: 16px; }
+  .features-grid { grid-template-columns: 1fr; }
+  .agents-grid { grid-template-columns: 1fr; }
+  .featured-grid { grid-template-columns: 1fr; }
+  .integrations-grid { grid-template-columns: 1fr; }
+  .section { padding: 80px 0 60px; }
+  .section-header h2 { font-size: 32px; }
+  .screenshot-chrome { margin-left: 0; margin-right: 0; }
+  .screenshot-body { height: 400px; }
+  .dash-grid { grid-template-columns: 1fr; }
+  .crm-row { grid-template-columns: 100px 1fr 70px; }
+  .crm-row .mono-label { display: none; }
+  .footer-inner { flex-direction: column; text-align: center; }
+  .footer-links { flex-wrap: wrap; justify-content: center; }
+}


### PR DESCRIPTION
## Summary

- **Landing page** for mechatty.com — Aurelia design system with product showcase (Chat, CRM, Onboarding, Heartbeat), features grid, agents spotlight, integrations section (Odoo + Telegram featured), and install instructions
- **OAuth callback proxy** at auth.mechatty.com — PHP script that receives Google's OAuth redirect and forwards the auth code to the originating Chatty instance, enabling a single redirect URI for all deployments
- **Backend OAuth change** — `start_oauth_flow()` encodes instance callback URL in the state parameter when `OAUTH_REDIRECT_URI` is set (backward-compatible, no-op without the env var)
- **Auto-deploy workflow** — GitHub Actions deploys `website/` to Pair Networks via FTP on merge to master

## Test plan

- [ ] Open `website/index.html` locally and verify all sections render correctly
- [ ] Verify OAuth proxy logic: state decoding, URL validation, domain allowlist, redirect
- [ ] After merge, confirm deploy workflow runs and files appear on mechatty.com
- [ ] Set `OAUTH_REDIRECT_URI=https://auth.mechatty.com/callback` on a Railway deployment and test Google OAuth flow end-to-end