### PR TITLE
Skip Telegram reply when agent is busy processing

### DIFF
--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -7,6 +7,8 @@ and JWT-protected admin endpoints for bot token management and registration.
 import asyncio
 import hmac
 import logging
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -23,6 +25,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["telegram"])
 
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="telegram-webhook")
+
+# Per-chat busy tracking: maps (agent_slug, chat_id) → start timestamp.
+# Entries older than _BUSY_TTL are treated as stale (hung request).
+_busy_chats: dict[tuple[str, int], float] = {}
+_busy_lock = threading.Lock()
+_BUSY_TTL = 300  # 5 minutes
 
 from pathlib import Path as _Path
 _AGENTS_DIR = _Path(__file__).resolve().parent.parent.parent / "data" / "agents"
@@ -147,28 +155,62 @@ def _safe_process_telegram(
             if is_bot:
                 group.record_bot_message(chat_id)
 
-            loop = asyncio.new_event_loop()
-            try:
-                response = loop.run_until_complete(
-                    service.process_group_message(
-                        chat_id=chat_id,
+            # Busy check — save message to history but skip AI if already processing
+            busy_key = (agent_slug, chat_id)
+            busy_started = time.monotonic()
+            with _busy_lock:
+                existing = _busy_chats.get(busy_key)
+                if existing is not None and (busy_started - existing) < _BUSY_TTL:
+                    is_busy = True
+                else:
+                    _busy_chats[busy_key] = busy_started
+                    is_busy = False
+
+            if is_busy:
+                logger.info("Telegram busy (group): agent=%s chat=%s — saving without reply", agent_slug, chat_id)
+                prefix = group.build_group_prefix(group_name, sender_name, is_bot)
+                loop = asyncio.new_event_loop()
+                try:
+                    loop.run_until_complete(service.save_message_only(
                         agent_id=agent["id"],
-                        sender_name=sender_name,
-                        sender_is_bot=is_bot,
-                        group_name=group_name,
-                        message_text=message,
-                    )
-                )
-            finally:
-                loop.close()
+                        agent_slug=agent_slug,
+                        sender_id=f"group:{chat_id}",
+                        content=prefix + message,
+                        source="telegram-group",
+                    ))
+                except Exception:
+                    logger.warning("Failed to save busy-skipped group message for chat=%s", chat_id, exc_info=True)
+                finally:
+                    loop.close()
+                return
 
             try:
-                send_message(chat_id, response, bot_token)
+                loop = asyncio.new_event_loop()
+                try:
+                    response = loop.run_until_complete(
+                        service.process_group_message(
+                            chat_id=chat_id,
+                            agent_id=agent["id"],
+                            sender_name=sender_name,
+                            sender_is_bot=is_bot,
+                            group_name=group_name,
+                            message_text=message,
+                        )
+                    )
+                finally:
+                    loop.close()
+
+                try:
+                    send_message(chat_id, response, bot_token)
+                finally:
+                    group.record_response(chat_id, agent["id"])
             finally:
-                group.record_response(chat_id, agent["id"])
+                with _busy_lock:
+                    if _busy_chats.get(busy_key) == busy_started:
+                        del _busy_chats[busy_key]
             return
 
-        # ── Private chat path (unchanged) ────────────────────────────
+        # ── Private chat path ────────────────────────────────────────
         # Check if sender has a mapping
         mapping = state.get_mapping_by_sender("telegram", user_id)
         if not mapping:
@@ -176,6 +218,7 @@ def _safe_process_telegram(
             if lifecycle.try_auto_register(agent["id"], user_id, sender_name):
                 logger.info("Auto-registered Telegram user %s for agent %s", user_id, agent["agent_name"])
                 _mark_telegram_configured(agent["slug"])
+                mapping = state.get_mapping_by_sender("telegram", user_id)
             else:
                 send_message(
                     chat_id,
@@ -184,16 +227,50 @@ def _safe_process_telegram(
                 )
                 return
 
-        # Process the message via async service
-        loop = asyncio.new_event_loop()
-        try:
-            response = loop.run_until_complete(
-                service.process_message(user_id, sender_name, message)
-            )
-        finally:
-            loop.close()
+        # Busy check — save message to history but skip AI if already processing
+        mapped_agent_id = mapping["agent_id"] if mapping else agent["id"]
+        busy_key = (agent_slug, chat_id)
+        busy_started = time.monotonic()
+        with _busy_lock:
+            existing = _busy_chats.get(busy_key)
+            if existing is not None and (busy_started - existing) < _BUSY_TTL:
+                is_busy = True
+            else:
+                _busy_chats[busy_key] = busy_started
+                is_busy = False
 
-        send_message(chat_id, response, bot_token)
+        if is_busy:
+            logger.info("Telegram busy (private): agent=%s chat=%s — saving without reply", agent_slug, chat_id)
+            prefix = f"[via Telegram from {sender_name}] "
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(service.save_message_only(
+                    agent_id=mapped_agent_id,
+                    agent_slug=agent_slug,
+                    sender_id=user_id,
+                    content=prefix + message,
+                ))
+            except Exception:
+                logger.warning("Failed to save busy-skipped message for chat=%s", chat_id, exc_info=True)
+            finally:
+                loop.close()
+            return
+
+        # Process the message via async service
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                response = loop.run_until_complete(
+                    service.process_message(user_id, sender_name, message)
+                )
+            finally:
+                loop.close()
+
+            send_message(chat_id, response, bot_token)
+        finally:
+            with _busy_lock:
+                if _busy_chats.get(busy_key) == busy_started:
+                    del _busy_chats[busy_key]
     except Exception:
         logger.exception("Telegram processing failed (slug=%s, user_id=%s)", agent_slug, user_id)
         try:

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -39,6 +39,43 @@ logger = logging.getLogger(__name__)
 # Maximum recent messages to include for context
 MAX_CONTEXT_MESSAGES = 20
 
+
+async def save_message_only(
+    agent_id: str,
+    agent_slug: str,
+    sender_id: str,
+    content: str,
+    source: str = "telegram",
+) -> None:
+    """Save a user message to chat history without running the AI.
+
+    Used when the agent is already busy processing a message for this chat.
+    The message is preserved so it appears in context for the next AI turn.
+    Never raises — logs failures internally.
+    """
+    try:
+        chat_service = get_chat_service(agent_slug)
+        if not chat_service:
+            logger.warning("save_message_only: no chat service for %s", agent_slug)
+            return
+
+        conv = state.get_or_create_conversation(sender_id, agent_id)
+        chatty_conv_id = conv.get("chatty_conversation_id")
+        if not chatty_conv_id:
+            # Don't create a new conversation here — the active request will
+            # create it.  Skip saving to avoid a race on conversation creation.
+            return
+
+        chat_service.save_message(
+            conversation_id=chatty_conv_id,
+            msg_id=str(uuid.uuid4()),
+            role="user",
+            content=content,
+        )
+        logger.info("save_message_only: saved busy-skipped message for %s", agent_slug)
+    except Exception:
+        logger.warning("save_message_only: failed for agent=%s sender=%s", agent_slug, sender_id, exc_info=True)
+
 # Integration module registry (same as agents/router.py)
 _INTEGRATION_MODULES = {
     "crm_lite": ("integrations.crm_lite.tools", "CRM_LITE_TOOL_DEFS"),


### PR DESCRIPTION
## Summary
- Adds per-chat busy-state tracking to Telegram webhook processing — when the agent is already handling a message for a chat, new messages are saved to chat history but no AI call is made and no reply is sent
- Prevents thread pool exhaustion and multi-minute delays when users send follow-up messages while the agent is doing long tool operations (e.g. batch email marking)
- Uses timestamps with 5-minute TTL so hung requests auto-expire; conditional cleanup prevents stale requests from popping newer entries

## Test plan
- [ ] Send a Telegram message that triggers a long tool operation (e.g. "search my emails and mark them all as read")
- [ ] While processing, send 2-3 follow-up messages on Telegram
- [ ] Verify follow-up messages appear in chat history (visible in Chatty web UI)
- [ ] Verify no AI response is sent for follow-up messages
- [ ] After the first operation completes, verify sending a new message works normally and includes the skipped messages in context
- [ ] Test group chats the same way