### PR TITLE
Add PDF and DOCX drag-and-drop import to chat

### DIFF
--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -739,7 +739,7 @@ async def update_title(
 
 # ── Per-agent: File upload chat ──────────────────────────────────────────────
 
-_ALLOWED_EXTENSIONS = {"csv", "xlsx", "md", "txt"}
+_ALLOWED_EXTENSIONS = {"csv", "xlsx", "md", "txt", "pdf", "docx"}
 _MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 _MAX_FILES = 5
 
@@ -803,6 +803,32 @@ async def agent_chat_upload(
                 f"[Attached zip file: {safe_name}] "
                 f"Call extract_zip with filename=\"{safe_name}\" to process it."
             )
+            continue
+
+        # Extract text from PDF / DOCX and cache raw bytes for forwarding
+        if ext in ("pdf", "docx"):
+            from core.agents.tools.file_cache import cache_file
+            from core.agents.tools.text_extraction import extract_text
+
+            _meta = {
+                "pdf": ("PDF", "upload.pdf", "application/pdf"),
+                "docx": ("DOCX", "upload.docx",
+                         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+            }
+            label, fallback, mime = _meta[ext]
+            safe_name = Path((f.filename or fallback).replace("\\", "/")).name
+
+            extracted, truncated = extract_text(content_bytes, ext, 50_000)
+            file_ref = cache_file(str(DATA_DIR / agent["slug"] / "file_cache"),
+                                  content_bytes, safe_name, mime)
+
+            footer = f"[End of {label}]"
+            if not extracted.strip():
+                extracted = "(No extractable text found. Use file_ref to forward the original.)"
+            elif truncated:
+                footer = f"(truncated at 50,000 characters)\n{footer}"
+
+            file_texts.append(f"[Attached {label}: {safe_name} — file_ref={file_ref}]\n{extracted}\n{footer}")
             continue
 
         # Convert XLSX to CSV

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -4,7 +4,7 @@ import { AgentMessageBubble } from './AgentMessageBubble';
 import { IconAttach, IconArrowUp } from '../../shared/icons';
 import { useIsMobile } from '../../shared/useIsMobile';
 
-const ALLOWED_EXTENSIONS = new Set(['csv', 'xlsx', 'md', 'txt', 'pdf']);
+const ALLOWED_EXTENSIONS = new Set(['csv', 'xlsx', 'md', 'txt', 'pdf', 'docx']);
 const MAX_FILE_SIZE = 1 * 1024 * 1024;
 const MAX_PDF_SIZE = 10 * 1024 * 1024;
 const MAX_FILES = 5;
@@ -86,8 +86,8 @@ export function AgentChatPanel({
       const ext = getExtension(f.name);
       const allowed = importMode ? new Set([...ALLOWED_EXTENSIONS, 'zip']) : ALLOWED_EXTENSIONS;
       if (!allowed.has(ext)) { errors.push(`${f.name}: unsupported type (.${ext})`); continue; }
-      const maxSize = ext === 'zip' ? 25 * 1024 * 1024 : ext === 'pdf' ? MAX_PDF_SIZE : MAX_FILE_SIZE;
-      const maxLabel = ext === 'pdf' ? '10 MB' : '1 MB';
+      const maxSize = ext === 'zip' ? 25 * 1024 * 1024 : (ext === 'pdf' || ext === 'docx') ? MAX_PDF_SIZE : MAX_FILE_SIZE;
+      const maxLabel = ext === 'zip' ? '25 MB' : (ext === 'pdf' || ext === 'docx') ? '10 MB' : '1 MB';
       if (f.size > maxSize) { errors.push(`${f.name}: exceeds ${maxLabel}`); continue; }
       if (f.size === 0) { errors.push(`${f.name}: empty file`); continue; }
       if (pendingFiles.some(p => p.name === f.name)) { errors.push(`${f.name}: already attached`); continue; }
@@ -209,7 +209,7 @@ export function AgentChatPanel({
                 ref={fileInputRef}
                 type="file"
                 multiple
-                accept=".csv,.xlsx,.md,.txt,.pdf"
+                accept=".csv,.xlsx,.md,.txt,.pdf,.docx"
                 style={{ display: 'none' }}
                 onChange={e => {
                   if (e.target.files?.length) {


### PR DESCRIPTION
## Summary
- Add `pdf` and `docx` to backend allowed upload extensions and route them through `extract_text()` + `cache_file()` for proper text extraction and binary caching
- Frontend: add `.docx` to allowed extensions, file picker `accept` attribute, and 10MB size limit (matching PDF)
- Fix pre-existing bug where oversized zip files showed "1 MB" instead of "25 MB" in error messages

## Test plan
- [ ] Drag a PDF into chat input, send message — agent reads and responds about content
- [ ] Drag a DOCX into chat input — same behavior
- [ ] Try a scanned/image PDF — agent reports no extractable text with file_ref
- [ ] Try a large PDF (>50K chars) — verify truncation note appears
- [ ] Verify XLSX drag-drop still works (unchanged code path)
- [ ] Click paperclip button — verify `.docx` files appear in file chooser
- [ ] Try unsupported file type, oversized file, empty file — proper error messages