### PR TITLE
Route OAuth through auth.mechatty.com proxy by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ OPENAI_CLIENT_SECRET=
 
 # ─── QuickBooks OAuth ────────────────────────────────────────────────────────
 # Create an app at developer.intuit.com
-# Redirect URI: {BACKEND_URL}/api/oauth/callback (or ngrok equivalent)
+# Redirect URI in Intuit portal: https://auth.mechatty.com/callback
 QUICKBOOKS_CLIENT_ID=
 QUICKBOOKS_CLIENT_SECRET=
 # Defaults to sandbox. For production: https://quickbooks.api.intuit.com/v3/company
@@ -48,9 +48,9 @@ WHATSAPP_BRIDGE_API_KEY=
 WHATSAPP_WEBHOOK_SECRET=
 
 # ─── OAuth Proxy ─────────────────────────────────────────────────────────────
-# Universal redirect URI for all deployments (via auth.mechatty.com proxy).
-# When set, the state parameter encodes this instance's callback URL so the
-# proxy knows where to forward the auth code. Leave blank for direct OAuth.
+# All OAuth flows route through auth.mechatty.com by default — no env var needed.
+# Set OAUTH_REDIRECT_URI only to override (e.g. your own proxy, or
+# {BACKEND_URL}/api/oauth/callback for direct mode without a proxy).
 # OAUTH_REDIRECT_URI=https://auth.mechatty.com/callback
 
 # ─── Server ──────────────────────────────────────────────────────────────────

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -52,7 +52,7 @@ These auto-generate if not set. You can override them for extra control:
 |----------|-------------|
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID (for Gmail + Calendar + Drive). Defaults to the Chatty-owned OAuth app provided by the Railway template. |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret (paired with `GOOGLE_CLIENT_ID`) |
-| `OAUTH_REDIRECT_URI` | Override the OAuth callback URL. Auto-computed from `BACKEND_URL` + `/api/oauth/callback` — only set this if you have an unusual networking setup. |
+| `OAUTH_REDIRECT_URI` | Override the OAuth callback URL. Defaults to `https://auth.mechatty.com/callback` (the shared OAuth proxy). Only set this if you run your own proxy or want direct-to-instance OAuth. |
 | `QUICKBOOKS_CLIENT_ID` | QuickBooks OAuth client ID |
 | `QUICKBOOKS_CLIENT_SECRET` | QuickBooks OAuth client secret |
 | `WHATSAPP_BRIDGE_URL` | WhatsApp Baileys bridge URL (advanced) |
@@ -101,10 +101,7 @@ your organization, create your own Google Cloud project:
    - `https://www.googleapis.com/auth/drive.readonly`
    - `https://www.googleapis.com/auth/drive`
 5. **Credentials → Create Credentials → OAuth client ID** → *Web application*
-6. Under **Authorized redirect URIs**, add:
-   - `http://localhost:8000/api/oauth/callback` (for local dev)
-   - `https://<your-railway-domain>/api/oauth/callback` (for your deployed Chatty)
-   - If you use a custom domain, add that too
+6. Under **Authorized redirect URIs**, add `https://auth.mechatty.com/callback`
 7. Copy the **Client ID** and **Client secret**
 8. In Railway, set the `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` env vars to the new values
 9. Trigger a redeploy so the new values take effect

--- a/backend/core/providers/oauth.py
+++ b/backend/core/providers/oauth.py
@@ -1,12 +1,20 @@
 """
-Chatty — PKCE OAuth flow for Google, OpenAI, and QuickBooks.
+Chatty — OAuth flow for Google, OpenAI, and QuickBooks.
 
-Two-step pattern (Railway-compatible):
+All OAuth flows route through the auth.mechatty.com proxy by default.
+The proxy receives the callback from the OAuth provider (Google, Intuit,
+OpenAI), then 302-redirects the auth code to the originating Chatty
+instance. This lets every deployment — local dev, Railway, custom host —
+share a single registered redirect URI without ngrok or per-instance
+callback URLs.
+
+Two-step pattern:
     1. `start_oauth_flow(provider, scopes=..., metadata=...)` returns
        {flow_id, auth_url}. The caller opens auth_url in a popup; the user
-       authorizes with Google/Intuit/OpenAI.
-    2. The provider redirects the user's browser to
-       `{backend_url}/api/oauth/callback?code=...&state=<flow_id>`.
+       authorizes with the provider.
+    2. The provider redirects to auth.mechatty.com/callback, which decodes
+       the instance callback URL from the state parameter and 302-redirects
+       to `{backend_url}/api/oauth/callback?code=...&state=<flow_id>`.
        That FastAPI route calls `complete_oauth_flow(...)` which exchanges
        the code for tokens and stashes them on the OAuthFlow object.
     3. The frontend polls `/api/oauth/flows/{flow_id}/status`; once it
@@ -14,9 +22,8 @@ Two-step pattern (Railway-compatible):
        `/setup/complete` endpoint (e.g. `/api/integrations/quickbooks/setup/complete`)
        which reads the tokens via `consume_flow(flow_id)` and persists them.
 
-This replaces the old "localhost:9876 HTTP server" pattern, which only
-worked when the backend ran on the same machine as the user's browser
-(i.e. local dev, not Railway).
+Set OAUTH_REDIRECT_URI to bypass the proxy (direct mode) or use a
+different proxy.
 """
 
 import base64
@@ -109,12 +116,11 @@ def _cleanup_expired_flows() -> None:
 
 # ── Redirect URI ──────────────────────────────────────────────────────────────
 
+_DEFAULT_REDIRECT_URI = "https://auth.mechatty.com/callback"
+
+
 def redirect_uri() -> str:
-    """Compute the OAuth callback URL — works for both local and Railway."""
-    override = os.getenv("OAUTH_REDIRECT_URI", "")
-    if override:
-        return override
-    return f"{settings.backend_url}{CALLBACK_PATH}"
+    return os.getenv("OAUTH_REDIRECT_URI", "") or _DEFAULT_REDIRECT_URI
 
 
 # ── PKCE helpers ──────────────────────────────────────────────────────────────
@@ -195,7 +201,9 @@ def start_oauth_flow(
     verifier, challenge = _generate_pkce() if use_pkce else (None, None)
     flow_id = secrets.token_urlsafe(32)
 
-    if os.getenv("OAUTH_REDIRECT_URI"):
+    if not os.getenv("OAUTH_REDIRECT_URI", ""):
+        # Proxy mode (default): encode the instance callback in state so the
+        # proxy knows where to forward the auth code.
         instance_callback = f"{settings.backend_url}{CALLBACK_PATH}"
         encoded = base64.urlsafe_b64encode(instance_callback.encode()).rstrip(b"=").decode()
         state = f"{flow_id}:{encoded}"

--- a/backend/core/providers/oauth_callback_router.py
+++ b/backend/core/providers/oauth_callback_router.py
@@ -6,8 +6,9 @@ authorizes. Exchanges the authorization code for tokens server-side, then
 stashes them on an OAuthFlow object keyed by state/flow_id. The frontend
 polls `/api/oauth/flows/{flow_id}/status` to know when to proceed.
 
-This replaces the old localhost:9876 HTTP server pattern so OAuth works
-on cloud deployments (Railway) as well as local dev.
+All OAuth flows route through the auth.mechatty.com proxy by default,
+which forwards the callback here. This works for both local dev and
+cloud deployments.
 """
 
 import html

--- a/docs/quickbooks-setup.md
+++ b/docs/quickbooks-setup.md
@@ -31,11 +31,11 @@ This guide walks you through connecting your QuickBooks Online account to Chatty
 1. On the Keys and credentials page, click the **redirect urls** link (or go to **Settings** in the left sidebar)
 2. Add the following redirect URI:
    ```
-   http://localhost:9876/oauth/callback
+   https://auth.mechatty.com/callback
    ```
 3. Click **Save**
 
-> **Note:** If you've deployed Chatty to Railway or another host, you still use the localhost redirect URI. The OAuth flow opens a browser on your local machine and captures the callback locally.
+> **Note:** This is the same redirect URI for all Chatty instances — local dev and Railway. The auth.mechatty.com proxy securely forwards the OAuth callback to your specific instance. If you're hosting on a different platform, see [Domain Allowlist](#domain-allowlist) below.
 
 ## Step 5: Add Credentials to Chatty
 
@@ -100,3 +100,24 @@ You're likely using Development credentials with the production API URL (or vice
 
 ### Token expired
 QuickBooks access tokens expire after 1 hour. Chatty automatically refreshes them using the refresh token. If refresh fails, reconnect QuickBooks through Settings > Integrations.
+
+## Domain Allowlist
+
+The auth.mechatty.com OAuth proxy validates that callbacks are only forwarded to trusted domains. Currently allowed:
+
+- `*.up.railway.app` — Railway deployments
+- `localhost` / `127.0.0.1` — local development
+
+If you're hosting Chatty on a different domain, the proxy will reject the callback with "Callback domain not allowed." To add your domain, open a pull request adding your domain pattern to `website/auth/callback/index.php`, or message Will directly on [WhatsApp](https://wa.me/qr/TX3OGA6ME6LHD1).
+
+### Advanced: Direct OAuth (bypassing the proxy)
+
+If you prefer not to use the proxy, you can configure QuickBooks OAuth to redirect directly to your instance:
+
+1. In the Intuit developer portal, create your own app and set the redirect URI to `https://your-domain.com/api/oauth/callback`
+2. In your `.env` file, set:
+   ```env
+   OAUTH_REDIRECT_URI=https://your-domain.com/api/oauth/callback
+   ```
+
+This bypasses the proxy entirely — your Intuit app redirects directly to your backend.

--- a/website/auth/callback/index.php
+++ b/website/auth/callback/index.php
@@ -2,9 +2,10 @@
 /**
  * Chatty OAuth Callback Proxy
  *
- * Receives Google's OAuth callback and redirects the auth code to the
- * originating Chatty instance. The instance's callback URL is encoded
- * in the state parameter as: {flow_id}:{base64url(callback_url)}
+ * Universal callback proxy for all OAuth providers (Google, Intuit/QuickBooks,
+ * OpenAI). Receives the provider's callback and redirects the auth code to the
+ * originating Chatty instance. The instance's callback URL is encoded in the
+ * state parameter as: {flow_id}:{base64url(callback_url)}
  */
 
 $ALLOWED_DOMAIN_PATTERNS = [


### PR DESCRIPTION
## Summary
- Make `https://auth.mechatty.com/callback` the default OAuth redirect URI for all providers (QuickBooks, Google, OpenAI) — no `OAUTH_REDIRECT_URI` env var needed
- Replace all ngrok/localhost:9876 references with the shared proxy in docs and config
- Add Domain Allowlist docs section explaining supported platforms (Railway, localhost) and how to request custom domain support

## Test plan
- [ ] Verify `redirect_uri()` returns `https://auth.mechatty.com/callback` with no env vars set
- [ ] Confirm state parameter encodes instance callback in proxy mode (default)
- [ ] Set `OAUTH_REDIRECT_URI` to a direct URL → confirm state is bare `flow_id` (direct mode)
- [ ] End-to-end: connect QuickBooks via auth.mechatty.com once SSL is live
- [ ] Verify Google OAuth still works through the proxy (existing flow)