### PR TITLE
Website sales section and cross-tool sales playbook

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ Mounts all routers, initializes databases, sets up CORS and APScheduler.
 import contextvars
 import logging
 import os
+import shutil
 import uuid as _uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -114,6 +115,16 @@ async def lifespan(app: FastAPI):
 
     from core.agents.shared_context.db import init_db as init_shared_context_db
     _safe_init("shared_context", init_shared_context_db)
+
+    from core.agents.shared_context.db import DATA_DIR as _shared_dir
+    _seed_dir = Path(__file__).parent / "seed" / "shared"
+    if _seed_dir.exists():
+        _shared_dir.mkdir(parents=True, exist_ok=True)
+        for _sf in _seed_dir.glob("*.md"):
+            _target = _shared_dir / _sf.name
+            if not _target.exists():
+                shutil.copy2(_sf, _target)
+                logger.info("Seeded shared context: %s", _sf.name)
 
     from core.agents.tool_config_db import init_db as init_tool_config_db
     _safe_init("tool_configs", init_tool_config_db)

--- a/backend/seed/shared/sales-workflow.md
+++ b/backend/seed/shared/sales-workflow.md
@@ -1,0 +1,70 @@
+# Sales Workflow — Cross-Tool Playbook
+
+This guide defines how your tools work together to build and manage the sales pipeline. Use it as your default framework when handling sales-related tasks.
+
+## The Sales Loop
+
+### 1. Capture — CRM + Gmail
+When a new inquiry arrives (email, Telegram, WhatsApp):
+- Check CRM for an existing contact (`crm_find_contact`)
+- If new: create the contact (`crm_create_contact`) with source, company, and notes
+- Create a deal (`crm_create_deal`) with estimated value and stage "Lead"
+- Log the initial interaction (`crm_log_activity` type: "email" or "note")
+
+### 2. Qualify — CRM + Gmail
+As you learn more about the prospect:
+- Update deal stage to "Qualified" (`crm_update_deal_stage`)
+- Update contact details as you learn them (`crm_update_contact`)
+- Log every call, email, or meeting as a CRM activity
+- Create tasks for follow-ups with due dates (`crm_create_task`)
+
+### 3. Propose — CRM + Gmail + QuickBooks/Odoo
+When it's time to send a proposal:
+- Move deal to "Proposal" stage
+- If QuickBooks is connected: create an estimate for the deal value
+- If Odoo is connected: create a quotation via the sales module
+- Email the proposal via Gmail (`send_email`)
+- Create a follow-up task (3 days out)
+
+### 4. Negotiate — CRM + Gmail
+During negotiation:
+- Move deal to "Negotiation"
+- Update deal value and probability as terms change
+- Log every touchpoint as a CRM activity
+- Watch for stalled deals — if no activity in 5+ days, flag and follow up
+
+### 5. Close — CRM + QuickBooks/Odoo
+When the deal closes:
+- Move deal to "Won" (or "Lost" with notes on why)
+- If QuickBooks: convert estimate to invoice
+- If Odoo: confirm the sales order and create an invoice
+- Log the close activity
+- Create onboarding or delivery tasks if needed
+
+## Cross-Tool Quick Reference
+
+| When this happens...              | Do this...                                        |
+|-----------------------------------|---------------------------------------------------|
+| New email from unknown sender     | Check CRM → create contact + deal if new          |
+| Email from existing contact       | Log as CRM activity, check for open deals         |
+| Meeting scheduled                 | Log as CRM activity, link to deal if relevant     |
+| Task comes due                    | Follow up via Gmail, update CRM                   |
+| Deal closes (won)                 | Create QuickBooks/Odoo invoice                    |
+| Deal closes (lost)               | Log reason in deal notes, update contact status   |
+
+## Stale Deal Rules
+- **5 days** no activity on a Lead or Qualified deal → send a follow-up email
+- **3 days** no response after Proposal sent → nudge with a follow-up
+- **7 days** stalled in Negotiation → flag to the user as at-risk
+
+## BambooHR
+When staffing or capacity questions come up during sales:
+- Check team availability before committing to delivery dates
+- Look up employee skills when scoping project work
+- Use org structure to identify who would handle the account
+
+## Key Principles
+- **Always log**: every email, call, and meeting gets a CRM activity entry
+- **Always task**: if something needs to happen later, create a CRM task with a due date
+- **Always update**: deal values, stages, and contact details stay current in real time
+- **Proactive, not reactive**: don't wait to be asked — flag stale deals, suggest follow-ups, keep the pipeline moving

--- a/website/index.html
+++ b/website/index.html
@@ -32,6 +32,7 @@
     </a>
     <div class="nav-links">
       <a href="#product">Product</a>
+      <a href="#sales">Sales</a>
       <a href="#agents">Agents</a>
       <a href="#integrations">Integrations</a>
       <a href="#install">Docs</a>
@@ -354,6 +355,88 @@
         </div>
         <div class="feature-title">Deploy anywhere</div>
         <div class="feature-body">One-click to Railway, or run it on a spare Raspberry Pi. Anywhere Python runs, Chatty runs.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── Sales ───────────────────────────────────────────── -->
+<section id="sales" class="section section-ruled">
+  <div class="container">
+    <div class="section-header">
+      <div class="eyebrow">Sales</div>
+      <h2>No sales, <em>no business.</em></h2>
+      <p class="section-sub">Selling is the most important thing in small business. Figuring out how to build your sales process is figuring out how to build your small business. Leverage Chatty and AI to streamline and grow your sales.</p>
+    </div>
+
+    <div class="sales-grid">
+      <div class="sales-card">
+        <div class="sales-num gold">01</div>
+        <h4>Capture everything</h4>
+        <p>No matter where it comes from &mdash; email, Telegram, or anywhere else &mdash; leverage your AI team to capture every lead. They log the conversation and add a new lead or deal to your pipeline automatically.</p>
+      </div>
+      <div class="sales-card">
+        <div class="sales-num gold">02</div>
+        <h4>Remember everything</h4>
+        <p>Follow up with every lead with perfection. Never forget a task. Proposal due Friday? No problem &mdash; your AI creates the task and reminds you when things are due. Deals never stall because someone is always watching and helping you move your sales forward.</p>
+      </div>
+      <div class="sales-card">
+        <div class="sales-num gold">03</div>
+        <h4>Close more deals</h4>
+        <p>When it's time to close business, it's your turn. You have all the information you need at your fingertips. Your pipeline is current, and you know exactly where everyone stands.</p>
+      </div>
+    </div>
+
+    <div class="sales-activity">
+      <div class="sales-activity-header">
+        <div class="sales-activity-agent">
+          <div class="mark mark-L" style="width:26px;height:26px;font-size:13px;border-radius:5px">L</div>
+          <span>Lior</span>
+          <span class="mono-label">Inbound Sales</span>
+        </div>
+        <span class="mono-label">Today</span>
+      </div>
+      <div class="sales-activity-body">
+        <div class="sa-row">
+          <div class="sa-time mono-label">7:12 AM</div>
+          <div class="sa-dot gold"></div>
+          <div class="sa-content">
+            <div class="sa-action">Created contact <span class="gold">Maria Chen</span> from inbound email</div>
+            <div class="sa-detail mono-label">Added to pipeline &middot; Lead &middot; $4,200</div>
+          </div>
+        </div>
+        <div class="sa-row">
+          <div class="sa-time mono-label">7:14 AM</div>
+          <div class="sa-dot sage"></div>
+          <div class="sa-content">
+            <div class="sa-action">Replied to Maria with pricing overview and next steps</div>
+            <div class="sa-detail mono-label">Gmail &middot; Draft approved by you yesterday</div>
+          </div>
+        </div>
+        <div class="sa-row">
+          <div class="sa-time mono-label">9:30 AM</div>
+          <div class="sa-dot gold"></div>
+          <div class="sa-content">
+            <div class="sa-action">Moved <span class="gold">Harbor Bistro</span> from Proposal &rarr; Negotiation</div>
+            <div class="sa-detail mono-label">Deal value &middot; $12,600 &middot; Expected close May 2</div>
+          </div>
+        </div>
+        <div class="sa-row">
+          <div class="sa-time mono-label">11:45 AM</div>
+          <div class="sa-dot coral"></div>
+          <div class="sa-content">
+            <div class="sa-action">Flagged <span class="coral">Sunset Catering</span> &mdash; no response in 7 days</div>
+            <div class="sa-detail mono-label">Created follow-up task &middot; Priority: high</div>
+          </div>
+        </div>
+        <div class="sa-row">
+          <div class="sa-time mono-label">2:00 PM</div>
+          <div class="sa-dot sage"></div>
+          <div class="sa-content">
+            <div class="sa-action">Sent follow-up to <span class="gold">Ocean View Caf&eacute;</span> with revised proposal</div>
+            <div class="sa-detail mono-label">Gmail &middot; Proposal &middot; $8,400</div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/website/style.css
+++ b/website/style.css
@@ -676,6 +676,87 @@ em { font-style: italic; }
   color: var(--ink-mute);
 }
 
+/* ─── Sales section ────────────────────────────────────── */
+.sales-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-bottom: 60px;
+}
+.sales-card {
+  padding: 32px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+.sales-num {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  margin-bottom: 20px;
+}
+.sales-card h4 {
+  font-family: var(--display);
+  font-size: 22px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+}
+.sales-card p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--ink-mute);
+}
+.sales-activity {
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--bg-elev);
+  box-shadow: 0 30px 80px -20px rgba(0,0,0,0.5);
+}
+.sales-activity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-card);
+}
+.sales-activity-agent {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--display);
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.sales-activity-body { padding: 4px 0; }
+.sa-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 14px 24px;
+}
+.sa-row:not(:last-child) { border-bottom: 1px solid var(--line); }
+.sa-time {
+  width: 70px;
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+.sa-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-top: 7px;
+  flex-shrink: 0;
+}
+.sa-dot.gold { background: var(--gold); box-shadow: 0 0 6px var(--gold); }
+.sa-dot.sage { background: var(--sage); box-shadow: 0 0 6px var(--sage); }
+.sa-dot.coral { background: var(--coral); box-shadow: 0 0 6px var(--coral); }
+.sa-content { flex: 1; }
+.sa-action { font-size: 14px; line-height: 1.5; }
+.sa-detail { margin-top: 4px; }
+
 /* ─── Agents section ────────────────────────────────────── */
 .agents-grid {
   display: grid;
@@ -1022,6 +1103,10 @@ em { font-style: italic; }
   .hero-heading { font-size: 42px; }
   .hero-sub { font-size: 16px; }
   .features-grid { grid-template-columns: 1fr; }
+  .sales-grid { grid-template-columns: 1fr; }
+  .sa-time { width: 56px; font-size: 9px; }
+  .sa-row { padding: 12px 16px; gap: 10px; }
+  .sales-activity-header { padding: 14px 16px; }
   .agents-grid { grid-template-columns: 1fr; }
   .featured-grid { grid-template-columns: 1fr; }
   .integrations-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- Add dedicated **Sales section** to the marketing website with "No sales, no business" messaging, three value-prop cards (Capture everything, Remember everything, Close more deals), and a Lior activity log showing agent-driven pipeline management throughout the day
- Add **sales-workflow.md** shared context playbook that gives all agents a framework for combining CRM, Gmail, QuickBooks, Odoo, and BambooHR into a 5-stage sales process (Capture → Qualify → Propose → Negotiate → Close)
- Add **seed file mechanism** in startup that copies default shared context files from `backend/seed/shared/` to `data/shared/` on first run

## Test plan
- [ ] Open `website/index.html` in browser — verify Sales section renders between Features and Agents
- [ ] Check responsive layout at mobile breakpoints (768px and below)
- [ ] Verify nav "Sales" link scrolls to the new section
- [ ] Start backend (`python run.py`) — verify `sales-workflow.md` is copied to `data/shared/`
- [ ] Confirm agents see the playbook in their shared context manifest