### PR TITLE
Add agent knowledge import system

### DIFF
--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -87,7 +87,7 @@ def _setup_connection() -> None:
 
     _connection.execute("""
         CREATE TABLE IF NOT EXISTS import_sources (
-            agent_id          TEXT PRIMARY KEY REFERENCES agents(id),
+            agent_id          TEXT PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
             adapter_type      TEXT NOT NULL,
             source_config     TEXT NOT NULL DEFAULT '{}',
             last_imported_at  TEXT,

--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -85,6 +85,16 @@ def _setup_connection() -> None:
         except sqlite3.OperationalError:
             pass
 
+    _connection.execute("""
+        CREATE TABLE IF NOT EXISTS import_sources (
+            agent_id          TEXT PRIMARY KEY REFERENCES agents(id),
+            adapter_type      TEXT NOT NULL,
+            source_config     TEXT NOT NULL DEFAULT '{}',
+            last_imported_at  TEXT,
+            file_hashes       TEXT NOT NULL DEFAULT '{}'
+        );
+    """)
+
     _connection.commit()
     logger.info("Agent registry DB initialized at %s", DB_PATH)
 
@@ -198,6 +208,33 @@ def delete_agent(agent_id: str) -> bool:
         cursor = _get_db().execute("DELETE FROM agents WHERE id = ?", (agent_id,))
         _get_db().commit()
     return cursor.rowcount > 0
+
+
+def get_import_source(agent_id: str) -> dict | None:
+    row = _get_db().execute(
+        "SELECT * FROM import_sources WHERE agent_id = ?", (agent_id,)
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def upsert_import_source(
+    agent_id: str,
+    adapter_type: str,
+    source_config: str = "{}",
+    file_hashes: str = "{}",
+) -> None:
+    with _write_lock:
+        _get_db().execute(
+            """INSERT INTO import_sources (agent_id, adapter_type, source_config, last_imported_at, file_hashes)
+               VALUES (?, ?, ?, datetime('now'), ?)
+               ON CONFLICT(agent_id) DO UPDATE SET
+                   adapter_type = excluded.adapter_type,
+                   source_config = excluded.source_config,
+                   last_imported_at = datetime('now'),
+                   file_hashes = excluded.file_hashes""",
+            (agent_id, adapter_type, source_config, file_hashes),
+        )
+        _get_db().commit()
 
 
 def close_db() -> None:

--- a/backend/agents/import_router.py
+++ b/backend/agents/import_router.py
@@ -34,6 +34,7 @@ async def start_import(body: StartImportRequest, user=Depends(get_current_user))
         raise HTTPException(status_code=400, detail="agent_name is required")
 
     agent = agent_db.create_agent(name)
+    agent_db.update_agent(agent["id"], onboarding_complete=1)
 
     # Seed only the import bootstrap file (not the full template set)
     context_dir = DATA_DIR / agent["slug"] / "context"

--- a/backend/agents/import_router.py
+++ b/backend/agents/import_router.py
@@ -103,10 +103,29 @@ into Chatty's native format.
 
 Present these options clearly in your first message:
 
+- **Drop files** — They can drag and drop .md, .txt, or .zip files into the chat
 - **Paste it** — They can copy and paste markdown content right into the chat
 - **Point me at a folder** — They can give you a path like ~/Downloads/agent-files/
-- **Drop a zip** — They can drag a .zip file of markdown files into the chat
 {openclaw_line}
+
+## Helping users find OpenClaw files
+
+If the user says they're coming from OpenClaw but isn't sure where their files are,
+guide them:
+
+- Default agent workspace: ~/.openclaw/workspace/
+- Additional agents: ~/.openclaw/workspace-{{agent-id}}/
+- Config file listing all agents: ~/.openclaw/openclaw.json
+- Key knowledge files: SOUL.md, IDENTITY.md, USER.md, TOOLS.md, MEMORY.md, HEARTBEAT.md
+- Daily memory logs: memory/ subdirectory with dated .md files
+
+If OpenClaw is on a different computer, tell them to:
+1. Zip up their workspace folder (e.g. zip -r my-agent.zip ~/.openclaw/workspace/)
+2. Transfer the zip to this computer (AirDrop, USB, email, cloud drive)
+3. Drop it into this chat or unzip it and point you at the folder
+
+If it's a CAKE OS backup (a folder named cake-backup-YYYYMMDD-HHMMSS), look for agents
+in both data/{{name}}/ and databases/{{name}}/ subdirectories.
 
 ## Handling backups with multiple agents
 
@@ -187,6 +206,13 @@ def _build_import_opener(agent_name: str, openclaw_agents: list[dict]) -> str:
         lines.append(
             f"\n**OpenClaw** — I found an OpenClaw installation on this machine "
             f"with agents: {names}. Just tell me which one and I'll pull the files automatically."
+        )
+    else:
+        lines.append(
+            "\n**Coming from OpenClaw?** Your knowledge files are in `~/.openclaw/workspace/` "
+            "(or `~/.openclaw/workspace-{agent-id}/` if you have multiple agents). "
+            "Copy that folder to this machine, zip it up, or just drag the `.md` files over. "
+            "Key files to look for: `SOUL.md`, `IDENTITY.md`, `USER.md`, `MEMORY.md`, `TOOLS.md`."
         )
 
     lines.append("\nWhat works best for you?")

--- a/backend/agents/import_router.py
+++ b/backend/agents/import_router.py
@@ -102,11 +102,24 @@ Present these options clearly in your first message:
 - **Drop a zip** — They can drag a .zip file of markdown files into the chat
 {openclaw_line}
 
+## Handling backups with multiple agents
+
+If the scan finds a backup folder with multiple agents (subdirectories like data/jamie/,
+data/connor/, databases/connor/, etc.), list the agent names you found and ask which one
+to import. Once the user picks one, call scan_directory again with the specific agent's
+subdirectory path (e.g. ~/Downloads/backup/data/connor/) to narrow down to just that
+agent's files.
+
+Look in BOTH data/{name}/ and databases/{name}/ — markdown knowledge files may be in
+either location. The data/ folder typically has context files (soul.md, MEMORY.md, etc.)
+and the databases/ folder may have additional ones.
+
 ## Step 2: Walk through files
 
 Read files ONE AT A TIME with read_import_file. After each, narrate what you found in 2-3 sentences.
 
-Order: IDENTITY.md first, then SOUL.md, USER.md, TOOLS.md, MEMORY.md, daily logs.
+Order: soul.md first, then IDENTITY.md, SOUL.md, USER.md, TOOLS.md, MEMORY.md, daily logs.
+If none of those exact names exist, read whatever .md files are available.
 
 After reading IDENTITY.md (or the first personality file), ask:
 "Do you want me to carry this identity forward (same name, vibe, personality), or start fresh —

--- a/backend/agents/import_router.py
+++ b/backend/agents/import_router.py
@@ -1,0 +1,138 @@
+"""Routes for agent knowledge import."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from core.auth import get_current_user
+
+from . import db as agent_db
+from .import_service.adapters.openclaw import discover_openclaw_agents
+from .import_service.adapters.paste import PasteSourceAdapter
+from .import_service import sessions
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/agents/import", tags=["import"])
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "agents"
+
+
+class StartImportRequest(BaseModel):
+    agent_name: str
+
+
+@router.post("/start")
+async def start_import(body: StartImportRequest, user=Depends(get_current_user)):
+    """Create a new agent in Import Mode and return agent + conversation IDs."""
+    name = body.agent_name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="agent_name is required")
+
+    agent = agent_db.create_agent(name)
+
+    # Seed only the import bootstrap file (not the full template set)
+    context_dir = DATA_DIR / agent["slug"] / "context"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    _seed_import_bootstrap(context_dir, name)
+
+    # Create an import-mode conversation
+    from .engine import get_chat_service
+    chat_svc = get_chat_service(agent["slug"])
+    conv = chat_svc.create_conversation(title="Knowledge Import", mode="import")
+
+    # Create a placeholder session (adapter will be set by scan_directory or ingest_pasted_text)
+    placeholder = PasteSourceAdapter("(awaiting source)")
+    session = sessions.create_session(
+        adapter=placeholder,
+        agent_id=agent["id"],
+        conversation_id=conv["id"],
+    )
+
+    return {
+        "agent_id": agent["id"],
+        "agent_slug": agent["slug"],
+        "conversation_id": conv["id"],
+        "session_token": session.token,
+    }
+
+
+@router.get("/openclaw/discover")
+async def discover_openclaw(user=Depends(get_current_user)):
+    """Check for a local OpenClaw installation and return discovered agents."""
+    agents = discover_openclaw_agents()
+    return {
+        "found": len(agents) > 0,
+        "agents": agents,
+    }
+
+
+_IMPORT_BOOTSTRAP = """\
+# Import Mode
+
+You are a new Chatty agent. Your human is importing knowledge from another AI system.
+
+## Your job
+
+Help them bring their knowledge files into Chatty. Start by asking where their files are,
+then walk through each file one at a time, narrate what you find, and rewrite everything
+into Chatty's native format.
+
+## Step 1: Find the files
+
+Present these options clearly in your first message:
+
+- **Paste it** — They can copy and paste markdown content right into the chat
+- **Point me at a folder** — They can give you a path like ~/Downloads/agent-files/
+- **Drop a zip** — They can drag a .zip file of markdown files into the chat
+{openclaw_line}
+
+## Step 2: Walk through files
+
+Read files ONE AT A TIME with read_import_file. After each, narrate what you found in 2-3 sentences.
+
+Order: IDENTITY.md first, then SOUL.md, USER.md, TOOLS.md, MEMORY.md, daily logs.
+
+After reading IDENTITY.md (or the first personality file), ask:
+"Do you want me to carry this identity forward (same name, vibe, personality), or start fresh —
+keeping everything your old agent knew, but developing my own personality?"
+
+Note anything surprising, outdated, or worth adjusting. Ask before making judgment calls.
+
+## Step 3: Write Chatty files
+
+Use write_import_context for each file. Use Chatty's style: first-person, concise, no filler.
+
+Targets:
+- soul.md — Core personality (from SOUL.md + IDENTITY.md)
+- identity.md — Name, vibe, emoji (from IDENTITY.md)
+- user.md — Basic human info (from USER.md)
+- profile.md — Deeper context (from USER.md + MEMORY.md)
+- goals.md — Current projects (from HEARTBEAT.md + MEMORY.md)
+- preferences.md — Communication style (from SOUL.md + MEMORY.md)
+- environment.md — Local setup notes (from TOOLS.md)
+- MEMORY.md — Living fact snapshot (from MEMORY.md + consolidated old daily logs)
+- daily/YYYY-MM-DD.md — Copy recent daily logs (last 30 days)
+
+Skip: BOOTSTRAP.md, AGENTS.md, *.dev.md
+
+## Step 4: Finalize
+
+Ask "Anything to adjust before I wrap up?" Then call finalize_import().
+"""
+
+
+def _seed_import_bootstrap(context_dir: Path, agent_name: str) -> None:
+    openclaw_agents = discover_openclaw_agents()
+    if openclaw_agents:
+        names = ", ".join(f"*{a['name']}*" for a in openclaw_agents)
+        openclaw_line = f"- **OpenClaw** — I found an OpenClaw installation with agents: {names}. Just tell me which one."
+    else:
+        openclaw_line = ""
+
+    content = _IMPORT_BOOTSTRAP.format(openclaw_line=openclaw_line)
+    (context_dir / "_import-bootstrap.md").write_text(content, encoding="utf-8")

--- a/backend/agents/import_router.py
+++ b/backend/agents/import_router.py
@@ -156,11 +156,11 @@ def _build_import_opener(agent_name: str, openclaw_agents: list[dict]) -> str:
         f"Hey! I'm {agent_name} — a brand new agent ready to learn. "
         "Let's bring your knowledge over from another system.\n",
         "Here's how you can get your files to me:\n",
-        "**Paste it** — Copy and paste markdown content right here in the chat. "
-        "Works great for a single file or a quick dump.\n",
+        "**Drop files** — Drag and drop `.md`, `.txt`, or `.zip` files right into the chat window.\n",
+        "**Paste it** — Copy and paste markdown content directly into the chat. "
+        "Works great for a quick dump.\n",
         "**Point me at a folder** — Give me a path like `~/Downloads/agent-files/` "
-        "and I'll scan it for markdown files.\n",
-        "**Drop a zip** — Drag a `.zip` file of markdown files into the chat window.",
+        "and I'll scan it for markdown files.",
     ]
 
     if openclaw_agents:

--- a/backend/agents/import_router.py
+++ b/backend/agents/import_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -39,12 +40,21 @@ async def start_import(body: StartImportRequest, user=Depends(get_current_user))
     # Seed only the import bootstrap file (not the full template set)
     context_dir = DATA_DIR / agent["slug"] / "context"
     context_dir.mkdir(parents=True, exist_ok=True)
-    _seed_import_bootstrap(context_dir, name)
+    openclaw_agents = discover_openclaw_agents()
+    _seed_import_bootstrap(context_dir, name, openclaw_agents)
 
-    # Create an import-mode conversation
+    # Create an import-mode conversation with a seeded opening message
     from .engine import get_chat_service
     chat_svc = get_chat_service(agent["slug"])
     conv = chat_svc.create_conversation(title="Knowledge Import", mode="import")
+    opener = _build_import_opener(name, openclaw_agents)
+    chat_svc.save_message(
+        conversation_id=conv["id"],
+        msg_id=str(uuid.uuid4()),
+        role="assistant",
+        content=opener,
+        seq=0,
+    )
 
     # Create a placeholder session (adapter will be set by scan_directory or ingest_pasted_text)
     placeholder = PasteSourceAdapter("(awaiting source)")
@@ -127,8 +137,9 @@ Ask "Anything to adjust before I wrap up?" Then call finalize_import().
 """
 
 
-def _seed_import_bootstrap(context_dir: Path, agent_name: str) -> None:
-    openclaw_agents = discover_openclaw_agents()
+def _seed_import_bootstrap(context_dir: Path, agent_name: str, openclaw_agents: list[dict] | None = None) -> None:
+    if openclaw_agents is None:
+        openclaw_agents = discover_openclaw_agents()
     if openclaw_agents:
         names = ", ".join(f"*{a['name']}*" for a in openclaw_agents)
         openclaw_line = f"- **OpenClaw** — I found an OpenClaw installation with agents: {names}. Just tell me which one."
@@ -137,3 +148,28 @@ def _seed_import_bootstrap(context_dir: Path, agent_name: str) -> None:
 
     content = _IMPORT_BOOTSTRAP.format(openclaw_line=openclaw_line)
     (context_dir / "_import-bootstrap.md").write_text(content, encoding="utf-8")
+
+
+def _build_import_opener(agent_name: str, openclaw_agents: list[dict]) -> str:
+    """Build the agent's opening message for the import conversation."""
+    lines = [
+        f"Hey! I'm {agent_name} — a brand new agent ready to learn. "
+        "Let's bring your knowledge over from another system.\n",
+        "Here's how you can get your files to me:\n",
+        "**Paste it** — Copy and paste markdown content right here in the chat. "
+        "Works great for a single file or a quick dump.\n",
+        "**Point me at a folder** — Give me a path like `~/Downloads/agent-files/` "
+        "and I'll scan it for markdown files.\n",
+        "**Drop a zip** — Drag a `.zip` file of markdown files into the chat window.",
+    ]
+
+    if openclaw_agents:
+        names = ", ".join(f"**{a['name']}**" for a in openclaw_agents)
+        lines.append(
+            f"\n**OpenClaw** — I found an OpenClaw installation on this machine "
+            f"with agents: {names}. Just tell me which one and I'll pull the files automatically."
+        )
+
+    lines.append("\nWhat works best for you?")
+
+    return "\n\n".join(lines)

--- a/backend/agents/import_router.py
+++ b/backend/agents/import_router.py
@@ -35,34 +35,40 @@ async def start_import(body: StartImportRequest, user=Depends(get_current_user))
         raise HTTPException(status_code=400, detail="agent_name is required")
 
     agent = agent_db.create_agent(name)
-    agent_db.update_agent(agent["id"], onboarding_complete=1)
 
-    # Seed only the import bootstrap file (not the full template set)
-    context_dir = DATA_DIR / agent["slug"] / "context"
-    context_dir.mkdir(parents=True, exist_ok=True)
-    openclaw_agents = discover_openclaw_agents()
-    _seed_import_bootstrap(context_dir, name, openclaw_agents)
+    try:
+        agent_db.update_agent(agent["id"], onboarding_complete=1)
 
-    # Create an import-mode conversation with a seeded opening message
-    from .engine import get_chat_service
-    chat_svc = get_chat_service(agent["slug"])
-    conv = chat_svc.create_conversation(title="Knowledge Import", mode="import")
-    opener = _build_import_opener(name, openclaw_agents)
-    chat_svc.save_message(
-        conversation_id=conv["id"],
-        msg_id=str(uuid.uuid4()),
-        role="assistant",
-        content=opener,
-        seq=0,
-    )
+        context_dir = DATA_DIR / agent["slug"] / "context"
+        context_dir.mkdir(parents=True, exist_ok=True)
+        openclaw_agents = discover_openclaw_agents()
+        _seed_import_bootstrap(context_dir, name, openclaw_agents)
 
-    # Create a placeholder session (adapter will be set by scan_directory or ingest_pasted_text)
-    placeholder = PasteSourceAdapter("(awaiting source)")
-    session = sessions.create_session(
-        adapter=placeholder,
-        agent_id=agent["id"],
-        conversation_id=conv["id"],
-    )
+        from .engine import get_chat_service
+        chat_svc = get_chat_service(agent["slug"])
+        conv = chat_svc.create_conversation(title="Knowledge Import", mode="import")
+        opener = _build_import_opener(name, openclaw_agents)
+        chat_svc.save_message(
+            conversation_id=conv["id"],
+            msg_id=str(uuid.uuid4()),
+            role="assistant",
+            content=opener,
+            seq=0,
+        )
+
+        placeholder = PasteSourceAdapter("(awaiting source)")
+        session = sessions.create_session(
+            adapter=placeholder,
+            agent_id=agent["id"],
+            conversation_id=conv["id"],
+        )
+    except Exception:
+        agent_db.delete_agent(agent["id"])
+        import shutil
+        agent_dir = DATA_DIR / agent["slug"]
+        if agent_dir.is_dir():
+            shutil.rmtree(agent_dir, ignore_errors=True)
+        raise
 
     return {
         "agent_id": agent["id"],
@@ -110,7 +116,7 @@ to import. Once the user picks one, call scan_directory again with the specific 
 subdirectory path (e.g. ~/Downloads/backup/data/connor/) to narrow down to just that
 agent's files.
 
-Look in BOTH data/{name}/ and databases/{name}/ — markdown knowledge files may be in
+Look in BOTH data/{{name}}/ and databases/{{name}}/ — markdown knowledge files may be in
 either location. The data/ folder typically has context files (soul.md, MEMORY.md, etc.)
 and the databases/ folder may have additional ones.
 

--- a/backend/agents/import_service/adapters/base.py
+++ b/backend/agents/import_service/adapters/base.py
@@ -1,0 +1,42 @@
+"""Base class for import source adapters."""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+
+
+@dataclass
+class FileEntry:
+    path: str
+    size_bytes: int
+    mtime: float | None = None
+
+
+@dataclass
+class SourceInfo:
+    agent_name: str | None
+    file_count: int
+    total_bytes: int
+
+
+class SourceAdapter(abc.ABC):
+    """Reads knowledge files from an external agent source."""
+
+    @abc.abstractmethod
+    def discover(self) -> SourceInfo:
+        """Probe the source and return summary info."""
+
+    @abc.abstractmethod
+    def list_files(self) -> list[FileEntry]:
+        """List available files (already filtered by skip rules)."""
+
+    @abc.abstractmethod
+    def read_file(self, path: str) -> str:
+        """Read and return scrubbed file content.
+
+        YAML front-matter is stripped. Secrets are redacted.
+        """
+
+    def close(self) -> None:
+        """Clean up resources (temp dirs, connections). Default is no-op."""

--- a/backend/agents/import_service/adapters/folder.py
+++ b/backend/agents/import_service/adapters/folder.py
@@ -27,10 +27,14 @@ class FolderSourceAdapter(SourceAdapter):
         total = sum(f.size_bytes for f in files)
         return SourceInfo(agent_name=None, file_count=len(files), total_bytes=total)
 
+    MAX_FILES = 200
+
     def list_files(self) -> list[FileEntry]:
         entries: list[FileEntry] = []
-        for dirpath, _dirs, filenames in os.walk(self._root):
-            # Skip hidden directories and common junk
+        _PRUNE_DIRS = {"node_modules", "__pycache__", ".venv", "venv", "dist", "build"}
+        for dirpath, dirs, filenames in os.walk(self._root):
+            dirs[:] = [d for d in dirs if d not in _PRUNE_DIRS and not d.startswith(".")]
+
             rel_dir = Path(dirpath).relative_to(self._root)
             if any(part.startswith(".") for part in rel_dir.parts):
                 continue
@@ -49,6 +53,10 @@ class FolderSourceAdapter(SourceAdapter):
                 except OSError:
                     continue
                 entries.append(FileEntry(path=rel, size_bytes=stat.st_size, mtime=stat.st_mtime))
+                if len(entries) >= self.MAX_FILES:
+                    break
+            if len(entries) >= self.MAX_FILES:
+                break
 
         entries.sort(key=lambda e: e.path)
         return entries

--- a/backend/agents/import_service/adapters/folder.py
+++ b/backend/agents/import_service/adapters/folder.py
@@ -27,7 +27,7 @@ class FolderSourceAdapter(SourceAdapter):
         total = sum(f.size_bytes for f in files)
         return SourceInfo(agent_name=None, file_count=len(files), total_bytes=total)
 
-    MAX_FILES = 200
+    MAX_FILES = 1000
 
     def list_files(self) -> list[FileEntry]:
         entries: list[FileEntry] = []

--- a/backend/agents/import_service/adapters/folder.py
+++ b/backend/agents/import_service/adapters/folder.py
@@ -6,11 +6,8 @@ import os
 import re
 from pathlib import Path
 
-from ..scrubber import scrub, should_skip_file
+from ..scrubber import scrub, should_skip_file, FRONT_MATTER_RE
 from .base import FileEntry, SourceAdapter, SourceInfo
-
-_FRONT_MATTER_RE = re.compile(r"^---\n[\s\S]*?\n---\n?")
-_BINARY_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".ico", ".db", ".sqlite", ".wasm", ".zip", ".tar", ".gz"}
 
 
 class FolderSourceAdapter(SourceAdapter):
@@ -42,8 +39,6 @@ class FolderSourceAdapter(SourceAdapter):
                 full = Path(dirpath) / fname
                 rel = str(full.relative_to(self._root))
 
-                if full.suffix.lower() in _BINARY_EXTENSIONS:
-                    continue
                 if not full.suffix.lower() == ".md":
                     continue
                 if should_skip_file(rel):
@@ -59,14 +54,16 @@ class FolderSourceAdapter(SourceAdapter):
         return entries
 
     def read_file(self, path: str) -> str:
-        if ".." in path or path.startswith("/"):
+        if ".." in path or path.startswith("/") or "\\" in path or "\0" in path:
             raise ValueError(f"Unsafe path: {path}")
 
         full = self._root / path
+        if not full.resolve().is_relative_to(self._root.resolve()):
+            raise ValueError(f"Path escapes source directory: {path}")
         if not full.is_file():
             raise FileNotFoundError(f"File not found: {path}")
 
         raw = full.read_text(encoding="utf-8", errors="replace")
-        stripped = _FRONT_MATTER_RE.sub("", raw, count=1)
+        stripped = FRONT_MATTER_RE.sub("", raw, count=1)
         scrubbed, _ = scrub(stripped)
         return scrubbed

--- a/backend/agents/import_service/adapters/folder.py
+++ b/backend/agents/import_service/adapters/folder.py
@@ -1,0 +1,72 @@
+"""Source adapter that reads markdown files from a local directory."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from ..scrubber import scrub, should_skip_file
+from .base import FileEntry, SourceAdapter, SourceInfo
+
+_FRONT_MATTER_RE = re.compile(r"^---\n[\s\S]*?\n---\n?")
+_BINARY_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".ico", ".db", ".sqlite", ".wasm", ".zip", ".tar", ".gz"}
+
+
+class FolderSourceAdapter(SourceAdapter):
+    """Walk a local directory and return scrubbed .md files."""
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root).expanduser().resolve()
+        if not self._root.is_dir():
+            raise FileNotFoundError(f"Not a directory: {self._root}")
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def discover(self) -> SourceInfo:
+        files = self.list_files()
+        total = sum(f.size_bytes for f in files)
+        return SourceInfo(agent_name=None, file_count=len(files), total_bytes=total)
+
+    def list_files(self) -> list[FileEntry]:
+        entries: list[FileEntry] = []
+        for dirpath, _dirs, filenames in os.walk(self._root):
+            # Skip hidden directories and common junk
+            rel_dir = Path(dirpath).relative_to(self._root)
+            if any(part.startswith(".") for part in rel_dir.parts):
+                continue
+
+            for fname in filenames:
+                full = Path(dirpath) / fname
+                rel = str(full.relative_to(self._root))
+
+                if full.suffix.lower() in _BINARY_EXTENSIONS:
+                    continue
+                if not full.suffix.lower() == ".md":
+                    continue
+                if should_skip_file(rel):
+                    continue
+
+                try:
+                    stat = full.stat()
+                except OSError:
+                    continue
+                entries.append(FileEntry(path=rel, size_bytes=stat.st_size, mtime=stat.st_mtime))
+
+        entries.sort(key=lambda e: e.path)
+        return entries
+
+    def read_file(self, path: str) -> str:
+        if ".." in path or path.startswith("/"):
+            raise ValueError(f"Unsafe path: {path}")
+
+        full = self._root / path
+        if not full.is_file():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        raw = full.read_text(encoding="utf-8", errors="replace")
+        stripped = _FRONT_MATTER_RE.sub("", raw, count=1)
+        scrubbed, _ = scrub(stripped)
+        return scrubbed

--- a/backend/agents/import_service/adapters/openclaw.py
+++ b/backend/agents/import_service/adapters/openclaw.py
@@ -45,7 +45,9 @@ def discover_openclaw_agents(
 
         workspace = entry.get("workspace")
         if not workspace:
-            if agent_id == "default":
+            if default_workspace:
+                workspace = str(Path(default_workspace).expanduser())
+            elif agent_id == "default":
                 workspace = str(state_dir / "workspace")
             else:
                 workspace = str(state_dir / f"workspace-{agent_id}")

--- a/backend/agents/import_service/adapters/openclaw.py
+++ b/backend/agents/import_service/adapters/openclaw.py
@@ -1,0 +1,88 @@
+"""Source adapter for local OpenClaw installations.
+
+Reads ~/.openclaw/openclaw.json to discover agents and resolve workspace paths,
+then delegates to FolderSourceAdapter for actual file reading.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from .base import FileEntry, SourceAdapter, SourceInfo
+from .folder import FolderSourceAdapter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATE_DIR = Path.home() / ".openclaw"
+DEFAULT_CONFIG = DEFAULT_STATE_DIR / "openclaw.json"
+
+
+def discover_openclaw_agents(
+    config_path: Path | None = None,
+) -> list[dict]:
+    """Read openclaw.json and return a list of {id, name, workspace} dicts."""
+    path = config_path or DEFAULT_CONFIG
+    if not path.is_file():
+        return []
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        logger.warning("Failed to read OpenClaw config at %s", path)
+        return []
+
+    agents_section = data.get("agents", {})
+    agent_list = agents_section.get("list", [])
+    default_workspace = agents_section.get("defaults", {}).get("workspace")
+    state_dir = path.parent
+
+    results = []
+    for entry in agent_list:
+        agent_id = entry.get("id", "")
+        name = entry.get("name", agent_id)
+
+        workspace = entry.get("workspace")
+        if not workspace:
+            if agent_id == "default":
+                workspace = str(state_dir / "workspace")
+            else:
+                workspace = str(state_dir / f"workspace-{agent_id}")
+        else:
+            workspace = str(Path(workspace).expanduser())
+
+        results.append({"id": agent_id, "name": name, "workspace": workspace})
+
+    return results
+
+
+class OpenClawFolderAdapter(SourceAdapter):
+    """Read files from a specific OpenClaw agent's workspace directory."""
+
+    def __init__(self, agent_id: str, config_path: Path | None = None) -> None:
+        agents = discover_openclaw_agents(config_path)
+        match = next((a for a in agents if a["id"] == agent_id), None)
+        if not match:
+            available = [a["id"] for a in agents]
+            raise ValueError(
+                f"OpenClaw agent '{agent_id}' not found. Available: {available}"
+            )
+
+        self._agent_id = agent_id
+        self._agent_name = match["name"]
+        self._inner = FolderSourceAdapter(match["workspace"])
+
+    def discover(self) -> SourceInfo:
+        info = self._inner.discover()
+        info.agent_name = self._agent_name
+        return info
+
+    def list_files(self) -> list[FileEntry]:
+        return self._inner.list_files()
+
+    def read_file(self, path: str) -> str:
+        return self._inner.read_file(path)
+
+    def close(self) -> None:
+        self._inner.close()

--- a/backend/agents/import_service/adapters/paste.py
+++ b/backend/agents/import_service/adapters/paste.py
@@ -40,9 +40,14 @@ class PasteSourceAdapter(SourceAdapter):
         for i, m in enumerate(headings):
             end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
             title = m.group(1).strip()
-            slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:60]
+            slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:60] or "section"
             content = text[m.start():end].strip()
-            files[f"{slug}.md"] = content
+            key = f"{slug}.md"
+            n = 2
+            while key in files:
+                key = f"{slug}-{n}.md"
+                n += 1
+            files[key] = content
         return files
 
     def discover(self) -> SourceInfo:

--- a/backend/agents/import_service/adapters/paste.py
+++ b/backend/agents/import_service/adapters/paste.py
@@ -1,0 +1,63 @@
+"""Source adapter for pasted markdown text."""
+
+from __future__ import annotations
+
+import re
+
+from ..scrubber import scrub
+from .base import FileEntry, SourceAdapter, SourceInfo
+
+MAX_PASTE_BYTES = 500 * 1024  # 500 KB
+
+_FRONT_MATTER_RE = re.compile(r"^---\n[\s\S]*?\n---\n?")
+_HEADING_RE = re.compile(r"^#\s+(.+)", re.MULTILINE)
+
+
+class PasteSourceAdapter(SourceAdapter):
+    """Treat pasted markdown as one or more logical files.
+
+    If the text contains multiple top-level `# Heading` sections, each becomes
+    a separate file (e.g., ``heading.md``). Otherwise the entire text is treated
+    as a single file named ``pasted.md``.
+    """
+
+    def __init__(self, text: str) -> None:
+        if len(text.encode("utf-8")) > MAX_PASTE_BYTES:
+            raise ValueError(
+                f"Pasted text exceeds {MAX_PASTE_BYTES // 1024} KB limit. "
+                "Use a file or zip instead."
+            )
+
+        stripped = _FRONT_MATTER_RE.sub("", text, count=1)
+        scrubbed, _ = scrub(stripped)
+        self._files = self._split_sections(scrubbed)
+
+    @staticmethod
+    def _split_sections(text: str) -> dict[str, str]:
+        headings = list(_HEADING_RE.finditer(text))
+        if len(headings) < 2:
+            return {"pasted.md": text.strip()}
+
+        files: dict[str, str] = {}
+        for i, m in enumerate(headings):
+            end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
+            title = m.group(1).strip()
+            slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:60]
+            content = text[m.start():end].strip()
+            files[f"{slug}.md"] = content
+        return files
+
+    def discover(self) -> SourceInfo:
+        total = sum(len(c.encode("utf-8")) for c in self._files.values())
+        return SourceInfo(agent_name=None, file_count=len(self._files), total_bytes=total)
+
+    def list_files(self) -> list[FileEntry]:
+        return [
+            FileEntry(path=name, size_bytes=len(content.encode("utf-8")))
+            for name, content in self._files.items()
+        ]
+
+    def read_file(self, path: str) -> str:
+        if path not in self._files:
+            raise FileNotFoundError(f"No pasted section: {path}")
+        return self._files[path]

--- a/backend/agents/import_service/adapters/paste.py
+++ b/backend/agents/import_service/adapters/paste.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import re
 
-from ..scrubber import scrub
+from ..scrubber import scrub, FRONT_MATTER_RE
 from .base import FileEntry, SourceAdapter, SourceInfo
 
 MAX_PASTE_BYTES = 500 * 1024  # 500 KB
-
-_FRONT_MATTER_RE = re.compile(r"^---\n[\s\S]*?\n---\n?")
 _HEADING_RE = re.compile(r"^#\s+(.+)", re.MULTILINE)
 
 
@@ -28,7 +26,7 @@ class PasteSourceAdapter(SourceAdapter):
                 "Use a file or zip instead."
             )
 
-        stripped = _FRONT_MATTER_RE.sub("", text, count=1)
+        stripped = FRONT_MATTER_RE.sub("", text, count=1)
         scrubbed, _ = scrub(stripped)
         self._files = self._split_sections(scrubbed)
 

--- a/backend/agents/import_service/adapters/zip.py
+++ b/backend/agents/import_service/adapters/zip.py
@@ -1,0 +1,64 @@
+"""Source adapter that extracts a zip file to a temp directory."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from .base import FileEntry, SourceAdapter, SourceInfo
+from .folder import FolderSourceAdapter
+
+logger = logging.getLogger(__name__)
+
+MAX_ZIP_SIZE = 25 * 1024 * 1024  # 25 MB
+MAX_FILES = 500
+
+
+class ZipSourceAdapter(SourceAdapter):
+    """Extract a zip archive to a temp directory and read its markdown files."""
+
+    def __init__(self, zip_path: str | Path) -> None:
+        zip_path = Path(zip_path)
+        if not zip_path.is_file():
+            raise FileNotFoundError(f"Zip not found: {zip_path}")
+        if zip_path.stat().st_size > MAX_ZIP_SIZE:
+            raise ValueError(f"Zip exceeds {MAX_ZIP_SIZE // (1024*1024)} MB limit")
+
+        self._tmp = tempfile.mkdtemp(prefix="chatty-import-")
+
+        try:
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                members = zf.namelist()
+                if len(members) > MAX_FILES:
+                    raise ValueError(f"Zip contains {len(members)} files (max {MAX_FILES})")
+                # Skip entries that look like path traversal
+                safe = [m for m in members if not m.startswith("/") and ".." not in m]
+                zf.extractall(self._tmp, members=safe)
+        except Exception:
+            shutil.rmtree(self._tmp, ignore_errors=True)
+            raise
+
+        # Find the actual content root (skip single top-level directory wrappers)
+        root = Path(self._tmp)
+        children = [c for c in root.iterdir() if not c.name.startswith(".")]
+        if len(children) == 1 and children[0].is_dir():
+            root = children[0]
+
+        self._inner = FolderSourceAdapter(root)
+
+    def discover(self) -> SourceInfo:
+        return self._inner.discover()
+
+    def list_files(self) -> list[FileEntry]:
+        return self._inner.list_files()
+
+    def read_file(self, path: str) -> str:
+        return self._inner.read_file(path)
+
+    def close(self) -> None:
+        self._inner.close()
+        shutil.rmtree(self._tmp, ignore_errors=True)
+        logger.info("Cleaned up import temp dir: %s", self._tmp)

--- a/backend/agents/import_service/adapters/zip.py
+++ b/backend/agents/import_service/adapters/zip.py
@@ -38,7 +38,7 @@ class ZipSourceAdapter(SourceAdapter):
                     m for m in members
                     if not m.startswith("/") and ".." not in m and "\\" not in m
                     and not zf.getinfo(m).is_dir()
-                    and not (zf.getinfo(m).external_attr >> 16) & 0o120000 == 0o120000
+                    and ((zf.getinfo(m).external_attr >> 16) & 0o120000) != 0o120000
                 ]
                 total_uncompressed = sum(zf.getinfo(m).file_size for m in safe)
                 if total_uncompressed > 100 * 1024 * 1024:

--- a/backend/agents/import_service/adapters/zip.py
+++ b/backend/agents/import_service/adapters/zip.py
@@ -34,8 +34,15 @@ class ZipSourceAdapter(SourceAdapter):
                 members = zf.namelist()
                 if len(members) > MAX_FILES:
                     raise ValueError(f"Zip contains {len(members)} files (max {MAX_FILES})")
-                # Skip entries that look like path traversal
-                safe = [m for m in members if not m.startswith("/") and ".." not in m]
+                safe = [
+                    m for m in members
+                    if not m.startswith("/") and ".." not in m and "\\" not in m
+                    and not zf.getinfo(m).is_dir()
+                    and not (zf.getinfo(m).external_attr >> 16) & 0o120000 == 0o120000
+                ]
+                total_uncompressed = sum(zf.getinfo(m).file_size for m in safe)
+                if total_uncompressed > 100 * 1024 * 1024:
+                    raise ValueError(f"Uncompressed size {total_uncompressed // (1024*1024)} MB exceeds 100 MB limit")
                 zf.extractall(self._tmp, members=safe)
         except Exception:
             shutil.rmtree(self._tmp, ignore_errors=True)

--- a/backend/agents/import_service/primed_opener.py
+++ b/backend/agents/import_service/primed_opener.py
@@ -1,0 +1,76 @@
+"""Generate the primed opener message for a newly-imported agent.
+
+Uses a one-shot Claude call (same pattern as consolidate_memory) to produce
+a warm 1-2 sentence greeting that demonstrates the agent internalized
+the imported knowledge.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.agents.context_manager import ContextManager
+from core.providers.credentials import CredentialStore
+
+logger = logging.getLogger(__name__)
+
+
+def generate_opener(ctx_manager: ContextManager, agent_name: str) -> str:
+    """Read the agent's freshly-written context and generate a primed greeting.
+
+    Falls back to a generic greeting if no API key is available or the call fails.
+    """
+    context = ctx_manager.load_all_context(agent_name=agent_name)
+    if not context:
+        return _fallback(agent_name)
+
+    store = CredentialStore()
+    _, profile = store.get_active_profile(provider_override="anthropic")
+    api_key = (profile or {}).get("key", "")
+    if not api_key:
+        return _fallback(agent_name)
+
+    system_prompt = (
+        f"You are {agent_name}, an AI agent that just finished importing knowledge "
+        "from another system. Your context files have been populated with personality, "
+        "memory, and user information.\n\n"
+        "Write a warm, natural 1-2 sentence opening message. Demonstrate that you "
+        "absorbed the imported knowledge by referencing something specific — a project, "
+        "a preference, the user's name, or a detail from your memory.\n\n"
+        "Do NOT mention 'importing' or 'migration' or technical details. Just greet "
+        "your human like you already know them. Be yourself.\n\n"
+        "Output ONLY the greeting message, no preamble."
+    )
+
+    user_message = (
+        "Here is your full context (personality, memory, user info, etc.):\n\n"
+        f"{context[:8000]}\n\n"
+        "Now write your opening greeting."
+    )
+
+    try:
+        import anthropic
+        client = anthropic.Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=256,
+            system=system_prompt,
+            messages=[{"role": "user", "content": user_message}],
+        )
+    except Exception as e:
+        logger.warning("Primed opener generation failed: %s", e)
+        return _fallback(agent_name)
+
+    text = ""
+    for block in response.content:
+        if getattr(block, "type", None) == "text":
+            text += block.text
+
+    return text.strip() or _fallback(agent_name)
+
+
+def _fallback(agent_name: str) -> str:
+    return (
+        f"Hey — I'm {agent_name}. I just finished going through everything you "
+        "brought over. Ready to pick up where we left off?"
+    )

--- a/backend/agents/import_service/scrubber.py
+++ b/backend/agents/import_service/scrubber.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 REPLACEMENT = "[REDACTED:credential]"
+FRONT_MATTER_RE = re.compile(r"^---\n[\s\S]*?\n---\n?")
 
 _PATTERNS: list[re.Pattern] = [
     re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),

--- a/backend/agents/import_service/scrubber.py
+++ b/backend/agents/import_service/scrubber.py
@@ -1,0 +1,51 @@
+"""Scrub secrets and credential-like values from text before LLM processing."""
+
+from __future__ import annotations
+
+import re
+
+REPLACEMENT = "[REDACTED:credential]"
+
+_PATTERNS: list[re.Pattern] = [
+    re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    re.compile(r"AIza[A-Za-z0-9_-]{30,}"),
+    re.compile(r"ghp_[A-Za-z0-9]{36,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"xox[abpr]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"(?<![A-Za-z0-9])AKIA[A-Z0-9]{16}"),
+    re.compile(r"gho_[A-Za-z0-9]{36,}"),
+    re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
+    # JWT-shaped: three base64url segments separated by dots
+    re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"),
+    # Generic long hex string tagged as a token/key (preceded by key= or token= etc.)
+    re.compile(r"(?:key|token|secret|password|credential)\s*[=:]\s*['\"]?([A-Fa-f0-9]{32,})['\"]?", re.IGNORECASE),
+]
+
+SKIP_FILENAME_PATTERNS: list[re.Pattern] = [
+    re.compile(r"\.env", re.IGNORECASE),
+    re.compile(r"secret", re.IGNORECASE),
+    re.compile(r"credential", re.IGNORECASE),
+    re.compile(r"\.git[\\/]"),
+    re.compile(r"node_modules[\\/]"),
+    re.compile(r"\.dev\.md$", re.IGNORECASE),
+]
+
+
+def scrub(text: str) -> tuple[str, int]:
+    """Remove credential-like values from text.
+
+    Returns (scrubbed_text, redaction_count).
+    """
+    count = 0
+    for pattern in _PATTERNS:
+        matches = pattern.findall(text)
+        if matches:
+            count += len(matches)
+            text = pattern.sub(REPLACEMENT, text)
+    return text, count
+
+
+def should_skip_file(filename: str) -> bool:
+    """Return True if a filename matches skip patterns."""
+    return any(p.search(filename) for p in SKIP_FILENAME_PATTERNS)

--- a/backend/agents/import_service/sessions.py
+++ b/backend/agents/import_service/sessions.py
@@ -56,13 +56,16 @@ def get_session(token: str) -> ImportSession | None:
 
 
 def get_session_by_conversation(conversation_id: str) -> ImportSession | None:
+    expired_token: str | None = None
     with _lock:
         for s in _sessions.values():
             if s.conversation_id == conversation_id:
                 if (time.time() - s.started_at) > SESSION_TTL:
-                    _sessions.pop(s.token, None)
-                    return None
+                    expired_token = s.token
+                    break
                 return s
+    if expired_token:
+        remove_session(expired_token)
     return None
 
 

--- a/backend/agents/import_service/sessions.py
+++ b/backend/agents/import_service/sessions.py
@@ -1,0 +1,89 @@
+"""In-memory registry of active import sessions."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from .adapters.base import SourceAdapter
+
+logger = logging.getLogger(__name__)
+
+SESSION_TTL = 30 * 60  # 30 minutes
+
+
+@dataclass
+class ImportSession:
+    token: str
+    adapter: SourceAdapter
+    agent_id: str
+    conversation_id: str
+    started_at: float = field(default_factory=time.time)
+    skipped_files: set[str] = field(default_factory=set)
+
+
+_sessions: dict[str, ImportSession] = {}
+_lock = threading.Lock()
+
+
+def create_session(
+    adapter: SourceAdapter,
+    agent_id: str,
+    conversation_id: str,
+) -> ImportSession:
+    token = str(uuid.uuid4())
+    session = ImportSession(
+        token=token,
+        adapter=adapter,
+        agent_id=agent_id,
+        conversation_id=conversation_id,
+    )
+    with _lock:
+        _sessions[token] = session
+    return session
+
+
+def get_session(token: str) -> ImportSession | None:
+    with _lock:
+        session = _sessions.get(token)
+    if session and (time.time() - session.started_at) > SESSION_TTL:
+        remove_session(token)
+        return None
+    return session
+
+
+def get_session_by_conversation(conversation_id: str) -> ImportSession | None:
+    with _lock:
+        for s in _sessions.values():
+            if s.conversation_id == conversation_id:
+                if (time.time() - s.started_at) > SESSION_TTL:
+                    _sessions.pop(s.token, None)
+                    return None
+                return s
+    return None
+
+
+def remove_session(token: str) -> None:
+    with _lock:
+        session = _sessions.pop(token, None)
+    if session:
+        try:
+            session.adapter.close()
+        except Exception:
+            logger.warning("Failed to close adapter for session %s", token)
+
+
+def sweep_expired() -> int:
+    """Remove expired sessions. Returns count removed."""
+    now = time.time()
+    expired: list[str] = []
+    with _lock:
+        for token, session in _sessions.items():
+            if now - session.started_at > SESSION_TTL:
+                expired.append(token)
+    for token in expired:
+        remove_session(token)
+    return len(expired)

--- a/backend/agents/import_service/tool_defs.py
+++ b/backend/agents/import_service/tool_defs.py
@@ -1,0 +1,130 @@
+"""Tool definitions for Import Mode."""
+
+IMPORT_TOOLS = [
+    {
+        "name": "scan_directory",
+        "description": "Scan a local directory for markdown files. Use when the user gives a folder path. Returns a list of found .md files with sizes. Restricted to the user's home directory.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Directory path to scan, e.g. '~/Downloads/agent-files/' or '~/Documents/openclaw-export/'",
+                },
+            },
+            "required": ["path"],
+        },
+        "kind": "import",
+        "writes": False,
+    },
+    {
+        "name": "ingest_pasted_text",
+        "description": "Process markdown text that the user pasted directly into the chat. Call this when the user pastes knowledge content rather than pointing to a file.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The markdown text the user pasted",
+                },
+            },
+            "required": ["text"],
+        },
+        "kind": "import",
+        "writes": False,
+    },
+    {
+        "name": "list_import_files",
+        "description": "List all files available in the current import source (after scan_directory or ingest_pasted_text has been called).",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        "kind": "import",
+        "writes": False,
+    },
+    {
+        "name": "read_import_file",
+        "description": "Read the content of a specific file from the import source. Secrets are automatically redacted.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File path from list_import_files (e.g. 'SOUL.md', 'memory/2026-04-15.md')",
+                },
+            },
+            "required": ["path"],
+        },
+        "kind": "import",
+        "writes": False,
+    },
+    {
+        "name": "skip_import_file",
+        "description": "Mark a file as skipped so it won't be imported.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File path to skip",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Brief reason for skipping",
+                },
+            },
+            "required": ["path"],
+        },
+        "kind": "import",
+        "writes": False,
+    },
+    {
+        "name": "read_existing_context",
+        "description": "Read one of the new agent's existing Chatty context files. Useful during re-import to compare what's already there versus what's being imported.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "description": "Chatty context filename (e.g. 'soul.md', 'MEMORY.md')",
+                },
+            },
+            "required": ["filename"],
+        },
+        "kind": "import",
+        "writes": False,
+    },
+    {
+        "name": "write_import_context",
+        "description": "Write a knowledge file to the new agent's context directory. Use Chatty's style: first-person, concise, no filler. Valid targets: soul.md, identity.md, user.md, profile.md, goals.md, preferences.md, environment.md, MEMORY.md, or daily/{date}.md for daily logs.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "description": "Target filename (e.g. 'soul.md', 'MEMORY.md', 'daily/2026-04-22.md')",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The markdown content to write",
+                },
+            },
+            "required": ["filename", "content"],
+        },
+        "kind": "import",
+        "writes": True,
+    },
+    {
+        "name": "finalize_import",
+        "description": "Complete the import process. Call this after all files have been written. Creates a fresh conversation with a primed opener greeting and marks the agent as ready.",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        "kind": "import",
+        "writes": True,
+    },
+]

--- a/backend/agents/import_service/tool_defs.py
+++ b/backend/agents/import_service/tool_defs.py
@@ -117,6 +117,38 @@ IMPORT_TOOLS = [
         "writes": True,
     },
     {
+        "name": "extract_zip",
+        "description": "Extract a zip file of markdown files uploaded by the user. Call this when a .zip file is attached to the chat. Provide the filename of the attachment.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "description": "The filename of the uploaded zip attachment",
+                },
+            },
+            "required": ["filename"],
+        },
+        "kind": "import",
+        "writes": False,
+    },
+    {
+        "name": "import_openclaw_agent",
+        "description": "Import knowledge from a specific OpenClaw agent. Use when the user picks an OpenClaw agent to import from. The agent must have been discovered via the OpenClaw auto-detection in the opening message.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "The OpenClaw agent ID (e.g. 'default', 'research-bot')",
+                },
+            },
+            "required": ["agent_id"],
+        },
+        "kind": "import",
+        "writes": False,
+    },
+    {
         "name": "finalize_import",
         "description": "Complete the import process. Call this after all files have been written. Creates a fresh conversation with a primed opener greeting and marks the agent as ready.",
         "input_schema": {

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -53,6 +53,8 @@ def _safe_import_filename(filename: str) -> bool:
 def _safe_scan_path(path: str) -> Path:
     """Resolve and validate a path for scan_directory. Must be under user's home."""
     home = Path.home()
+    if home == Path("/"):
+        raise ValueError("Cannot determine safe home directory — running as root is not supported for directory scanning")
     resolved = Path(path).expanduser().resolve()
     if not resolved.is_relative_to(home):
         raise ValueError(f"Path must be under your home directory ({home})")
@@ -364,7 +366,14 @@ def _finalize_import(
     if bootstrap_path.exists():
         bootstrap_path.unlink()
 
-    # 6. Clean up session
+    # 6. Clean up file_cache (uploaded zips)
+    if agent:
+        import shutil
+        file_cache = Path(ctx_manager.data_dir).parent / "file_cache"
+        if file_cache.is_dir():
+            shutil.rmtree(file_cache, ignore_errors=True)
+
+    # 7. Clean up session
     sessions.remove_session(session.token)
 
     return {

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -373,7 +373,15 @@ def _finalize_import(
         if file_cache.is_dir():
             shutil.rmtree(file_cache, ignore_errors=True)
 
-    # 7. Clean up session
+    # 7. Reindex memory DB so imported context is searchable
+    if agent:
+        try:
+            from agents.engine import ensure_memory_db
+            ensure_memory_db(agent["slug"])
+        except Exception:
+            logger.warning("Could not reindex memory DB after import")
+
+    # 8. Clean up session
     sessions.remove_session(session.token)
 
     return {

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -1,0 +1,285 @@
+"""Import tool execution handlers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from pathlib import Path
+
+from core.agents.context_manager import ContextManager
+
+from . import sessions
+from .adapters.folder import FolderSourceAdapter
+from .adapters.paste import PasteSourceAdapter
+from .scrubber import scrub
+
+logger = logging.getLogger(__name__)
+
+_BLOCKED_CHATTY_FILES = {
+    "_bootstrap.md", "_guide.md", "_integration-setup.md",
+    "_pending-setup.md", "_onboarding-progress.md", "_import-bootstrap.md",
+    "_load-order.json",
+}
+
+_ALLOWED_WRITE_TARGETS = {
+    "soul.md", "identity.md", "user.md", "profile.md",
+    "goals.md", "preferences.md", "environment.md", "MEMORY.md",
+    "background.md",
+}
+
+_DAILY_RE = re.compile(r"^daily/\d{4}-\d{2}-\d{2}\.md$")
+
+
+def _safe_import_filename(filename: str) -> bool:
+    if not filename:
+        return False
+    if ".." in filename or filename.startswith("/") or "\\" in filename:
+        return False
+    if filename in _BLOCKED_CHATTY_FILES:
+        return False
+    if filename in _ALLOWED_WRITE_TARGETS:
+        return True
+    if _DAILY_RE.match(filename):
+        return True
+    if filename.startswith("imported-") and filename.endswith(".md"):
+        return True
+    return False
+
+
+def _safe_scan_path(path: str) -> Path:
+    """Resolve and validate a path for scan_directory. Must be under user's home."""
+    home = Path.home()
+    resolved = Path(path).expanduser().resolve()
+    if not str(resolved).startswith(str(home)):
+        raise ValueError(f"Path must be under your home directory ({home})")
+    for blocked in ("/etc", "/var", "/usr", "/System", "/Library"):
+        if str(resolved).startswith(blocked):
+            raise ValueError(f"Cannot scan system directory: {blocked}")
+    if not resolved.is_dir():
+        raise FileNotFoundError(f"Directory not found: {resolved}")
+    return resolved
+
+
+def execute_import_tool(
+    tool_name: str,
+    args: dict,
+    session: sessions.ImportSession | None,
+    ctx_manager: ContextManager,
+) -> dict:
+    try:
+        if tool_name == "scan_directory":
+            return _scan_directory(args, session, ctx_manager)
+        elif tool_name == "ingest_pasted_text":
+            return _ingest_pasted_text(args, session, ctx_manager)
+        elif tool_name == "list_import_files":
+            return _list_import_files(session)
+        elif tool_name == "read_import_file":
+            return _read_import_file(args, session)
+        elif tool_name == "skip_import_file":
+            return _skip_import_file(args, session)
+        elif tool_name == "read_existing_context":
+            return _read_existing_context(args, ctx_manager)
+        elif tool_name == "write_import_context":
+            return _write_import_context(args, ctx_manager)
+        elif tool_name == "finalize_import":
+            return _finalize_import(session, ctx_manager)
+        else:
+            return {"error": f"Unknown import tool: {tool_name}"}
+    except Exception as e:
+        logger.exception("Import tool %s failed", tool_name)
+        return {"error": str(e)}
+
+
+def _scan_directory(
+    args: dict,
+    session: sessions.ImportSession | None,
+    ctx_manager: ContextManager,
+) -> dict:
+    path_str = args.get("path", "")
+    resolved = _safe_scan_path(path_str)
+
+    adapter = FolderSourceAdapter(resolved)
+
+    if session:
+        try:
+            session.adapter.close()
+        except Exception:
+            pass
+        session.adapter = adapter
+    else:
+        return {"error": "No active import session. Please restart the import."}
+
+    files = adapter.list_files()
+    return {
+        "found": len(files),
+        "files": [{"path": f.path, "size_bytes": f.size_bytes} for f in files],
+        "source_path": str(resolved),
+    }
+
+
+def _ingest_pasted_text(
+    args: dict,
+    session: sessions.ImportSession | None,
+    ctx_manager: ContextManager,
+) -> dict:
+    text = args.get("text", "")
+    if not text.strip():
+        return {"error": "No text provided"}
+
+    adapter = PasteSourceAdapter(text)
+
+    if session:
+        try:
+            session.adapter.close()
+        except Exception:
+            pass
+        session.adapter = adapter
+    else:
+        return {"error": "No active import session. Please restart the import."}
+
+    files = adapter.list_files()
+    return {
+        "found": len(files),
+        "files": [{"path": f.path, "size_bytes": f.size_bytes} for f in files],
+    }
+
+
+def _list_import_files(session: sessions.ImportSession | None) -> dict:
+    if not session:
+        return {"error": "No active import session."}
+
+    files = session.adapter.list_files()
+    return {
+        "files": [
+            {
+                "path": f.path,
+                "size_bytes": f.size_bytes,
+                "skipped": f.path in session.skipped_files,
+            }
+            for f in files
+        ],
+    }
+
+
+def _read_import_file(args: dict, session: sessions.ImportSession | None) -> dict:
+    if not session:
+        return {"error": "No active import session."}
+
+    path = args.get("path", "")
+    if path in session.skipped_files:
+        return {"error": f"File '{path}' was marked as skipped."}
+
+    content = session.adapter.read_file(path)
+    return {"path": path, "content": content, "size_bytes": len(content.encode("utf-8"))}
+
+
+def _skip_import_file(args: dict, session: sessions.ImportSession | None) -> dict:
+    if not session:
+        return {"error": "No active import session."}
+
+    path = args.get("path", "")
+    reason = args.get("reason", "")
+    session.skipped_files.add(path)
+    return {"skipped": path, "reason": reason}
+
+
+def _read_existing_context(args: dict, ctx_manager: ContextManager) -> dict:
+    filename = args.get("filename", "")
+    if not filename.endswith(".md"):
+        return {"error": "Filename must end with .md"}
+
+    content = ctx_manager.read_context(filename)
+    if content is None:
+        return {"error": f"File '{filename}' does not exist yet."}
+    return {"filename": filename, "content": content}
+
+
+def _write_import_context(args: dict, ctx_manager: ContextManager) -> dict:
+    filename = args.get("filename", "")
+    content = args.get("content", "")
+
+    if not _safe_import_filename(filename):
+        return {"error": f"Cannot write to '{filename}'. Allowed targets: {sorted(_ALLOWED_WRITE_TARGETS)} or daily/YYYY-MM-DD.md"}
+
+    if _DAILY_RE.match(filename):
+        daily_dir = Path(ctx_manager.data_dir) / "daily"
+        daily_dir.mkdir(exist_ok=True)
+
+    ctx_manager.write_context(filename, content)
+    return {"written": filename, "size_bytes": len(content.encode("utf-8"))}
+
+
+def _finalize_import(
+    session: sessions.ImportSession | None,
+    ctx_manager: ContextManager,
+) -> dict:
+    if not session:
+        return {"error": "No active import session."}
+
+    # 1. Compute file hashes for re-import diffing
+    file_hashes: dict[str, str] = {}
+    try:
+        for f in session.adapter.list_files():
+            if f.path not in session.skipped_files:
+                content = session.adapter.read_file(f.path)
+                file_hashes[f.path] = hashlib.sha256(content.encode()).hexdigest()
+    except Exception:
+        logger.warning("Could not compute file hashes for import source")
+
+    # 2. Persist import source metadata
+    from agents import db as agent_db
+    agent_db.upsert_import_source(
+        agent_id=session.agent_id,
+        adapter_type=type(session.adapter).__name__,
+        source_config="{}",
+        file_hashes=json.dumps(file_hashes),
+    )
+    agent_db.update_agent(session.agent_id, onboarding_complete=1)
+
+    # 3. Generate the primed opener
+    agent = agent_db.get_agent(session.agent_id)
+    agent_name = agent["agent_name"] if agent else "Agent"
+
+    from .primed_opener import generate_opener
+    opener_text = generate_opener(ctx_manager, agent_name)
+
+    # 4. Create a new normal conversation with the opener as the first message
+    new_conversation_id = None
+    try:
+        from agents.engine import get_chat_service
+        slug = agent["slug"] if agent else ""
+        if slug:
+            chat_svc = get_chat_service(slug)
+            new_conv = chat_svc.create_conversation(title="(just getting started)")
+            new_conversation_id = new_conv["id"]
+
+            import uuid
+            chat_svc.save_message(
+                conversation_id=new_conversation_id,
+                msg_id=str(uuid.uuid4()),
+                role="assistant",
+                content=opener_text,
+                seq=0,
+            )
+    except Exception:
+        logger.exception("Failed to create primed opener conversation")
+
+    # 5. Remove the _import-bootstrap.md file now that import is done
+    bootstrap_path = Path(ctx_manager.data_dir) / "_import-bootstrap.md"
+    if bootstrap_path.exists():
+        bootstrap_path.unlink()
+
+    # 6. Clean up session
+    sessions.remove_session(session.token)
+
+    return {
+        "ok": True,
+        "agent_id": session.agent_id,
+        "files_imported": len(file_hashes),
+        "files_skipped": len(session.skipped_files),
+        "new_conversation_id": new_conversation_id,
+        "opener_preview": opener_text[:200],
+    }

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -177,10 +177,16 @@ def _extract_zip(
     if not agent:
         return {"error": "Agent not found"}
 
+    safe_name = Path(filename).name
+    if not safe_name.endswith(".zip") or ".." in safe_name or "/" in safe_name or "\\" in safe_name or "\0" in safe_name:
+        return {"error": "Invalid zip filename"}
+
     file_cache_dir = Path(__file__).resolve().parent.parent.parent / "data" / "agents" / agent["slug"] / "file_cache"
-    zip_path = file_cache_dir / filename
+    zip_path = (file_cache_dir / safe_name).resolve()
+    if not zip_path.is_relative_to(file_cache_dir.resolve()):
+        return {"error": "Invalid zip filename"}
     if not zip_path.is_file():
-        return {"error": f"Zip file '{filename}' not found in uploads. Make sure you dragged a .zip file into the chat."}
+        return {"error": "Zip file not found in uploads. Make sure you dragged a .zip file into the chat."}
 
     from .adapters.zip import ZipSourceAdapter
     adapter = ZipSourceAdapter(zip_path)

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import uuid
 from pathlib import Path
 
 from core.agents.context_manager import ContextManager
@@ -44,7 +45,7 @@ def _safe_import_filename(filename: str) -> bool:
         return True
     if _DAILY_RE.match(filename):
         return True
-    if filename.startswith("imported-") and filename.endswith(".md"):
+    if filename.startswith("imported-") and filename.endswith(".md") and "/" not in filename:
         return True
     return False
 
@@ -53,7 +54,7 @@ def _safe_scan_path(path: str) -> Path:
     """Resolve and validate a path for scan_directory. Must be under user's home."""
     home = Path.home()
     resolved = Path(path).expanduser().resolve()
-    if not str(resolved).startswith(str(home)):
+    if not resolved.is_relative_to(home):
         raise ValueError(f"Path must be under your home directory ({home})")
     for blocked in ("/etc", "/var", "/usr", "/System", "/Library"):
         if str(resolved).startswith(blocked):
@@ -71,9 +72,9 @@ def execute_import_tool(
 ) -> dict:
     try:
         if tool_name == "scan_directory":
-            return _scan_directory(args, session, ctx_manager)
+            return _scan_directory(args, session)
         elif tool_name == "ingest_pasted_text":
-            return _ingest_pasted_text(args, session, ctx_manager)
+            return _ingest_pasted_text(args, session)
         elif tool_name == "list_import_files":
             return _list_import_files(session)
         elif tool_name == "read_import_file":
@@ -88,15 +89,20 @@ def execute_import_tool(
             return _finalize_import(session, ctx_manager)
         else:
             return {"error": f"Unknown import tool: {tool_name}"}
+    except FileNotFoundError as e:
+        logger.warning("Import tool %s: file not found: %s", tool_name, e)
+        return {"error": "File or directory not found."}
+    except ValueError as e:
+        logger.warning("Import tool %s: validation error: %s", tool_name, e)
+        return {"error": str(e)}
     except Exception as e:
         logger.exception("Import tool %s failed", tool_name)
-        return {"error": str(e)}
+        return {"error": "An unexpected error occurred. Check the server logs."}
 
 
 def _scan_directory(
     args: dict,
     session: sessions.ImportSession | None,
-    ctx_manager: ContextManager,
 ) -> dict:
     path_str = args.get("path", "")
     resolved = _safe_scan_path(path_str)
@@ -123,7 +129,6 @@ def _scan_directory(
 def _ingest_pasted_text(
     args: dict,
     session: sessions.ImportSession | None,
-    ctx_manager: ContextManager,
 ) -> dict:
     text = args.get("text", "")
     if not text.strip():
@@ -190,9 +195,11 @@ def _read_existing_context(args: dict, ctx_manager: ContextManager) -> dict:
     filename = args.get("filename", "")
     if not filename.endswith(".md"):
         return {"error": "Filename must end with .md"}
+    if "/" in filename or "\\" in filename or ".." in filename:
+        return {"error": "Filename must not contain path separators"}
 
     content = ctx_manager.read_context(filename)
-    if content is None:
+    if not content:
         return {"error": f"File '{filename}' does not exist yet."}
     return {"filename": filename, "content": content}
 
@@ -256,7 +263,6 @@ def _finalize_import(
             new_conv = chat_svc.create_conversation(title="(just getting started)")
             new_conversation_id = new_conv["id"]
 
-            import uuid
             chat_svc.save_message(
                 conversation_id=new_conversation_id,
                 msg_id=str(uuid.uuid4()),

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -85,6 +85,10 @@ def execute_import_tool(
             return _read_existing_context(args, ctx_manager)
         elif tool_name == "write_import_context":
             return _write_import_context(args, ctx_manager)
+        elif tool_name == "extract_zip":
+            return _extract_zip(args, session)
+        elif tool_name == "import_openclaw_agent":
+            return _import_openclaw_agent(args, session)
         elif tool_name == "finalize_import":
             return _finalize_import(session, ctx_manager)
         else:
@@ -149,6 +153,82 @@ def _ingest_pasted_text(
     return {
         "found": len(files),
         "files": [{"path": f.path, "size_bytes": f.size_bytes} for f in files],
+    }
+
+
+def _extract_zip(
+    args: dict,
+    session: sessions.ImportSession | None,
+) -> dict:
+    if not session:
+        return {"error": "No active import session. Please restart the import."}
+
+    filename = args.get("filename", "")
+    if not filename:
+        return {"error": "No filename provided"}
+
+    agent = None
+    try:
+        from agents import db as agent_db
+        agent = agent_db.get_agent(session.agent_id)
+    except Exception:
+        pass
+
+    if not agent:
+        return {"error": "Agent not found"}
+
+    file_cache_dir = Path(__file__).resolve().parent.parent.parent / "data" / "agents" / agent["slug"] / "file_cache"
+    zip_path = file_cache_dir / filename
+    if not zip_path.is_file():
+        return {"error": f"Zip file '{filename}' not found in uploads. Make sure you dragged a .zip file into the chat."}
+
+    from .adapters.zip import ZipSourceAdapter
+    adapter = ZipSourceAdapter(zip_path)
+
+    try:
+        session.adapter.close()
+    except Exception:
+        pass
+    session.adapter = adapter
+
+    files = adapter.list_files()
+    return {
+        "found": len(files),
+        "files": [{"path": f.path, "size_bytes": f.size_bytes} for f in files],
+        "source": f"zip:{filename}",
+    }
+
+
+def _import_openclaw_agent(
+    args: dict,
+    session: sessions.ImportSession | None,
+) -> dict:
+    if not session:
+        return {"error": "No active import session. Please restart the import."}
+
+    agent_id = args.get("agent_id", "")
+    if not agent_id:
+        return {"error": "No agent_id provided"}
+
+    from .adapters.openclaw import OpenClawFolderAdapter
+    try:
+        adapter = OpenClawFolderAdapter(agent_id)
+    except (ValueError, FileNotFoundError) as e:
+        return {"error": str(e)}
+
+    try:
+        session.adapter.close()
+    except Exception:
+        pass
+    session.adapter = adapter
+
+    info = adapter.discover()
+    files = adapter.list_files()
+    return {
+        "found": len(files),
+        "agent_name": info.agent_name,
+        "files": [{"path": f.path, "size_bytes": f.size_bytes} for f in files],
+        "source": f"openclaw:{agent_id}",
     }
 
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -763,17 +763,40 @@ async def agent_chat_upload(
     if not messages:
         raise HTTPException(status_code=400, detail="No messages provided")
 
+    # Detect import mode for zip support
+    import_mode = False
+    conv_id = body.get("conversation_id")
+    if conv_id:
+        chat_svc = get_chat_service(agent["slug"])
+        conv = chat_svc.get_conversation(conv_id)
+        if conv and conv.get("mode") == "import":
+            import_mode = True
+
+    allowed_ext = _ALLOWED_EXTENSIONS | ({"zip"} if import_mode else set())
+
     # Process uploaded files
     file_texts = []
     for f in files[:_MAX_FILES]:
         ext = (f.filename or "").rsplit(".", 1)[-1].lower()
-        if ext not in _ALLOWED_EXTENSIONS:
+        if ext not in allowed_ext:
             raise HTTPException(status_code=400, detail=f"File type '.{ext}' not allowed")
 
         content_bytes = await f.read()
         if len(content_bytes) > _MAX_FILE_SIZE:
             raise HTTPException(status_code=400, detail=f"File '{f.filename}' exceeds 10 MB limit")
         if not content_bytes:
+            continue
+
+        # Save zip to file_cache for extract_zip tool (import mode only)
+        if ext == "zip" and import_mode:
+            file_cache_dir = DATA_DIR / agent["slug"] / "file_cache"
+            file_cache_dir.mkdir(parents=True, exist_ok=True)
+            zip_path = file_cache_dir / (f.filename or "upload.zip")
+            zip_path.write_bytes(content_bytes)
+            file_texts.append(
+                f"[Attached zip file: {f.filename}] "
+                f"Call extract_zip with filename=\"{f.filename}\" to process it."
+            )
             continue
 
         # Convert XLSX to CSV
@@ -835,6 +858,7 @@ async def agent_chat_upload(
         agent, messages, body.get("training_mode", False), body.get("conversation_id"),
         training_type=body.get("training_type"), plan_mode=body.get("plan_mode", False),
         tool_mode=body.get("tool_mode", "normal"), approved_tool=body.get("approved_tool"),
+        import_mode=import_mode,
     )
 
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -791,11 +791,16 @@ async def agent_chat_upload(
         if ext == "zip" and import_mode:
             file_cache_dir = DATA_DIR / agent["slug"] / "file_cache"
             file_cache_dir.mkdir(parents=True, exist_ok=True)
-            zip_path = file_cache_dir / (f.filename or "upload.zip")
+            safe_name = Path(f.filename or "upload.zip").name
+            if not safe_name.endswith(".zip") or ".." in safe_name or "/" in safe_name or "\\" in safe_name or "\0" in safe_name:
+                safe_name = "upload.zip"
+            zip_path = (file_cache_dir / safe_name).resolve()
+            if not zip_path.is_relative_to(file_cache_dir.resolve()):
+                raise HTTPException(status_code=400, detail="Invalid zip filename")
             zip_path.write_bytes(content_bytes)
             file_texts.append(
-                f"[Attached zip file: {f.filename}] "
-                f"Call extract_zip with filename=\"{f.filename}\" to process it."
+                f"[Attached zip file: {safe_name}] "
+                f"Call extract_zip with filename=\"{safe_name}\" to process it."
             )
             continue
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -469,7 +469,8 @@ async def get_avatar(agent_id: str, request: Request, token: str | None = None):
 
 def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_id: str | None,
                   training_type: str | None = None, plan_mode: bool = False,
-                  tool_mode: str = "normal", approved_tool: dict | None = None):
+                  tool_mode: str = "normal", approved_tool: dict | None = None,
+                  import_mode: bool = False):
     """Build provider, registry, and return a StreamingResponse for agent chat."""
     config = build_agent_config(agent)
     ctx_manager = get_context_manager(agent["slug"])
@@ -509,6 +510,12 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
         scheduled_action_handlers=sa_handlers,
     )
 
+    if import_mode and conversation_id:
+        from agents.import_service.sessions import get_session_by_conversation
+        import_session = get_session_by_conversation(conversation_id)
+        if import_session:
+            registry._import_session = import_session
+
     _, anthropic_profile = store.get_active_profile(provider_override="anthropic")
     anthropic_api_key = (anthropic_profile or {}).get("key", "")
 
@@ -522,6 +529,7 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
             training_mode=training_mode,
             training_type=training_type,
             plan_mode=plan_mode,
+            import_mode=import_mode,
             conversation_id=conversation_id,
             chat_service=chat_service,
             anthropic_api_key=anthropic_api_key,
@@ -547,9 +555,18 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
 async def agent_chat(agent_id: str, req: ChatRequest, user=Depends(get_current_user)):
     """Stream a chat response for a specific agent."""
     agent = _get_agent_or_404(agent_id)
+
+    import_mode = False
+    if req.conversation_id:
+        chat_svc = get_chat_service(agent["slug"])
+        conv = chat_svc.get_conversation(req.conversation_id)
+        if conv and conv.get("mode") == "import":
+            import_mode = True
+
     return _stream_chat(agent, req.messages, req.training_mode, req.conversation_id,
                         training_type=req.training_type, plan_mode=req.plan_mode,
-                        tool_mode=req.tool_mode, approved_tool=req.approved_tool)
+                        tool_mode=req.tool_mode, approved_tool=req.approved_tool,
+                        import_mode=import_mode)
 
 
 # ── Per-agent: Plan mode approve/iterate ──────────────────────────────────────

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -782,8 +782,9 @@ async def agent_chat_upload(
             raise HTTPException(status_code=400, detail=f"File type '.{ext}' not allowed")
 
         content_bytes = await f.read()
-        if len(content_bytes) > _MAX_FILE_SIZE:
-            raise HTTPException(status_code=400, detail=f"File '{f.filename}' exceeds 10 MB limit")
+        max_size = 25 * 1024 * 1024 if (ext == "zip" and import_mode) else _MAX_FILE_SIZE
+        if len(content_bytes) > max_size:
+            raise HTTPException(status_code=400, detail=f"File '{f.filename}' exceeds {max_size // (1024*1024)} MB limit")
         if not content_bytes:
             continue
 

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -492,6 +492,7 @@ async def chat(
     training_mode: bool = False,
     training_type: str | None = None,
     plan_mode: bool = False,
+    import_mode: bool = False,
     conversation_id: str | None = None,
     chat_service=None,
     anthropic_api_key: str = "",
@@ -529,6 +530,10 @@ async def chat(
     if training_mode:
         tool_mode = "power"
 
+    # Import mode forces power (user opted in at wizard start)
+    if import_mode:
+        tool_mode = "power"
+
     # Plan mode forces read-only
     if plan_mode:
         tool_mode = "read-only"
@@ -545,6 +550,7 @@ async def chat(
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
+        import_mode=import_mode,
         **google_caps,
     )
     kind_map = _build_kind_map(tool_defs)

--- a/backend/core/agents/chat_history/db.py
+++ b/backend/core/agents/chat_history/db.py
@@ -104,5 +104,7 @@ class ChatHistoryDB:
             conn.execute("ALTER TABLE conversations ADD COLUMN source TEXT DEFAULT NULL")
         if "pinned" not in conv_cols:
             conn.execute("ALTER TABLE conversations ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0")
+        if "mode" not in conv_cols:
+            conn.execute("ALTER TABLE conversations ADD COLUMN mode TEXT NOT NULL DEFAULT 'normal'")
 
         conn.commit()

--- a/backend/core/agents/chat_history/service.py
+++ b/backend/core/agents/chat_history/service.py
@@ -22,21 +22,30 @@ class ChatHistoryService:
     def __init__(self, db: ChatHistoryDB):
         self._db = db
 
-    def create_conversation(self, source: str | None = None) -> dict:
+    def create_conversation(
+        self,
+        source: str | None = None,
+        title: str | None = None,
+        mode: str = "normal",
+    ) -> dict:
         """Create a new conversation and return it.
 
         Args:
             source: Optional platform identifier ('telegram', 'whatsapp').
                     Messaging conversations are auto-pinned.
+            title: Optional custom title. Defaults based on source.
+            mode: 'normal' or 'import'. Import-mode conversations expose
+                  import tools to the agent.
         """
         conv_id = str(uuid.uuid4())
         pinned = 1 if source else 0
-        title = {"telegram": "Telegram", "telegram-group": "Telegram Group", "whatsapp": "WhatsApp"}.get(source or "", "New conversation")
+        if title is None:
+            title = {"telegram": "Telegram", "telegram-group": "Telegram Group", "whatsapp": "WhatsApp"}.get(source or "", "New conversation")
         db = self._db.get_db()
         with self._db.write_lock():
             db.execute(
-                "INSERT INTO conversations (id, title, title_edited_by_user, source, pinned) VALUES (?, ?, ?, ?, ?)",
-                (conv_id, title, 1 if source else 0, source, pinned),
+                "INSERT INTO conversations (id, title, title_edited_by_user, source, pinned, mode) VALUES (?, ?, ?, ?, ?, ?)",
+                (conv_id, title, 1 if source else 0, source, pinned, mode),
             )
             db.commit()
         row = db.execute("SELECT * FROM conversations WHERE id = ?", (conv_id,)).fetchone()

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1336,6 +1336,7 @@ def get_tool_definitions(
     shared_context_enabled: bool = True,
     integration_tools: list[dict] | None = None,
     dynamic_real_tools: list[dict] | None = None,
+    import_mode: bool = False,
 ) -> list[dict]:
     """Return the full list of tool definitions for the given feature flags.
 
@@ -1345,6 +1346,10 @@ def get_tool_definitions(
     granular flags by intersecting global scope grants (from google.json)
     with the agent's per-capability toggles.
     """
+    if import_mode:
+        from agents.import_service.tool_defs import IMPORT_TOOLS
+        return list(CONTEXT_TOOLS) + list(IMPORT_TOOLS)
+
     tools = list(CONTEXT_TOOLS)
     if memory_enabled:
         tools.extend(MEMORY_TOOLS)

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1348,7 +1348,8 @@ def get_tool_definitions(
     """
     if import_mode:
         from agents.import_service.tool_defs import IMPORT_TOOLS
-        return list(CONTEXT_TOOLS) + list(IMPORT_TOOLS)
+        read_only_context = [t for t in CONTEXT_TOOLS if not t.get("writes", False)]
+        return read_only_context + list(IMPORT_TOOLS)
 
     tools = list(CONTEXT_TOOLS)
     if memory_enabled:

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -131,6 +131,8 @@ class ToolRegistry:
                 return await self._execute_integration(tool_name, tool_args)
             elif kind == "setup":
                 return self._execute_setup(tool_name, tool_args)
+            elif kind == "import":
+                return self._execute_import(tool_name, tool_args)
             else:
                 return {"error": f"Unknown tool kind: {kind}"}
         except Exception as e:
@@ -466,6 +468,15 @@ class ToolRegistry:
         elif tool_name == "check_integrations":
             return self._check_integrations()
         return {"error": f"Unknown setup tool: {tool_name}"}
+
+    def _execute_import(self, tool_name: str, args: dict) -> dict:
+        from agents.import_service import sessions
+        from agents.import_service.tools import execute_import_tool
+        from core.agents.context_manager import ContextManager
+
+        session = getattr(self, "_import_session", None)
+        ctx_manager = ContextManager(self.context_dir, gcs_prefix=self.gcs_prefix)
+        return execute_import_tool(tool_name, args, session, ctx_manager)
 
     def _mark_setup_complete(self, integration_name: str) -> None:
         """Auto-update _pending-setup.md to check off a completed integration."""

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -475,7 +475,7 @@ class ToolRegistry:
         from core.agents.context_manager import ContextManager
 
         session = getattr(self, "_import_session", None)
-        ctx_manager = ContextManager(self.context_dir, gcs_prefix=self.gcs_prefix)
+        ctx_manager = ContextManager(Path(self.context_dir), gcs_prefix=self.gcs_prefix)
         return execute_import_tool(tool_name, args, session, ctx_manager)
 
     def _mark_setup_complete(self, integration_name: str) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -150,6 +150,9 @@ async def lifespan(app: FastAPI):
     from core.auth_2fa import cleanup_expired_devices
     _scheduler.add_job(cleanup_expired_devices, "interval", hours=24, id="2fa_device_cleanup")
 
+    from agents.import_service.sessions import sweep_expired as _sweep_import_sessions
+    _scheduler.add_job(_sweep_import_sessions, "interval", seconds=600, id="import_session_sweep")
+
     _scheduler.start()
     logger.info("APScheduler started (reminder heartbeat + scheduled actions + nightly jobs)")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from core.auth_2fa import router as auth_2fa_router
 from core.providers.router import router as providers_router
 from core.providers.oauth_callback_router import router as oauth_callback_router
 from agents.router import router as agents_router
+from agents.import_router import router as import_router
 from branding.router import router as branding_router
 from integrations.router import router as integrations_router
 from integrations.crm_lite.router import router as crm_router
@@ -238,6 +239,7 @@ app.include_router(auth_2fa_router, prefix="/api", tags=["auth-2fa"])
 app.include_router(providers_router, prefix="/api/providers", tags=["providers"])
 app.include_router(oauth_callback_router, prefix="/api/oauth", tags=["oauth"])
 app.include_router(agents_router, prefix="/api/agents", tags=["agents"])
+app.include_router(import_router, tags=["import"])
 app.include_router(branding_router, prefix="/api/branding", tags=["branding"])
 app.include_router(integrations_router, prefix="/api/integrations", tags=["integrations"])
 app.include_router(whatsapp_router, prefix="/api/messaging", tags=["messaging"])

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -148,6 +148,18 @@ export function AgentPage() {
     convs.loadConversations();
   }, [agentId]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Auto-redirect to active import conversation if user navigates away
+  useEffect(() => {
+    if (!convs.conversations.length) return;
+    const importConv = convs.conversations.find(c => c.mode === 'import');
+    if (!importConv) return;
+    if (convs.activeId === importConv.id) return;
+    (async () => {
+      const msgs = await convs.selectConversation(importConv.id);
+      if (msgs) chat.loadMessages(msgs, importConv.id);
+    })();
+  }, [convs.conversations, convs.activeId]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Handle conversation from URL search params (used by import flow)
   const importConvHandled = useRef<string | null>(null);
   useEffect(() => {

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -80,11 +80,13 @@ export function AgentPage() {
     onImportComplete: (id) => importCompleteRef.current?.(id),
   });
 
-  importCompleteRef.current = async (newConversationId: string) => {
-    await convs.loadConversations();
-    const msgs = await convs.selectConversation(newConversationId);
-    if (msgs) chat.loadMessages(msgs, newConversationId);
-  };
+  useEffect(() => {
+    importCompleteRef.current = async (newConversationId: string) => {
+      await convs.loadConversations();
+      const msgs = await convs.selectConversation(newConversationId);
+      if (msgs) chat.loadMessages(msgs, newConversationId);
+    };
+  }); // intentionally no deps — always tracks latest convs/chat
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const topBarVisible = useScrollDirection(scrollRef);

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -148,11 +148,20 @@ export function AgentPage() {
     convs.loadConversations();
   }, [agentId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-redirect to active import conversation if user navigates away
+  // Auto-redirect to active import conversation if user navigates away.
+  // If the import conversation is older than 35 minutes (session TTL is 30min),
+  // treat it as orphaned and delete it instead of trapping the user.
   useEffect(() => {
     if (!convs.conversations.length) return;
     const importConv = convs.conversations.find(c => c.mode === 'import');
     if (!importConv) return;
+
+    const ageMs = Date.now() - new Date(importConv.created_at).getTime();
+    if (ageMs > 35 * 60 * 1000) {
+      convs.deleteConversation(importConv.id);
+      return;
+    }
+
     if (convs.activeId === importConv.id) return;
     (async () => {
       const msgs = await convs.selectConversation(importConv.id);
@@ -538,6 +547,13 @@ export function AgentPage() {
               agentName={agent.agent_name}
               conversationSource={convs.conversations.find(c => c.id === convs.activeId)?.source}
               importMode={convs.conversations.find(c => c.id === convs.activeId)?.mode === 'import'}
+              onCancelImport={async () => {
+                if (!confirm('Cancel this import? The agent and all progress will be deleted.')) return;
+                try {
+                  await api(`/api/agents/${agentId}`, { method: 'DELETE' });
+                } catch { /* ignore */ }
+                navigate('/');
+              }}
             />
           </>
         ) : activeTab === 'knowledge' ? (

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -73,7 +73,7 @@ export function AgentPage() {
     convs.loadConversations();
   }, [convs]);
 
-  const importCompleteRef = useRef<(id: string) => void>();
+  const importCompleteRef = useRef<((id: string) => void) | null>(null);
 
   const chat = useAgentChat(apiPrefix, {
     onTitleUpdate: handleTitleUpdate,
@@ -145,6 +145,22 @@ export function AgentPage() {
   useEffect(() => {
     convs.loadConversations();
   }, [agentId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Handle conversation from URL search params (used by import flow)
+  const importConvHandled = useRef(false);
+  useEffect(() => {
+    const convId = searchParams.get('conversation');
+    if (convId && !importConvHandled.current) {
+      importConvHandled.current = true;
+      searchParams.delete('conversation');
+      setSearchParams(searchParams, { replace: true });
+      (async () => {
+        await convs.loadConversations();
+        const msgs = await convs.selectConversation(convId);
+        if (msgs) chat.loadMessages(msgs, convId);
+      })();
+    }
+  }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle tab from URL search params
   useEffect(() => {

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -73,7 +73,18 @@ export function AgentPage() {
     convs.loadConversations();
   }, [convs]);
 
-  const chat = useAgentChat(apiPrefix, { onTitleUpdate: handleTitleUpdate });
+  const importCompleteRef = useRef<(id: string) => void>();
+
+  const chat = useAgentChat(apiPrefix, {
+    onTitleUpdate: handleTitleUpdate,
+    onImportComplete: (id) => importCompleteRef.current?.(id),
+  });
+
+  importCompleteRef.current = async (newConversationId: string) => {
+    await convs.loadConversations();
+    const msgs = await convs.selectConversation(newConversationId);
+    if (msgs) chat.loadMessages(msgs, newConversationId);
+  };
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const topBarVisible = useScrollDirection(scrollRef);
@@ -480,6 +491,19 @@ export function AgentPage() {
                 onSearch={convs.searchConversations}
                 onRename={convs.renameConversation}
               />
+            )}
+            {convs.conversations.find(c => c.id === convs.activeId)?.mode === 'import' && (
+              <div style={{
+                padding: '8px 16px',
+                background: 'rgba(212,168,90,0.12)',
+                borderBottom: '1px solid rgba(212,168,90,0.25)',
+                display: 'flex', alignItems: 'center', gap: 8,
+                fontFamily: "'Inter Tight', system-ui, sans-serif",
+                fontSize: 12, color: '#D4A85A',
+              }}>
+                <span style={{ fontSize: 14 }}>&#8615;</span>
+                <span>Import Mode — Your agent is importing knowledge from another system</span>
+              </div>
             )}
             <AgentChatPanel
               messages={chat.messages}

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -510,19 +510,6 @@ export function AgentPage() {
                 onRename={convs.renameConversation}
               />
             )}
-            {convs.conversations.find(c => c.id === convs.activeId)?.mode === 'import' && (
-              <div style={{
-                padding: '8px 16px',
-                background: 'rgba(212,168,90,0.12)',
-                borderBottom: '1px solid rgba(212,168,90,0.25)',
-                display: 'flex', alignItems: 'center', gap: 8,
-                fontFamily: "'Inter Tight', system-ui, sans-serif",
-                fontSize: 12, color: '#D4A85A',
-              }}>
-                <span style={{ fontSize: 14 }}>&#8615;</span>
-                <span>Import Mode — Your agent is importing knowledge from another system</span>
-              </div>
-            )}
             <AgentChatPanel
               messages={chat.messages}
               isStreaming={chat.isStreaming}
@@ -538,6 +525,7 @@ export function AgentPage() {
               onToolModeChange={handleToolModeChange}
               agentName={agent.agent_name}
               conversationSource={convs.conversations.find(c => c.id === convs.activeId)?.source}
+              importMode={convs.conversations.find(c => c.id === convs.activeId)?.mode === 'import'}
             />
           </>
         ) : activeTab === 'knowledge' ? (

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -149,11 +149,11 @@ export function AgentPage() {
   }, [agentId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle conversation from URL search params (used by import flow)
-  const importConvHandled = useRef(false);
+  const importConvHandled = useRef<string | null>(null);
   useEffect(() => {
     const convId = searchParams.get('conversation');
-    if (convId && !importConvHandled.current) {
-      importConvHandled.current = true;
+    if (convId && importConvHandled.current !== convId) {
+      importConvHandled.current = convId;
       searchParams.delete('conversation');
       setSearchParams(searchParams, { replace: true });
       (async () => {
@@ -162,7 +162,7 @@ export function AgentPage() {
         if (msgs) chat.loadMessages(msgs, convId);
       })();
     }
-  }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [searchParams, agentId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle tab from URL search params
   useEffect(() => {

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -171,7 +171,7 @@ export function AgentPage() {
       (async () => {
         await convs.loadConversations();
         const msgs = await convs.selectConversation(convId);
-        if (msgs) chat.loadMessages(msgs, convId);
+        if (msgs) chat.loadMessages(msgs, convId, true);
       })();
     }
   }, [searchParams, agentId]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -28,6 +28,7 @@ interface Props {
   onToolModeChange?: (mode: ToolMode) => void;
   agentName?: string;
   conversationSource?: string | null;
+  importMode?: boolean;
 }
 
 const TOOL_MODES: { key: ToolMode; label: string }[] = [
@@ -39,7 +40,7 @@ const TOOL_MODES: { key: ToolMode; label: string }[] = [
 export function AgentChatPanel({
   messages, isStreaming, onSend, onStop, onApprove, onDeny,
   onApprovePlan, onIteratePlan, scrollRef: externalScrollRef,
-  contextUsage, toolMode, onToolModeChange, agentName, conversationSource,
+  contextUsage, toolMode, onToolModeChange, agentName, conversationSource, importMode,
 }: Props) {
   const [input, setInput] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -82,8 +83,9 @@ export function AgentChatPanel({
 
     for (const f of incoming) {
       const ext = getExtension(f.name);
-      if (!ALLOWED_EXTENSIONS.has(ext)) { errors.push(`${f.name}: unsupported type (.${ext})`); continue; }
-      const maxSize = ext === 'pdf' ? MAX_PDF_SIZE : MAX_FILE_SIZE;
+      const allowed = importMode ? new Set([...ALLOWED_EXTENSIONS, 'zip']) : ALLOWED_EXTENSIONS;
+      if (!allowed.has(ext)) { errors.push(`${f.name}: unsupported type (.${ext})`); continue; }
+      const maxSize = ext === 'zip' ? 25 * 1024 * 1024 : ext === 'pdf' ? MAX_PDF_SIZE : MAX_FILE_SIZE;
       const maxLabel = ext === 'pdf' ? '10 MB' : '1 MB';
       if (f.size > maxSize) { errors.push(`${f.name}: exceeds ${maxLabel}`); continue; }
       if (f.size === 0) { errors.push(`${f.name}: empty file`); continue; }
@@ -348,6 +350,20 @@ export function AgentChatPanel({
                 </span>
                 <span style={{ fontSize: 11, color: 'rgba(237,240,244,0.4)' }}>
                   Messages from {conversationSource?.startsWith('telegram') ? 'Telegram' : 'WhatsApp'} appear here
+                </span>
+              </div>
+            )}
+            {importMode && (
+              <div style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                padding: '8px 14px', borderRadius: 8,
+                background: 'rgba(212,168,90,0.08)', border: '1px solid rgba(212,168,90,0.2)',
+              }}>
+                <span style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.05em', color: '#D4A85A' }}>
+                  Import Mode
+                </span>
+                <span style={{ fontSize: 11, color: 'rgba(237,240,244,0.4)' }}>
+                  Importing knowledge from another system
                 </span>
               </div>
             )}

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -29,6 +29,7 @@ interface Props {
   agentName?: string;
   conversationSource?: string | null;
   importMode?: boolean;
+  onCancelImport?: () => void;
 }
 
 const TOOL_MODES: { key: ToolMode; label: string }[] = [
@@ -40,7 +41,7 @@ const TOOL_MODES: { key: ToolMode; label: string }[] = [
 export function AgentChatPanel({
   messages, isStreaming, onSend, onStop, onApprove, onDeny,
   onApprovePlan, onIteratePlan, scrollRef: externalScrollRef,
-  contextUsage, toolMode, onToolModeChange, agentName, conversationSource, importMode,
+  contextUsage, toolMode, onToolModeChange, agentName, conversationSource, importMode, onCancelImport,
 }: Props) {
   const [input, setInput] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -362,9 +363,22 @@ export function AgentChatPanel({
                 <span style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.05em', color: '#D4A85A' }}>
                   Import Mode
                 </span>
-                <span style={{ fontSize: 11, color: 'rgba(237,240,244,0.4)' }}>
+                <span style={{ flex: 1, fontSize: 11, color: 'rgba(237,240,244,0.4)' }}>
                   Importing knowledge from another system
                 </span>
+                {onCancelImport && (
+                  <button
+                    onClick={onCancelImport}
+                    style={{
+                      background: 'transparent', border: '1px solid rgba(212,168,90,0.3)',
+                      color: '#D4A85A', borderRadius: 4,
+                      padding: '3px 10px', fontSize: 11, cursor: 'pointer',
+                      fontFamily: "'Inter Tight', system-ui, sans-serif",
+                    }}
+                  >
+                    Cancel
+                  </button>
+                )}
               </div>
             )}
             {messages.filter(msg => !msg.hidden).map(msg => {

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -79,6 +79,7 @@ export interface ContextUsage {
 
 interface Options {
   onTitleUpdate?: (convId: string, title: string) => void;
+  onImportComplete?: (newConversationId: string) => void;
 }
 
 export function useAgentChat(apiPrefix: string, options?: Options) {
@@ -274,6 +275,14 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
                     : tc;
                 }),
               }));
+              if (event.tool === 'finalize_import' && event.result) {
+                try {
+                  const result = typeof event.result === 'string' ? JSON.parse(event.result) : event.result;
+                  if (result.new_conversation_id && options?.onImportComplete) {
+                    setTimeout(() => options.onImportComplete!(result.new_conversation_id), 2000);
+                  }
+                } catch { /* ignore parse errors */ }
+              }
             } else if (event.type === 'confirm' && event.tool) {
               flushPendingText();
               updateLastAssistant(last => ({

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -483,9 +483,37 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
     setContextUsage(null);
   }, []);
 
-  const loadMessages = useCallback((msgs: ChatMessage[], id: string) => {
-    setMessages(msgs);
+  const loadMessages = useCallback((msgs: ChatMessage[], id: string, streamIn?: boolean) => {
+    if (!streamIn || !msgs.length || msgs[msgs.length - 1].role !== 'assistant') {
+      setMessages(msgs);
+      setConversationId(id);
+      return;
+    }
+
+    const lastMsg = msgs[msgs.length - 1];
+    const fullText = lastMsg.content;
+    const preceding = msgs.slice(0, -1);
+
     setConversationId(id);
+    setIsStreaming(true);
+    setMessages([...preceding, { ...lastMsg, content: '', isStreaming: true }]);
+
+    let i = 0;
+    const interval = setInterval(() => {
+      const chunkEnd = Math.min(i + 3, fullText.length);
+      const soFar = fullText.slice(0, chunkEnd);
+      i = chunkEnd;
+      setMessages(prev => {
+        const last = prev[prev.length - 1];
+        if (last?.role !== 'assistant') return prev;
+        return [...prev.slice(0, -1), { ...last, content: soFar }];
+      });
+      if (i >= fullText.length) {
+        clearInterval(interval);
+        setIsStreaming(false);
+        setMessages(prev => prev.map(m => m.isStreaming ? { ...m, isStreaming: false } : m));
+      }
+    }, 12);
   }, []);
 
   return {

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -92,6 +92,10 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
   const [toolMode, setToolMode] = useState<ToolMode>('normal');
   const [contextUsage, setContextUsage] = useState<ContextUsage | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const streamInIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => () => {
+    if (streamInIntervalRef.current) clearInterval(streamInIntervalRef.current);
+  }, []);
   const savedToolModeRef = useRef<ToolMode>('normal');
   const savedToolModeForPlanRef = useRef<ToolMode>('normal');
   const trainingKickoffRef = useRef(false);
@@ -484,6 +488,11 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
   }, []);
 
   const loadMessages = useCallback((msgs: ChatMessage[], id: string, streamIn?: boolean) => {
+    if (streamInIntervalRef.current) {
+      clearInterval(streamInIntervalRef.current);
+      streamInIntervalRef.current = null;
+    }
+
     if (!streamIn || !msgs.length || msgs[msgs.length - 1].role !== 'assistant') {
       setMessages(msgs);
       setConversationId(id);
@@ -499,7 +508,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
     setMessages([...preceding, { ...lastMsg, content: '', isStreaming: true }]);
 
     let i = 0;
-    const interval = setInterval(() => {
+    streamInIntervalRef.current = setInterval(() => {
       const chunkEnd = Math.min(i + 3, fullText.length);
       const soFar = fullText.slice(0, chunkEnd);
       i = chunkEnd;
@@ -509,7 +518,8 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
         return [...prev.slice(0, -1), { ...last, content: soFar }];
       });
       if (i >= fullText.length) {
-        clearInterval(interval);
+        if (streamInIntervalRef.current) clearInterval(streamInIntervalRef.current);
+        streamInIntervalRef.current = null;
         setIsStreaming(false);
         setMessages(prev => prev.map(m => m.isStreaming ? { ...m, isStreaming: false } : m));
       }

--- a/frontend/src/agent/hooks/useConversations.ts
+++ b/frontend/src/agent/hooks/useConversations.ts
@@ -13,6 +13,7 @@ export interface Conversation {
   title_edited_by_user: boolean;
   source?: string | null;
   pinned?: number;
+  mode?: 'normal' | 'import';
   created_at: string;
   updated_at: string;
   message_count?: number;

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -42,6 +42,7 @@ export interface Conversation {
   title_edited_by_user: boolean;
   source?: string | null;
   pinned?: number;
+  mode?: 'normal' | 'import';
   created_at: string;
   updated_at: string;
   message_count?: number;

--- a/frontend/src/dashboard/AgentCard.tsx
+++ b/frontend/src/dashboard/AgentCard.tsx
@@ -5,10 +5,9 @@ import type { Agent } from '../core/types';
 
 interface Props {
   agent: Agent;
-  onDelete: (id: string) => void;
 }
 
-export function AgentCard({ agent, onDelete }: Props) {
+export function AgentCard({ agent }: Props) {
   const navigate = useNavigate();
   const letter = agent.agent_name.charAt(0);
   const avatarUrl = agent.avatar_url
@@ -56,21 +55,6 @@ export function AgentCard({ agent, onDelete }: Props) {
         )}
       </div>
 
-      <button
-        onClick={e => { e.stopPropagation(); onDelete(agent.id); }}
-        style={{
-          position: 'absolute', top: 6, right: 6,
-          background: 'transparent', border: 'none',
-          color: 'rgba(237,240,244,0.38)', fontSize: 14,
-          cursor: 'pointer', opacity: 0, transition: 'opacity 0.15s',
-          padding: '2px 4px',
-        }}
-        title="Delete agent"
-        onMouseEnter={e => { (e.currentTarget as HTMLElement).style.opacity = '1'; }}
-        onMouseLeave={e => { (e.currentTarget as HTMLElement).style.opacity = '0'; }}
-      >
-        ×
-      </button>
     </div>
   );
 }

--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { api } from '../core/api/client';
 import { AgentCard } from './AgentCard';
 import { CreateAgentModal } from './CreateAgentModal';
 import { ImportAgentModal } from './ImportAgentModal';
+import { DeleteAgentModal } from './DeleteAgentModal';
 import { WarmHalo } from '../shared/WarmHalo';
 import { IconSearch, IconPlus, IconDownload } from '../shared/icons';
 import { MobileMenuDrawer } from '../shared/MobileMenuDrawer';
@@ -35,6 +36,7 @@ export function DashboardPage() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [showCreate, setShowCreate] = useState(false);
   const [showImport, setShowImport] = useState(false);
+  const [deleteAgent, setDeleteAgent] = useState<Agent | null>(null);
   const [suggestedTitle, setSuggestedTitle] = useState('');
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
@@ -57,10 +59,9 @@ export function DashboardPage() {
     }).finally(() => setLoading(false));
   }, [navigate]);
 
-  async function handleDelete(id: string) {
-    if (!confirm('Delete this agent? This cannot be undone.')) return;
-    await api(`/api/agents/${id}`, { method: 'DELETE' });
-    setAgents(prev => prev.filter(a => a.id !== id));
+  function handleDelete(id: string) {
+    const agent = agents.find(a => a.id === id);
+    if (agent) setDeleteAgent(agent);
   }
 
   const isMobile = useIsMobile();
@@ -293,6 +294,17 @@ export function DashboardPage() {
 
       {showImport && (
         <ImportAgentModal onClose={() => setShowImport(false)} />
+      )}
+
+      {deleteAgent && (
+        <DeleteAgentModal
+          agent={deleteAgent}
+          onClose={() => setDeleteAgent(null)}
+          onDeleted={id => {
+            setAgents(prev => prev.filter(a => a.id !== id));
+            setDeleteAgent(null);
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -3,8 +3,9 @@ import { useNavigate, useOutletContext } from 'react-router-dom';
 import { api } from '../core/api/client';
 import { AgentCard } from './AgentCard';
 import { CreateAgentModal } from './CreateAgentModal';
+import { ImportAgentModal } from './ImportAgentModal';
 import { WarmHalo } from '../shared/WarmHalo';
-import { IconSearch, IconPlus } from '../shared/icons';
+import { IconSearch, IconPlus, IconDownload } from '../shared/icons';
 import { MobileMenuDrawer } from '../shared/MobileMenuDrawer';
 import { useIsMobile } from '../shared/useIsMobile';
 import type { Agent, BrandingConfig, ProviderStatus } from '../core/types';
@@ -33,6 +34,7 @@ const mono = (size: number, color = 'rgba(237,240,244,0.38)') => ({
 export function DashboardPage() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [showCreate, setShowCreate] = useState(false);
+  const [showImport, setShowImport] = useState(false);
   const [suggestedTitle, setSuggestedTitle] = useState('');
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
@@ -160,18 +162,32 @@ export function DashboardPage() {
           <div style={mono(10, 'rgba(237,240,244,0.38)')}>
             Your agents · {agents.length}
           </div>
-          <button
-            onClick={() => setShowCreate(true)}
-            style={{
-              background: 'transparent', color: '#EDF0F4',
-              border: '1px solid rgba(230,235,242,0.14)',
-              fontSize: 12, padding: '6px 12px', borderRadius: 4,
-              display: 'flex', alignItems: 'center', gap: 6,
-              cursor: 'pointer', fontFamily: "'Inter Tight', system-ui, sans-serif",
-            }}
-          >
-            <IconPlus size={13} strokeWidth={2.25} /> Commission agent
-          </button>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              onClick={() => setShowImport(true)}
+              style={{
+                background: 'transparent', color: 'rgba(237,240,244,0.62)',
+                border: '1px solid rgba(230,235,242,0.14)',
+                fontSize: 12, padding: '6px 12px', borderRadius: 4,
+                display: 'flex', alignItems: 'center', gap: 6,
+                cursor: 'pointer', fontFamily: "'Inter Tight', system-ui, sans-serif",
+              }}
+            >
+              <IconDownload size={13} strokeWidth={2.25} /> Import agent
+            </button>
+            <button
+              onClick={() => setShowCreate(true)}
+              style={{
+                background: 'transparent', color: '#EDF0F4',
+                border: '1px solid rgba(230,235,242,0.14)',
+                fontSize: 12, padding: '6px 12px', borderRadius: 4,
+                display: 'flex', alignItems: 'center', gap: 6,
+                cursor: 'pointer', fontFamily: "'Inter Tight', system-ui, sans-serif",
+              }}
+            >
+              <IconPlus size={13} strokeWidth={2.25} /> Commission agent
+            </button>
+          </div>
         </div>
 
         {loading ? (
@@ -273,6 +289,10 @@ export function DashboardPage() {
             setSuggestedTitle('');
           }}
         />
+      )}
+
+      {showImport && (
+        <ImportAgentModal onClose={() => setShowImport(false)} />
       )}
     </div>
   );

--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -4,7 +4,6 @@ import { api } from '../core/api/client';
 import { AgentCard } from './AgentCard';
 import { CreateAgentModal } from './CreateAgentModal';
 import { ImportAgentModal } from './ImportAgentModal';
-import { DeleteAgentModal } from './DeleteAgentModal';
 import { WarmHalo } from '../shared/WarmHalo';
 import { IconSearch, IconPlus, IconDownload } from '../shared/icons';
 import { MobileMenuDrawer } from '../shared/MobileMenuDrawer';
@@ -36,7 +35,6 @@ export function DashboardPage() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [showCreate, setShowCreate] = useState(false);
   const [showImport, setShowImport] = useState(false);
-  const [deleteAgent, setDeleteAgent] = useState<Agent | null>(null);
   const [suggestedTitle, setSuggestedTitle] = useState('');
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
@@ -59,10 +57,6 @@ export function DashboardPage() {
     }).finally(() => setLoading(false));
   }, [navigate]);
 
-  function handleDelete(id: string) {
-    const agent = agents.find(a => a.id === id);
-    if (agent) setDeleteAgent(agent);
-  }
 
   const isMobile = useIsMobile();
   const [showMenu, setShowMenu] = useState(false);
@@ -237,7 +231,7 @@ export function DashboardPage() {
         ) : (
           <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)', gap: 8 }}>
             {agents.map(agent => (
-              <AgentCard key={agent.id} agent={agent} onDelete={handleDelete} />
+              <AgentCard key={agent.id} agent={agent} />
             ))}
           </div>
         )}
@@ -296,16 +290,6 @@ export function DashboardPage() {
         <ImportAgentModal onClose={() => setShowImport(false)} />
       )}
 
-      {deleteAgent && (
-        <DeleteAgentModal
-          agent={deleteAgent}
-          onClose={() => setDeleteAgent(null)}
-          onDeleted={id => {
-            setAgents(prev => prev.filter(a => a.id !== id));
-            setDeleteAgent(null);
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/frontend/src/dashboard/DeleteAgentModal.tsx
+++ b/frontend/src/dashboard/DeleteAgentModal.tsx
@@ -1,0 +1,134 @@
+import { useState, type FormEvent } from 'react';
+import { api } from '../core/api/client';
+import type { Agent } from '../core/types';
+
+interface Props {
+  agent: Agent;
+  onClose: () => void;
+  onDeleted: (id: string) => void;
+}
+
+export function DeleteAgentModal({ agent, onClose, onDeleted }: Props) {
+  const [confirmation, setConfirmation] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const confirmPhrase = `delete ${agent.agent_name.toLowerCase()}`;
+  const canDelete = confirmation.toLowerCase() === confirmPhrase;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!canDelete) return;
+    setLoading(true);
+    setError('');
+    try {
+      await api(`/api/agents/${agent.id}`, { method: 'DELETE' });
+      onDeleted(agent.id);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to delete agent');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: '#11141A', borderRadius: 6,
+          border: '1px solid rgba(230,235,242,0.14)',
+          padding: 32, width: '100%', maxWidth: 420,
+          boxShadow: '0 8px 40px rgba(0,0,0,0.5)',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 style={{
+          fontFamily: "'Fraunces', Georgia, serif",
+          fontSize: 24, fontWeight: 400, letterSpacing: '-0.02em',
+          marginBottom: 8, color: '#EDF0F4',
+        }}>Delete Agent</h2>
+
+        <p style={{
+          fontSize: 13, color: 'rgba(237,240,244,0.5)',
+          marginBottom: 8, lineHeight: 1.5,
+        }}>
+          This will permanently delete <strong style={{ color: '#EDF0F4' }}>{agent.agent_name}</strong> and
+          all of their knowledge, conversations, and memory. This cannot be undone.
+        </p>
+
+        <div style={{
+          background: 'rgba(217,119,87,0.08)',
+          border: '1px solid rgba(217,119,87,0.2)',
+          borderRadius: 6, padding: '12px 14px',
+          marginBottom: 20,
+        }}>
+          <p style={{
+            fontSize: 12, color: '#D97757', margin: 0, lineHeight: 1.5,
+          }}>
+            To confirm, type <strong style={{
+              fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+              background: 'rgba(217,119,87,0.12)',
+              padding: '1px 6px', borderRadius: 3,
+            }}>{confirmPhrase}</strong> below.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <input
+            type="text"
+            value={confirmation}
+            onChange={e => setConfirmation(e.target.value)}
+            placeholder={confirmPhrase}
+            autoFocus
+            autoComplete="off"
+            style={{
+              width: '100%', boxSizing: 'border-box',
+              background: 'rgba(20,24,30,0.78)',
+              border: '1px solid rgba(230,235,242,0.14)',
+              color: '#EDF0F4', borderRadius: 4,
+              padding: '10px 14px', fontSize: 14,
+              outline: 'none', marginBottom: 20,
+              fontFamily: "'Inter Tight', system-ui, sans-serif",
+            }}
+          />
+
+          {error && <p style={{ color: '#D97757', fontSize: 13, marginBottom: 16 }}>{error}</p>}
+
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                flex: 1, padding: '9px 16px', borderRadius: 4,
+                border: '1px solid rgba(230,235,242,0.14)',
+                background: 'transparent', color: 'rgba(237,240,244,0.62)',
+                cursor: 'pointer', fontSize: 13,
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !canDelete}
+              style={{
+                flex: 1, padding: '9px 16px', borderRadius: 4,
+                background: canDelete ? '#D97757' : 'rgba(217,119,87,0.3)',
+                color: canDelete ? '#0E1013' : 'rgba(14,16,19,0.5)',
+                border: 'none', fontWeight: 500, cursor: canDelete ? 'pointer' : 'default',
+                fontSize: 13,
+                transition: 'background 0.15s, color 0.15s',
+              }}
+            >
+              {loading ? 'Deleting...' : 'Delete permanently'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/dashboard/ImportAgentModal.tsx
+++ b/frontend/src/dashboard/ImportAgentModal.tsx
@@ -1,0 +1,134 @@
+import { useState, type FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../core/api/client';
+
+interface Props {
+  onClose: () => void;
+}
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+  fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
+  color: 'rgba(237,240,244,0.38)', marginBottom: 6,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box',
+  background: 'rgba(20,24,30,0.78)',
+  border: '1px solid rgba(230,235,242,0.14)',
+  color: '#EDF0F4', borderRadius: 4,
+  padding: '10px 14px', fontSize: 14,
+  outline: 'none',
+  fontFamily: "'Inter Tight', system-ui, sans-serif",
+};
+
+export function ImportAgentModal({ onClose }: Props) {
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setLoading(true);
+    setError('');
+    try {
+      const result = await api<{
+        agent_id: string;
+        agent_slug: string;
+        conversation_id: string;
+        session_token: string;
+      }>('/api/agents/import/start', {
+        method: 'POST',
+        body: JSON.stringify({ agent_name: name.trim() }),
+      });
+      navigate(`/agent/${result.agent_id}?conversation=${result.conversation_id}`);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to start import');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: '#11141A', borderRadius: 6,
+          border: '1px solid rgba(230,235,242,0.14)',
+          padding: 32, width: '100%', maxWidth: 420,
+          boxShadow: '0 8px 40px rgba(0,0,0,0.5)',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 style={{
+          fontFamily: "'Fraunces', Georgia, serif",
+          fontSize: 24, fontWeight: 400, letterSpacing: '-0.02em',
+          marginBottom: 8, color: '#EDF0F4',
+        }}>Import Existing Agent</h2>
+
+        <p style={{
+          fontSize: 13, color: 'rgba(237,240,244,0.5)',
+          marginBottom: 24, lineHeight: 1.5,
+        }}>
+          Bring knowledge from another AI system into a new Chatty agent.
+          Your agent will walk you through the import.
+        </p>
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: 24 }}>
+            <label style={labelStyle}>Agent name *</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Name for your new agent"
+              autoFocus
+              maxLength={60}
+              style={inputStyle}
+            />
+            <p style={{
+              fontSize: 11, color: 'rgba(237,240,244,0.28)', marginTop: 4,
+            }}>You can change this during import if you're cloning an existing agent.</p>
+          </div>
+
+          {error && <p style={{ color: '#D97757', fontSize: 13, marginBottom: 16 }}>{error}</p>}
+
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                flex: 1, padding: '9px 16px', borderRadius: 4,
+                border: '1px solid rgba(230,235,242,0.14)',
+                background: 'transparent', color: 'rgba(237,240,244,0.62)',
+                cursor: 'pointer', fontSize: 13,
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !name.trim()}
+              style={{
+                flex: 1, padding: '9px 16px', borderRadius: 4,
+                background: '#D4A85A', color: '#0E1013',
+                border: 'none', fontWeight: 500, cursor: 'pointer', fontSize: 13,
+                opacity: (loading || !name.trim()) ? 0.5 : 1,
+              }}
+            >
+              {loading ? 'Starting...' : 'Start Import'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { api } from '../core/api/client';
-import type { BrandingConfig } from '../core/types';
+import type { Agent, BrandingConfig } from '../core/types';
 import { ProviderSetup } from '../setup/ProviderSetup';
 import { IntegrationsTab } from './IntegrationsTab';
 import { DataTab } from './DataTab';
 import { SecurityTab } from './SecurityTab';
+import { DeleteAgentModal } from './DeleteAgentModal';
+import { AgentMark } from '../shared/AgentMark';
 
 interface Props {
   branding: BrandingConfig | null;
@@ -12,10 +14,18 @@ interface Props {
   onClose: () => void;
 }
 
-type Tab = 'providers' | 'branding' | 'integrations' | 'chat' | 'data' | 'security';
+type Tab = 'providers' | 'branding' | 'integrations' | 'chat' | 'data' | 'security' | 'danger';
 
 export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
   const [tab, setTab] = useState<Tab>('providers');
+  const [deleteAgent, setDeleteAgent] = useState<Agent | null>(null);
+  const [dangerAgents, setDangerAgents] = useState<Agent[]>([]);
+
+  useEffect(() => {
+    if (tab === 'danger') {
+      api<{ agents: Agent[] }>('/api/agents').then(d => setDangerAgents(d.agents)).catch(() => {});
+    }
+  }, [tab]);
   const [companyName, setCompanyName] = useState(branding?.company_name || '');
   const [accentColor, setAccentColor] = useState(branding?.accent_color || '#C8D1D9');
   const [saving, setSaving] = useState(false);
@@ -56,6 +66,7 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
     { id: 'chat', label: 'Chat' },
     { id: 'data', label: 'Data' },
     { id: 'security', label: 'Security' },
+    { id: 'danger', label: 'Danger' },
   ];
 
   return (
@@ -98,8 +109,12 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
                   flex: 1, padding: '10px 0', textAlign: 'center',
                   fontSize: 12,
                   fontFamily: "'Inter Tight', system-ui, sans-serif",
-                  color: active ? '#EDF0F4' : 'rgba(237,240,244,0.62)',
-                  borderBottom: active ? '1px solid #D4A85A' : '1px solid rgba(230,235,242,0.07)',
+                  color: t.id === 'danger'
+                    ? (active ? '#D97757' : 'rgba(217,119,87,0.6)')
+                    : (active ? '#EDF0F4' : 'rgba(237,240,244,0.62)'),
+                  borderBottom: active
+                    ? (t.id === 'danger' ? '1px solid #D97757' : '1px solid #D4A85A')
+                    : '1px solid rgba(230,235,242,0.07)',
                   cursor: 'pointer',
                 }}
               >
@@ -230,6 +245,80 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
           {tab === 'data' && <DataTab />}
 
           {tab === 'security' && <SecurityTab />}
+
+          {tab === 'danger' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+              <div style={{
+                background: 'rgba(217,119,87,0.06)',
+                border: '1px solid rgba(217,119,87,0.15)',
+                borderRadius: 6, padding: '14px 16px',
+              }}>
+                <p style={{ fontSize: 13, color: '#D97757', margin: 0, lineHeight: 1.5 }}>
+                  Actions here are permanent and cannot be undone. Deleted agents lose all knowledge, conversations, and memory.
+                </p>
+              </div>
+
+              <div>
+                <h3 style={{
+                  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                  fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
+                  color: 'rgba(237,240,244,0.38)', marginBottom: 12,
+                }}>Delete agents</h3>
+
+                {dangerAgents.length === 0 ? (
+                  <p style={{ fontSize: 13, color: 'rgba(237,240,244,0.38)' }}>No agents to delete.</p>
+                ) : (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    {dangerAgents.map(agent => (
+                      <div key={agent.id} style={{
+                        display: 'flex', alignItems: 'center', gap: 12,
+                        padding: '10px 14px', borderRadius: 6,
+                        background: 'rgba(20,24,30,0.78)',
+                        border: '1px solid rgba(230,235,242,0.07)',
+                      }}>
+                        <AgentMark
+                          letter={agent.agent_name.charAt(0)}
+                          size={28}
+                          avatarUrl={agent.avatar_url
+                            ? `${agent.avatar_url}${agent.avatar_url.includes('?') ? '&' : '?'}token=${sessionStorage.getItem('chatty_token') || ''}`
+                            : undefined}
+                        />
+                        <span style={{
+                          flex: 1, fontSize: 14, color: '#EDF0F4',
+                          fontFamily: "'Inter Tight', system-ui, sans-serif",
+                        }}>{agent.agent_name}</span>
+                        <button
+                          onClick={() => setDeleteAgent(agent)}
+                          style={{
+                            background: 'transparent',
+                            border: '1px solid rgba(217,119,87,0.3)',
+                            color: '#D97757', borderRadius: 4,
+                            padding: '5px 12px', fontSize: 12,
+                            cursor: 'pointer',
+                            fontFamily: "'Inter Tight', system-ui, sans-serif",
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {deleteAgent && (
+            <DeleteAgentModal
+              agent={deleteAgent}
+              onClose={() => setDeleteAgent(null)}
+              onDeleted={id => {
+                setDangerAgents(prev => prev.filter(a => a.id !== id));
+                setDeleteAgent(null);
+                window.location.reload();
+              }}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/shared/icons.tsx
+++ b/frontend/src/shared/icons.tsx
@@ -28,6 +28,7 @@ export function IconPhone(p: IconProps) { return <Ico d="M22 16.9v3a2 2 0 0 1-2.
 export function IconUsers(p: IconProps) { return <Ico {...p}><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.9M16 3.1a4 4 0 0 1 0 7.8" /></Ico>; }
 export function IconFunnel(p: IconProps) { return <Ico {...p}><path d="M22 3H2l8 9.5V19l4 2v-8.5L22 3z" /></Ico>; }
 export function IconUser(p: IconProps) { return <Ico {...p}><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" /></Ico>; }
+export function IconDownload(p: IconProps) { return <Ico d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" {...p} />; }
 export function IconBot({ size = 18, strokeWidth = 1.75, className, style }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} style={{ flexShrink: 0, ...style }}>


### PR DESCRIPTION
## Summary

- Adds an **Import existing agent** button on the dashboard that creates a new Chatty agent through a guided conversational import wizard
- The new agent itself conducts the import — reading source files one by one, narrating what it finds, asking the user whether to clone or start fresh, and rewriting everything into Chatty's native context format
- Supports 4 source types: folder scan, OpenClaw auto-discovery (with guidance for remote installs), zip file upload, and pasted markdown
- Pre-seeded opening message with typewriter effect lists all options clearly; agent auto-redirects back to import conversation if user navigates away
- After import, generates a primed opener greeting in a fresh conversation
- Agent delete moved from card × button to Settings > Danger tab with Railway-style type-to-confirm modal

## Changes (18 commits, 32 files, ~2000 lines)

**Backend:**
- `backend/agents/import_service/` — source adapters (folder, OpenClaw, zip, paste), secrets scrubber, session manager, 10 import tools, primed opener
- `backend/agents/import_router.py` — `/import/start`, `/openclaw/discover`, seeded opener, OpenClaw guidance
- Import mode wired through `ai_service.chat()` with tool gating + forced power mode
- Schema: `conversations.mode` column, `import_sources` table with `ON DELETE CASCADE`
- Session sweep registered with APScheduler; file_cache cleanup on finalize

**Frontend:**
- Import Agent button + modal on dashboard
- Import Mode pill banner inside chat area (matches Telegram/WhatsApp style)
- `?conversation=` URL param handling + auto-redirect to active import conversation
- Typewriter effect on pre-seeded opener message
- `DeleteAgentModal` with type-to-confirm; Settings > Danger tab lists all agents
- `.zip` file attachments allowed (25MB) in import mode

**Security (6 review rounds):**
- Path traversal guards via `is_relative_to()` on all read/write paths
- Zip: symlink rejection, uncompressed size cap (100MB), filename sanitization
- Root home guard (`Path.home() != /`)
- Import mode excludes write/delete context tools (read-only context only)
- Error messages sanitized; orphaned agents cleaned up on start failure
- Folder scan caps at 1000 files, prunes node_modules/venv/build

## Test plan

- [ ] Click "Import agent", enter name, verify typewriter opener with source options
- [ ] Drag `.md`/`.txt` files into chat — agent processes them
- [ ] Give a folder path — agent scans and lists files
- [ ] Drop a `.zip` — agent extracts and lists contents
- [ ] Point at a CAKE OS backup with multiple agents — agent lists them, drills into subdirectory
- [ ] Agent walks through files, asks clone-vs-fresh, writes context files
- [ ] `finalize_import` creates new conversation with primed opener, frontend navigates
- [ ] Navigate away during import — auto-redirects back
- [ ] Settings > Danger tab — type-to-confirm delete works, agent removed from dashboard
- [ ] Verify secrets in source files are redacted
- [ ] Normal agent creation flow still works
- [ ] `npm run build` passes