### PR TITLE
Reframe QuickBooks setup doc around self-hosted app ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Chatty connects to your existing business tools so your agents can answer questi
 
 | Integration | Setup | What your agent can do |
 |---|---|---|
-| [Gmail](docs/gmail-setup.md) | Google sign-in | Search, read, send, reply to, and draft emails |
-| [Google Calendar](docs/google-calendar-setup.md) | Google sign-in | View, create, update, and delete calendar events |
-| [Google Drive](docs/google-drive-setup.md) | Google sign-in | Search, read, and upload files |
-| [QuickBooks Online](docs/quickbooks-setup.md) | Intuit OAuth | Invoices, estimates, payments, customers, vendors, and financial reports |
+| [Gmail](docs/gmail-setup.md) | Your own Google OAuth app — see [Google OAuth Setup](docs/google-oauth-setup.md) | Search, read, send, reply to, and draft emails |
+| [Google Calendar](docs/google-calendar-setup.md) | Your own Google OAuth app — see [Google OAuth Setup](docs/google-oauth-setup.md) | View, create, update, and delete calendar events |
+| [Google Drive](docs/google-drive-setup.md) | Your own Google OAuth app — see [Google OAuth Setup](docs/google-oauth-setup.md) | Search, read, and upload files |
+| [QuickBooks Online](docs/quickbooks-setup.md) | Your own Intuit OAuth app — see [QuickBooks Setup](docs/quickbooks-setup.md) | Invoices, estimates, payments, customers, vendors, and financial reports |
 | [QuickBooks CSV](docs/quickbooks-csv-setup.md) | One-click | Analyze exported QuickBooks CSV files — no OAuth required |
 | [CRM Lite](docs/crm-lite-setup.md) | One-click | Manage contacts, deals, tasks, and activities — built in, ships with demo data you can clear when ready |
 | [Telegram](docs/telegram-setup.md) | Bot token | Chat with your agent from Telegram |

--- a/docs/gmail-setup.md
+++ b/docs/gmail-setup.md
@@ -5,40 +5,24 @@ Connect your Gmail account so your Chatty agents can search, read, send, reply t
 ## Prerequisites
 
 - A Google account with Gmail enabled
+- Google OAuth credentials configured for Chatty — see [Google OAuth Setup](google-oauth-setup.md)
 
-## Local Setup
+> Gmail uses the same Google connection as Calendar and Drive. If you've already done the OAuth setup for one of those, you do not need to do it again — just enable the Gmail API in the same Google Cloud project.
 
-1. Start Chatty with `python run.py`
-2. Go to **Settings** > **Integrations** and click **Connect Google**
-3. Sign in with your Google account and choose the access level you want to grant:
-   - **Read** — search and read emails
-   - **Send** — read access plus send, reply, and draft emails
+## Setup
 
-## Railway Setup
+1. In your Google Cloud project, enable the **Gmail API** under **APIs & Services → Library** (skip if already enabled)
+2. In your OAuth consent screen → **Scopes**, add the Gmail scopes for the level of access you want:
+   - **Read** — `gmail.readonly`
+   - **Send** — `gmail.readonly` + `gmail.send` + `gmail.compose`
+   - **Modify** — `gmail.readonly` + `gmail.send` + `gmail.compose` + `gmail.modify`
+3. In Chatty, go to **Settings → Integrations** and click **Connect Google**
+4. Sign in and choose the Gmail access level you want — Chatty will request the matching scopes from Google
+5. Approve and you're connected
 
-1. Open your Chatty instance
-2. Go to **Settings** > **Integrations** and click **Connect Google**
-3. Sign in with your Google account and choose your access levels
+> **Note on scopes:** `gmail.readonly` and `gmail.modify` are Google "Restricted" scopes. For self-hosted personal use, this is fine — keep your OAuth app in Testing mode and add yourself as a test user. See the [Google OAuth Setup guide](google-oauth-setup.md#scopes--the-most-important-part) for the full picture.
 
-That's it — Chatty handles the OAuth flow through its hosted service at `auth.mechatty.com`, so there's no Google Cloud project or credentials to configure.
-
-> **Note:** Gmail uses the same Google connection as Google Calendar and Google Drive. You choose the access level for each service during the same sign-in flow.
-
-### Self-hosted OAuth (advanced)
-
-If you prefer to use your own Google OAuth credentials instead of the hosted service:
-
-1. Create a project in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) and enable the **Gmail API**
-2. Create OAuth 2.0 credentials (Client ID and Client Secret)
-3. Add your redirect URI (e.g., `http://localhost:8000/api/oauth/callback` for local)
-4. Set these in your `.env` file:
-   ```env
-   GOOGLE_CLIENT_ID=your-client-id
-   GOOGLE_CLIENT_SECRET=your-client-secret
-   ```
-5. Remove or leave `OAUTH_REDIRECT_URI` unset
-
-## What Your Agents Can Do
+## What your agents can do
 
 Once connected, your agents can:
 
@@ -48,6 +32,7 @@ Once connected, your agents can:
 - **Send emails** — compose and send new emails to any recipient
 - **Reply to emails** — reply to a specific message, or reply-all to the thread
 - **Create drafts** — draft an email for you to review and send later
+- **Mark as read/unread** — modify message read status (requires `gmail.modify` scope)
 
 Example questions you can ask:
 
@@ -59,7 +44,7 @@ Example questions you can ask:
 
 ## Notes
 
-- You choose the access level during setup — **Read** for search/read only, or **Send** for full email capabilities
+- You choose the access level during setup — **Read** for search/read only, **Send** for full email composition, or **Modify** for everything plus marking read/unread
 - Gmail search filters work the same as in Gmail itself (`from:`, `subject:`, `is:unread`, `has:attachment`, etc.)
 - HTML emails are automatically converted to readable text
-- Gmail uses the same Google connection as Calendar and Drive
+- Gmail uses the same Google connection as Calendar and Drive — connect once, use everywhere

--- a/docs/google-calendar-setup.md
+++ b/docs/google-calendar-setup.md
@@ -5,40 +5,23 @@ Connect your Google Calendar so your Chatty agents can view, search, create, upd
 ## Prerequisites
 
 - A Google account with Calendar enabled
+- Google OAuth credentials configured for Chatty — see [Google OAuth Setup](google-oauth-setup.md)
 
-## Local Setup
+> Google Calendar uses the same Google connection as Gmail and Drive. If you've already done the OAuth setup for one of those, you do not need to do it again — just enable the Google Calendar API in the same Google Cloud project.
 
-1. Start Chatty with `python run.py`
-2. Go to **Settings** > **Integrations** and click **Connect Google**
-3. Sign in with your Google account and choose the access level you want to grant:
-   - **Read** — view and search events
-   - **Full** — read access plus create, update, and delete events
+## Setup
 
-## Railway Setup
+1. In your Google Cloud project, enable the **Google Calendar API** under **APIs & Services → Library** (skip if already enabled)
+2. In your OAuth consent screen → **Scopes**, add the Calendar scopes for the level of access you want:
+   - **Read** — `calendar.readonly`
+   - **Full** — `calendar` (read + create/update/delete events)
+3. In Chatty, go to **Settings → Integrations** and click **Connect Google**
+4. Sign in and choose the Calendar access level you want — Chatty will request the matching scopes from Google
+5. Approve and you're connected
 
-1. Open your Chatty instance
-2. Go to **Settings** > **Integrations** and click **Connect Google**
-3. Sign in with your Google account and choose your access levels
+> **Note on scopes:** Both Calendar scopes are Google "Sensitive" scopes (not Restricted), which means they don't require the CASA security assessment if you ever submit for verification. For self-hosted personal use, Testing mode with yourself as a test user is fine.
 
-That's it — Chatty handles the OAuth flow through its hosted service at `auth.mechatty.com`, so there's no Google Cloud project or credentials to configure.
-
-> **Note:** Google Calendar uses the same Google connection as Gmail and Google Drive. You choose the access level for each service during the same sign-in flow.
-
-### Self-hosted OAuth (advanced)
-
-If you prefer to use your own Google OAuth credentials instead of the hosted service:
-
-1. Create a project in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) and enable the **Google Calendar API**
-2. Create OAuth 2.0 credentials (Client ID and Client Secret)
-3. Add your redirect URI (e.g., `http://localhost:8000/api/oauth/callback` for local)
-4. Set these in your `.env` file:
-   ```env
-   GOOGLE_CLIENT_ID=your-client-id
-   GOOGLE_CLIENT_SECRET=your-client-secret
-   ```
-5. Remove or leave `OAUTH_REDIRECT_URI` unset
-
-## What Your Agents Can Do
+## What your agents can do
 
 Once connected, your agents can:
 
@@ -65,4 +48,4 @@ Example questions you can ask:
 - Uses your primary calendar by default (other calendars can be specified by ID)
 - All-day events and timed events are both supported
 - Attendee response status (accepted, declined, tentative) is included in event details
-- Google Calendar uses the same Google connection as Gmail and Drive
+- Google Calendar uses the same Google connection as Gmail and Drive — connect once, use everywhere

--- a/docs/google-drive-setup.md
+++ b/docs/google-drive-setup.md
@@ -5,41 +5,24 @@ Connect your Google Drive so your Chatty agents can search, read, and upload fil
 ## Prerequisites
 
 - A Google account with Drive enabled
+- Google OAuth credentials configured for Chatty — see [Google OAuth Setup](google-oauth-setup.md)
 
-## Local Setup
+> Google Drive uses the same Google connection as Gmail and Calendar. If you've already done the OAuth setup for one of those, you do not need to do it again — just enable the Google Drive API in the same Google Cloud project.
 
-1. Start Chatty with `python run.py`
-2. Go to **Settings** > **Integrations** and click **Connect Google**
-3. Sign in with your Google account and choose the access level you want to grant:
-   - **Readonly** — browse and read files
-   - **File** — read access plus upload new files (can only access files created by Chatty)
-   - **Full** — complete Drive access including all files
+## Setup
 
-## Railway Setup
+1. In your Google Cloud project, enable the **Google Drive API** under **APIs & Services → Library** (skip if already enabled)
+2. In your OAuth consent screen → **Scopes**, add the Drive scopes for the level of access you want:
+   - **File** — `drive.file` (read/write only files Chatty creates or you explicitly open with it)
+   - **Readonly** — `drive.readonly` (browse and read all your Drive files)
+   - **Full** — `drive` (complete Drive access — read, write, and delete)
+3. In Chatty, go to **Settings → Integrations** and click **Connect Google**
+4. Sign in and choose the Drive access level you want — Chatty will request the matching scopes from Google
+5. Approve and you're connected
 
-1. Open your Chatty instance
-2. Go to **Settings** > **Integrations** and click **Connect Google**
-3. Sign in with your Google account and choose your access levels
+> **Note on scopes:** `drive.file` is a "Recommended" scope and works without verification. `drive.readonly` and `drive` are "Restricted" scopes — for self-hosted personal use, Testing mode with yourself as a test user sidesteps the CASA assessment requirement. See [Google OAuth Setup](google-oauth-setup.md#scopes--the-most-important-part) for details.
 
-That's it — Chatty handles the OAuth flow through its hosted service at `auth.mechatty.com`, so there's no Google Cloud project or credentials to configure.
-
-> **Note:** Google Drive uses the same Google connection as Gmail and Google Calendar. You choose the access level for each service during the same sign-in flow.
-
-### Self-hosted OAuth (advanced)
-
-If you prefer to use your own Google OAuth credentials instead of the hosted service:
-
-1. Create a project in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) and enable the **Google Drive API**
-2. Create OAuth 2.0 credentials (Client ID and Client Secret)
-3. Add your redirect URI (e.g., `http://localhost:8000/api/oauth/callback` for local)
-4. Set these in your `.env` file:
-   ```env
-   GOOGLE_CLIENT_ID=your-client-id
-   GOOGLE_CLIENT_SECRET=your-client-secret
-   ```
-5. Remove or leave `OAUTH_REDIRECT_URI` unset
-
-## What Your Agents Can Do
+## What your agents can do
 
 Once connected, your agents can:
 
@@ -59,6 +42,6 @@ Example questions you can ask:
 
 ## Notes
 
-- You choose the access level during setup — **Readonly** for browsing, **File** for read + upload (Chatty's own files only), or **Full** for complete access
+- You choose the access level during setup — **File** for Chatty's own files only, **Readonly** for browsing all files, or **Full** for complete access including delete
 - Google Docs, Sheets, and Slides are automatically exported to readable formats
-- Google Drive uses the same Google connection as Gmail and Calendar
+- Google Drive uses the same Google connection as Gmail and Calendar — connect once, use everywhere

--- a/docs/google-oauth-setup.md
+++ b/docs/google-oauth-setup.md
@@ -1,0 +1,176 @@
+# Google OAuth Setup
+
+This is the one-time Google Cloud setup that powers Gmail, Google Calendar, and Google Drive in Chatty. You only need to do this once — the same OAuth app is used for all three services, even if you only use one of them today.
+
+## How this works
+
+Because Chatty is self-hosted, **you must create your own Google Cloud project and bring your own OAuth Client ID and Client Secret.** The project does not provide a shared Google app, Client ID, or Client Secret — every Chatty user is the operator of their own private Google Cloud project, which authorizes their own Chatty instance against their own Google account.
+
+This setup is the price of admission for using any Google service with Chatty. Once it's done, your agents can talk to Gmail, Calendar, and Drive indefinitely.
+
+You will:
+
+1. Create a free Google Cloud project
+2. Enable the APIs for the Google services you want to use
+3. Configure the OAuth consent screen with your scopes
+4. Create OAuth 2.0 credentials (Client ID + Client Secret)
+5. Add the Redirect URI for your Chatty instance
+6. Drop the credentials into Chatty's `.env`
+
+## Prerequisites
+
+- A Google account
+- A running Chatty instance (local or deployed on Railway)
+- The public URL where your Chatty instance is reachable (e.g. `http://localhost:8000`, your Railway URL, or your custom domain)
+
+## Step 1: Create a Google Cloud project
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
+2. Click the project dropdown at the top → **New Project**
+3. Name it something like `Chatty` and click **Create**
+4. Wait a few seconds, then select the new project from the project picker
+
+The project is free. Google does not charge for OAuth or for the API calls Chatty makes — you only pay for billable services if you opt into them, which Chatty does not require.
+
+## Step 2: Enable the APIs you need
+
+For each Google service you want to use, you have to enable its API in your project.
+
+1. In the Cloud Console, open the navigation menu → **APIs & Services** → **Library**
+2. Search for and enable each of:
+   - **Gmail API** — required for the [Gmail integration](gmail-setup.md)
+   - **Google Calendar API** — required for the [Google Calendar integration](google-calendar-setup.md)
+   - **Google Drive API** — required for the [Google Drive integration](google-drive-setup.md)
+
+You only need to enable the APIs for services you actually want to use. You can come back later and enable more in the same project — no need to start over.
+
+## Step 3: Configure the OAuth consent screen
+
+This is the screen Google shows when you click "Connect Google" in Chatty. It tells Google what your app is and what permissions it asks for.
+
+1. In the Cloud Console, go to **APIs & Services** → **OAuth consent screen**
+2. Choose **External** as the user type and click **Create**
+   - "Internal" is only available if you have a Google Workspace organization. External works for everyone else.
+3. Fill in the basics:
+   - **App name** — `Chatty` (or whatever you want — only you will see this)
+   - **User support email** — your email
+   - **Developer contact** — your email
+4. Click **Save and Continue**
+
+### Scopes — the most important part
+
+On the **Scopes** step, click **Add or Remove Scopes** and select the scopes for the services you enabled. Chatty supports tiered access — pick whichever level matches what you want your agents to be able to do:
+
+**Gmail scopes:**
+
+| Scope | What it grants | Google's classification |
+|---|---|---|
+| `https://www.googleapis.com/auth/gmail.readonly` | Read emails | Restricted |
+| `https://www.googleapis.com/auth/gmail.send` | Send emails | Sensitive |
+| `https://www.googleapis.com/auth/gmail.compose` | Draft emails | Sensitive |
+| `https://www.googleapis.com/auth/gmail.modify` | Modify labels, mark read/unread | Restricted |
+
+**Calendar scopes:**
+
+| Scope | What it grants | Google's classification |
+|---|---|---|
+| `https://www.googleapis.com/auth/calendar.readonly` | View events | Sensitive |
+| `https://www.googleapis.com/auth/calendar` | Full calendar access (create/update/delete) | Sensitive |
+
+**Drive scopes:**
+
+| Scope | What it grants | Google's classification |
+|---|---|---|
+| `https://www.googleapis.com/auth/drive.file` | Read/write only files Chatty creates | Recommended (no verification) |
+| `https://www.googleapis.com/auth/drive.readonly` | Read all Drive files | Restricted |
+| `https://www.googleapis.com/auth/drive` | Full Drive access | Restricted |
+
+Click **Update**, then **Save and Continue** through the rest of the wizard.
+
+### Test users (important for personal use)
+
+On the **Test users** step, click **Add Users** and add the Google email address(es) you'll be using with Chatty.
+
+By default a new OAuth app is in **Testing** mode, which means only the test users you list here can authorize it. This is fine and free for personal/self-hosted use — you just add yourself as a test user and you're done. **Verification is not required** for your own use.
+
+> **Important:** Apps in Testing mode have a 7-day refresh token expiry. That means after a week without using Chatty, you'll have to click "Connect Google" again. If you use Chatty regularly this never matters — the token rotates on every API call. If you're going on vacation for two weeks, expect to reconnect when you get back.
+
+If you want longer refresh tokens, you can submit your app for **Verification** (free, takes ~2–6 weeks, requires a privacy policy URL and a YouTube demo of each scope being used). This makes sense if you're going to host Chatty for others. For personal use, Testing mode is fine.
+
+> **Restricted scopes (`gmail.readonly`, `gmail.modify`, `drive`, `drive.readonly`)** require an annual third-party security assessment called CASA on top of regular verification — typically $1,500+/year. For self-hosters using only their own Google account, Testing mode sidesteps this entirely. Just add yourself as a test user.
+
+## Step 4: Create OAuth credentials
+
+1. In the Cloud Console, go to **APIs & Services** → **Credentials**
+2. Click **Create Credentials** → **OAuth client ID**
+3. Application type: **Web application**
+4. Name: `Chatty` (or whatever)
+5. Under **Authorized redirect URIs**, click **Add URI** and paste the URL where your Chatty instance is reachable, with `/api/oauth/callback` appended:
+
+   | Where Chatty runs | Redirect URI |
+   |---|---|
+   | Local development | `http://localhost:8000/api/oauth/callback` |
+   | Railway | `https://your-app.up.railway.app/api/oauth/callback` |
+   | Custom domain | `https://chatty.yourdomain.com/api/oauth/callback` |
+
+6. Click **Create**
+7. Copy the **Client ID** and **Client Secret** that Google shows you
+
+Your Google app talks directly to your Chatty backend — there is no Chatty-operated proxy or shared callback URL.
+
+## Step 5: Add credentials to Chatty
+
+In your Chatty `backend/.env` file:
+
+```env
+GOOGLE_CLIENT_ID=your-client-id-here
+GOOGLE_CLIENT_SECRET=your-client-secret-here
+OAUTH_REDIRECT_URI=https://your-app.up.railway.app/api/oauth/callback
+```
+
+Use the exact same Redirect URI you configured in Step 4 — they must match character-for-character.
+
+Restart the Chatty backend so it picks up the new `.env`.
+
+## Step 6: Connect Google in Chatty
+
+1. Open Chatty in your browser
+2. Go to **Settings** (gear icon) → **Integrations** and click **Connect Google**
+3. A browser window opens to Google's consent screen
+4. Sign in with the Google account you added as a test user in Step 3
+5. You'll see an **"unverified app"** warning — this is expected for apps in Testing mode. Click **Advanced** → **Go to Chatty (unsafe)**. It says "unsafe" because Google has not verified your app, but it's *your* app authorizing *your* account, so it's exactly as safe as you make it.
+6. Choose the access level for each service (Gmail/Calendar/Drive) and approve
+7. You'll see a "Connected!" confirmation — the window can be closed
+
+## Troubleshooting
+
+### "Error 400: redirect_uri_mismatch"
+The Redirect URI in your Google Cloud OAuth credentials does not match what Chatty is sending. They must match exactly, including `http` vs `https`, the port, and the trailing `/api/oauth/callback`. Update one or the other.
+
+### "Access blocked: Chatty has not completed the Google verification process"
+Your Google account is not in the test users list. Go back to **OAuth consent screen** → **Test users** and add the email address you're trying to sign in with.
+
+### "This app isn't verified" warning every time
+Expected behavior for apps in Testing mode. Click **Advanced** → **Go to Chatty (unsafe)** to proceed. This is your own app — the warning is Google's standard caution for unverified apps. To remove the warning, submit for verification (free, ~2–6 weeks for Sensitive scopes).
+
+### Refresh token suddenly stopped working
+If your app is in Testing mode, refresh tokens expire after 7 days of inactivity. Just click **Connect Google** again in **Settings → Integrations** to get a fresh token. To eliminate this, submit for verification.
+
+### Missing capabilities (e.g. agent says it can't read email but you connected Gmail)
+You probably granted only some scopes during the consent screen. Disconnect Google in **Settings → Integrations** and reconnect, this time choosing the access level you actually want. Or check the **OAuth consent screen → Scopes** in Google Cloud to confirm the right scopes are configured for your app.
+
+### "The OAuth client was not found" / "invalid_client"
+Your `GOOGLE_CLIENT_ID` or `GOOGLE_CLIENT_SECRET` in `.env` is wrong. Re-copy them from Google Cloud and restart the backend.
+
+## Why does Chatty work this way?
+
+Most consumer products hide all of this — you click "Connect Google" and it just works, because the company runs a single shared Google app on your behalf. Chatty is open source and self-hosted, so **there is no shared Google app, Client ID, or Client Secret provided by the project**. Every Chatty user creates their own Google Cloud project and uses their own credentials.
+
+The benefits:
+
+- You have full control over your Google credentials — they live in your `.env` and never leave your machine
+- No third-party infrastructure sits in the OAuth path
+- The project stays free to run, with no centralized cost to fund
+- Whatever Google data your agents access flows directly between Google and your Chatty instance — Chatty's project does not see it
+
+The trade-off is the 15 minutes of one-time setup above and the weekly re-auth in Testing mode. If that ever becomes a barrier, see the project README for the optional managed hosted service that handles this for you.

--- a/docs/google-oauth-setup.md
+++ b/docs/google-oauth-setup.md
@@ -173,4 +173,4 @@ The benefits:
 - The project stays free to run, with no centralized cost to fund
 - Whatever Google data your agents access flows directly between Google and your Chatty instance — Chatty's project does not see it
 
-The trade-off is the 15 minutes of one-time setup above and the weekly re-auth in Testing mode. If that ever becomes a barrier, see the project README for the optional managed hosted service that handles this for you.
+The trade-off is the 15 minutes of one-time setup above and the weekly re-auth in Testing mode.

--- a/docs/quickbooks-setup.md
+++ b/docs/quickbooks-setup.md
@@ -4,7 +4,7 @@ This guide walks you through connecting your QuickBooks Online account to Chatty
 
 ## How this works
 
-Because Chatty is self-hosted, **you create your own private Intuit Developer app** and use it to authorize your own Chatty instance against your own QuickBooks company. Chatty does not have a shared, central QuickBooks app that all installations connect through — every self-hosted user is the operator of their own app.
+Because Chatty is self-hosted, **you must create your own Intuit Developer app and bring your own Client ID and Client Secret.** The project does not provide a shared QuickBooks app, Client ID, or Client Secret — every Chatty user is the operator of their own private app, which authorizes their own Chatty instance against their own QuickBooks company.
 
 This is a one-time setup. Once your app is created, your agents can talk to your QuickBooks data indefinitely.
 
@@ -59,11 +59,7 @@ For real use:
 
 The Redirect URI is the URL Intuit sends users to after they approve the connection. It must match **exactly** between your Intuit app and your Chatty config.
 
-Pick the option that matches how you're running Chatty:
-
-### Option A — Direct to your Chatty instance (recommended for self-hosters)
-
-Use the URL where Chatty is reachable, with `/api/oauth/callback` appended:
+Use the URL where your Chatty instance is reachable, with `/api/oauth/callback` appended:
 
 | Where Chatty runs | Redirect URI |
 |---|---|
@@ -71,27 +67,9 @@ Use the URL where Chatty is reachable, with `/api/oauth/callback` appended:
 | Railway | `https://your-app.up.railway.app/api/oauth/callback` |
 | Custom domain | `https://chatty.yourdomain.com/api/oauth/callback` |
 
-In your Intuit app, on the **Keys and credentials** page, click **redirect urls** (or open **Settings**), paste the URL, and click **Save**.
+In your Intuit app, on the **Keys and credentials** page, click **redirect urls** (or open **Settings**), paste your URL, and click **Save**.
 
-Then in your Chatty `.env`:
-
-```env
-OAUTH_REDIRECT_URI=https://your-app.up.railway.app/api/oauth/callback
-```
-
-This is the cleanest setup — your Intuit app talks directly to your Chatty backend, no third party in between.
-
-### Option B — Use the auth.mechatty.com proxy (Railway convenience option)
-
-If you're on Railway and don't want to keep updating the Intuit app every time your Railway URL changes, you can use Chatty's shared callback proxy. Set the redirect URI in your Intuit app to:
-
-```
-https://auth.mechatty.com/callback
-```
-
-Leave `OAUTH_REDIRECT_URI` **unset** in your `.env`. The proxy receives the callback from Intuit and forwards it to your Chatty instance based on the state parameter. No customer data flows through it — only the short-lived authorization code.
-
-Allowed forwarding destinations: `*.up.railway.app`, `localhost`, `127.0.0.1`. See [Domain Allowlist](#domain-allowlist) below to add your own.
+Your Intuit app talks directly to your Chatty backend — there is no Chatty-operated proxy or shared callback URL.
 
 ## Step 5: Add credentials to Chatty
 
@@ -110,7 +88,7 @@ QUICKBOOKS_API_BASE_URL=https://quickbooks.api.intuit.com/v3/company
 
 If you're using **Development** credentials (sandbox), leave that line out — Chatty defaults to the sandbox URL.
 
-If you chose **Option A** above, also set:
+Set the Redirect URI to match what you configured in your Intuit app in Step 4:
 
 ```env
 OAUTH_REDIRECT_URI=https://your-app.up.railway.app/api/oauth/callback
@@ -172,21 +150,14 @@ QuickBooks access tokens expire after 1 hour. Chatty automatically refreshes the
 ### "Sandbox not found" or empty data
 Your Development app needs a sandbox company attached. In the Intuit Developer dashboard, go to **Sandboxes** and create one. Then re-authorize from Chatty.
 
-## Domain Allowlist
-
-If you're using **Option B** (the `auth.mechatty.com` proxy), the proxy only forwards callbacks to a known list of trusted destinations. Currently allowed:
-
-- `*.up.railway.app` — Railway deployments
-- `localhost` / `127.0.0.1` — local development
-
-If you're hosting Chatty on a different domain and want to keep using the proxy, open a pull request adding your domain pattern to `website/auth/callback/index.php`, or just switch to **Option A** (Direct to your Chatty instance) — that approach has no domain restrictions because there's no proxy involved.
-
 ## Why does Chatty work this way?
 
-Most consumer SaaS products hide all of this — you click "Connect QuickBooks" and it just works, because the company runs a single shared Intuit app on your behalf. Chatty is open source and self-hosted, so there is no central operator. You become the operator of your own private app, which:
+Most consumer SaaS products hide all of this — you click "Connect QuickBooks" and it just works, because the company runs a single shared Intuit app on your behalf. Chatty is open source and self-hosted, so **there is no shared QuickBooks app, Client ID, or Client Secret provided by the project**. Every Chatty user creates their own Intuit Developer app and uses their own credentials.
 
-- Gives you full control over your QuickBooks credentials (they never leave your machine)
-- Avoids any per-user data passing through a third party
-- Keeps the project free — there's no centralized cost to fund
+The benefits:
+
+- You have full control over your QuickBooks credentials — they live in your `.env` and never leave your machine
+- No third-party infrastructure sits in the OAuth path
+- The project stays free to run, with no centralized cost to fund
 
 The trade-off is the 10 minutes of one-time setup above. If that ever becomes a barrier, see the project README for the optional managed hosted service that handles this for you.

--- a/docs/quickbooks-setup.md
+++ b/docs/quickbooks-setup.md
@@ -2,68 +2,132 @@
 
 This guide walks you through connecting your QuickBooks Online account to Chatty so your AI agents can query invoices, customers, bills, and financial reports.
 
+## How this works
+
+Because Chatty is self-hosted, **you create your own private Intuit Developer app** and use it to authorize your own Chatty instance against your own QuickBooks company. Chatty does not have a shared, central QuickBooks app that all installations connect through — every self-hosted user is the operator of their own app.
+
+This is a one-time setup. Once your app is created, your agents can talk to your QuickBooks data indefinitely.
+
+You will:
+
+1. Create a free Intuit Developer account
+2. Create an app in their dashboard (this is your private app, not published anywhere)
+3. Copy your Client ID, Client Secret, and Redirect URI into Chatty's `.env`
+4. Click **Connect QuickBooks** in Chatty and authorize your own app
+
 ## Prerequisites
 
-- A QuickBooks Online account (any plan)
+- A QuickBooks Online account (Simple Start or higher — Self-Employed plans don't expose the v3 Accounting API)
 - A running Chatty instance (local or deployed on Railway)
+- The public URL where your Chatty instance is reachable (e.g. `http://localhost:8000`, your Railway URL, or your custom domain)
 
-## Step 1: Create an Intuit Developer Account
+## Step 1: Create an Intuit Developer account
 
 1. Go to [developer.intuit.com](https://developer.intuit.com/)
-2. Sign in with your existing QuickBooks/Intuit credentials (or create a new account)
+2. Sign in with your existing QuickBooks/Intuit credentials, or create a new account
 
-## Step 2: Create an App
+The developer account is free and separate from your QuickBooks subscription. You can use the same email.
+
+## Step 2: Create your app
 
 1. From the Intuit Developer dashboard, click **Create an app**
 2. Select **QuickBooks Online and Payments**
-3. Name your app (e.g. "Chatty")
-4. Select the **com.intuit.quickbooks.accounting** scope
+3. Name your app — `Chatty` is fine, but it can be anything (e.g. `Acme Co Chatty`). Only you will see this name.
+4. Under scopes, select **com.intuit.quickbooks.accounting**
 5. Click **Create app**
 
-## Step 3: Get Your Credentials
+Because this app is for your own private use, you do **not** need to submit it for Intuit App Review or publish it to the App Store. App Review is only required if you want to distribute the app to other QuickBooks users — which a self-hoster doesn't.
 
-1. In your app, go to **Keys and credentials** in the left sidebar
-2. Select the **Development** tab (for testing with sandbox data) or **Production** tab (for your real QuickBooks data)
-3. Toggle **Show credentials** and copy your **Client ID** and **Client Secret**
+## Step 3: Get your credentials
+
+Intuit gives every app two sets of credentials — keep them straight, this trips people up:
+
+| Tab | What it does | When to use |
+|---|---|---|
+| **Development** | Connects only to Intuit's *sandbox* (a fake test company) | Trying things out before touching real books |
+| **Production** | Connects to your real QuickBooks company data | Actual day-to-day use |
+
+For real use:
+
+1. In your app, open **Keys and credentials** in the left sidebar
+2. Switch to the **Production** tab
+3. Toggle **Show credentials** and copy the **Client ID** and **Client Secret**
+
+> Intuit may ask you to complete a short security questionnaire before issuing Production keys (data handling, where the app runs, etc.). For a personal self-hosted instance the answers are straightforward — the app runs on your own machine or your own Railway deployment, data is stored locally, and you are the only user.
 
 ## Step 4: Set the Redirect URI
 
-1. On the Keys and credentials page, click the **redirect urls** link (or go to **Settings** in the left sidebar)
-2. Add the following redirect URI:
-   ```
-   https://auth.mechatty.com/callback
-   ```
-3. Click **Save**
+The Redirect URI is the URL Intuit sends users to after they approve the connection. It must match **exactly** between your Intuit app and your Chatty config.
 
-> **Note:** This is the same redirect URI for all Chatty instances — local dev and Railway. The auth.mechatty.com proxy securely forwards the OAuth callback to your specific instance. If you're hosting on a different platform, see [Domain Allowlist](#domain-allowlist) below.
+Pick the option that matches how you're running Chatty:
 
-## Step 5: Add Credentials to Chatty
+### Option A — Direct to your Chatty instance (recommended for self-hosters)
 
-Add these environment variables to your Chatty `.env` file (in the `backend/` directory):
+Use the URL where Chatty is reachable, with `/api/oauth/callback` appended:
+
+| Where Chatty runs | Redirect URI |
+|---|---|
+| Local development | `http://localhost:8000/api/oauth/callback` |
+| Railway | `https://your-app.up.railway.app/api/oauth/callback` |
+| Custom domain | `https://chatty.yourdomain.com/api/oauth/callback` |
+
+In your Intuit app, on the **Keys and credentials** page, click **redirect urls** (or open **Settings**), paste the URL, and click **Save**.
+
+Then in your Chatty `.env`:
+
+```env
+OAUTH_REDIRECT_URI=https://your-app.up.railway.app/api/oauth/callback
+```
+
+This is the cleanest setup — your Intuit app talks directly to your Chatty backend, no third party in between.
+
+### Option B — Use the auth.mechatty.com proxy (Railway convenience option)
+
+If you're on Railway and don't want to keep updating the Intuit app every time your Railway URL changes, you can use Chatty's shared callback proxy. Set the redirect URI in your Intuit app to:
+
+```
+https://auth.mechatty.com/callback
+```
+
+Leave `OAUTH_REDIRECT_URI` **unset** in your `.env`. The proxy receives the callback from Intuit and forwards it to your Chatty instance based on the state parameter. No customer data flows through it — only the short-lived authorization code.
+
+Allowed forwarding destinations: `*.up.railway.app`, `localhost`, `127.0.0.1`. See [Domain Allowlist](#domain-allowlist) below to add your own.
+
+## Step 5: Add credentials to Chatty
+
+In your Chatty `backend/.env` file:
 
 ```env
 QUICKBOOKS_CLIENT_ID=your-client-id-here
 QUICKBOOKS_CLIENT_SECRET=your-client-secret-here
 ```
 
-If you're using your real QuickBooks account (not sandbox), also set:
+If you're using **Production** credentials (real QuickBooks data), also set:
 
 ```env
 QUICKBOOKS_API_BASE_URL=https://quickbooks.api.intuit.com/v3/company
 ```
 
-Restart the Chatty backend after updating the `.env` file.
+If you're using **Development** credentials (sandbox), leave that line out — Chatty defaults to the sandbox URL.
+
+If you chose **Option A** above, also set:
+
+```env
+OAUTH_REDIRECT_URI=https://your-app.up.railway.app/api/oauth/callback
+```
+
+Restart the Chatty backend so it picks up the new `.env`.
 
 ## Step 6: Connect QuickBooks in Chatty
 
 1. Open Chatty in your browser
-2. Go to **Settings** (gear icon) > **Integrations** tab, or run through the onboarding wizard
+2. Go to **Settings** (gear icon) → **Integrations**, or run through the onboarding wizard
 3. Click **Connect QuickBooks**
-4. A browser window will open to Intuit's login page
-5. Sign in and authorize Chatty to access your QuickBooks data
+4. A browser window opens to Intuit's login page
+5. Sign in (or pick the QuickBooks company you want to authorize) and approve the connection
 6. You'll see a "Connected!" confirmation — the window can be closed
 
-## What Your Agents Can Do
+## What your agents can do
 
 Once connected, your AI agents can:
 
@@ -77,6 +141,7 @@ Once connected, your AI agents can:
 - **Send documents** — email invoices and estimates directly to customers from QuickBooks
 
 Example questions you can ask your agent:
+
 - "Show me all unpaid invoices"
 - "Who are my top 5 customers by revenue?"
 - "What's my profit and loss for Q1 2026?"
@@ -88,36 +153,40 @@ Example questions you can ask your agent:
 ## Troubleshooting
 
 ### "OAuth not configured for quickbooks: missing client_id in .env"
-Your `QUICKBOOKS_CLIENT_ID` is not set. Check your `.env` file in the `backend/` directory and restart the backend.
+Your `QUICKBOOKS_CLIENT_ID` is not set. Check your `.env` file in `backend/` and restart the backend.
+
+### "redirect_uri did not match" / "invalid_redirect_uri"
+The URL in your Intuit app's Redirect URIs list does not match what Chatty is sending. They must match character-for-character, including `http` vs `https` and the trailing `/api/oauth/callback`. Update one or the other so they line up exactly.
 
 ### "QuickBooks did not return a company ID (realmId)"
-The OAuth flow completed but QuickBooks didn't return a company ID. Try disconnecting and reconnecting.
+The OAuth flow completed but Intuit didn't return a company ID. Disconnect and reconnect; if it persists, confirm your app has the **com.intuit.quickbooks.accounting** scope enabled.
 
 ### 403 Forbidden errors on API calls
-You're likely using Development credentials with the production API URL (or vice versa). Make sure:
-- **Development credentials** → don't set `QUICKBOOKS_API_BASE_URL` (defaults to sandbox)
+You're likely mixing Development credentials with the production API URL (or vice versa):
+- **Development credentials** → leave `QUICKBOOKS_API_BASE_URL` unset (defaults to sandbox)
 - **Production credentials** → set `QUICKBOOKS_API_BASE_URL=https://quickbooks.api.intuit.com/v3/company`
 
 ### Token expired
-QuickBooks access tokens expire after 1 hour. Chatty automatically refreshes them using the refresh token. If refresh fails, reconnect QuickBooks through Settings > Integrations.
+QuickBooks access tokens expire after 1 hour. Chatty automatically refreshes them using the refresh token. Refresh tokens themselves last 100 days and rotate on each use, so as long as you connect at least once every 100 days you'll stay connected. If refresh fails, just reconnect from **Settings → Integrations**.
+
+### "Sandbox not found" or empty data
+Your Development app needs a sandbox company attached. In the Intuit Developer dashboard, go to **Sandboxes** and create one. Then re-authorize from Chatty.
 
 ## Domain Allowlist
 
-The auth.mechatty.com OAuth proxy validates that callbacks are only forwarded to trusted domains. Currently allowed:
+If you're using **Option B** (the `auth.mechatty.com` proxy), the proxy only forwards callbacks to a known list of trusted destinations. Currently allowed:
 
 - `*.up.railway.app` — Railway deployments
 - `localhost` / `127.0.0.1` — local development
 
-If you're hosting Chatty on a different domain, the proxy will reject the callback with "Callback domain not allowed." To add your domain, open a pull request adding your domain pattern to `website/auth/callback/index.php`, or message Will directly on [WhatsApp](https://wa.me/qr/TX3OGA6ME6LHD1).
+If you're hosting Chatty on a different domain and want to keep using the proxy, open a pull request adding your domain pattern to `website/auth/callback/index.php`, or just switch to **Option A** (Direct to your Chatty instance) — that approach has no domain restrictions because there's no proxy involved.
 
-### Advanced: Direct OAuth (bypassing the proxy)
+## Why does Chatty work this way?
 
-If you prefer not to use the proxy, you can configure QuickBooks OAuth to redirect directly to your instance:
+Most consumer SaaS products hide all of this — you click "Connect QuickBooks" and it just works, because the company runs a single shared Intuit app on your behalf. Chatty is open source and self-hosted, so there is no central operator. You become the operator of your own private app, which:
 
-1. In the Intuit developer portal, create your own app and set the redirect URI to `https://your-domain.com/api/oauth/callback`
-2. In your `.env` file, set:
-   ```env
-   OAUTH_REDIRECT_URI=https://your-domain.com/api/oauth/callback
-   ```
+- Gives you full control over your QuickBooks credentials (they never leave your machine)
+- Avoids any per-user data passing through a third party
+- Keeps the project free — there's no centralized cost to fund
 
-This bypasses the proxy entirely — your Intuit app redirects directly to your backend.
+The trade-off is the 10 minutes of one-time setup above. If that ever becomes a barrier, see the project README for the optional managed hosted service that handles this for you.

--- a/docs/quickbooks-setup.md
+++ b/docs/quickbooks-setup.md
@@ -160,4 +160,4 @@ The benefits:
 - No third-party infrastructure sits in the OAuth path
 - The project stays free to run, with no centralized cost to fund
 
-The trade-off is the 10 minutes of one-time setup above. If that ever becomes a barrier, see the project README for the optional managed hosted service that handles this for you.
+The trade-off is the 10 minutes of one-time setup above.


### PR DESCRIPTION
Lead with the reality that self-hosters operate their own private
Intuit app, promote direct-to-instance redirect URIs as the default
path (proxy is now an opt-in Railway convenience), clarify
Development vs Production credentials, and expand troubleshooting
for redirect URI mismatches and refresh token lifetimes.