### PR TITLE
Auto-greet on first chat after agent onboarding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "highlight.js": "^11.11.1",
         "html2pdf.js": "^0.14.0",

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -140,9 +140,31 @@ export function AgentPage() {
     prevOnboardingComplete.current = agent.onboarding_complete;
     if (wasIncomplete && agent.onboarding_complete) {
       if (chat.trainingMode) chat.setTrainingMode(false);
+      chat.setGreetingPending(true);
       if (!agent.avatar_url) queueMicrotask(() => setShowAvatarPicker(true));
     }
   }, [agent]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-greet on first real chat after onboarding (or page refresh of fresh agent)
+  const autoGreetRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!agent || !agent.onboarding_complete || agent.id !== agentId) return;
+    if (autoGreetRef.current === agentId) return;
+    if (showAvatarPicker) return;
+    if (chat.messages.length > 0 || chat.isStreaming || chat.trainingMode) return;
+    if (!convs.loaded) return;
+    if (convs.conversations.length > 0) {
+      chat.setGreetingPending(false);
+      return;
+    }
+
+    autoGreetRef.current = agentId!;
+    chat.setGreetingPending(false);
+    chat.sendMessage(
+      '[Start the conversation. Greet the user warmly based on your personality and role. Keep it brief — 1-2 sentences.]',
+      undefined, undefined, { hidden: true },
+    );
+  }, [agentId, agent, showAvatarPicker, chat.messages.length, chat.isStreaming, chat.trainingMode, convs.loaded, convs.conversations.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     convs.loadConversations();
@@ -547,6 +569,7 @@ export function AgentPage() {
               agentName={agent.agent_name}
               conversationSource={convs.conversations.find(c => c.id === convs.activeId)?.source}
               importMode={convs.conversations.find(c => c.id === convs.activeId)?.mode === 'import'}
+              greetingPending={chat.greetingPending}
               onCancelImport={async () => {
                 if (!confirm('Cancel this import? The agent and all progress will be deleted.')) return;
                 try {

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -30,6 +30,7 @@ interface Props {
   conversationSource?: string | null;
   importMode?: boolean;
   onCancelImport?: () => void;
+  greetingPending?: boolean;
 }
 
 const TOOL_MODES: { key: ToolMode; label: string }[] = [
@@ -42,6 +43,7 @@ export function AgentChatPanel({
   messages, isStreaming, onSend, onStop, onApprove, onDeny,
   onApprovePlan, onIteratePlan, scrollRef: externalScrollRef,
   contextUsage, toolMode, onToolModeChange, agentName, conversationSource, importMode, onCancelImport,
+  greetingPending,
 }: Props) {
   const [input, setInput] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -149,6 +151,7 @@ export function AgentChatPanel({
 
   const isMobile = useIsMobile();
   const isEmpty = messages.length === 0;
+  const showEmptyState = isEmpty && !isStreaming && !greetingPending;
 
   function renderInputBox() {
     return (
@@ -289,6 +292,8 @@ export function AgentChatPanel({
   }
 
   return (
+    <>
+    {greetingPending && <style>{`@keyframes chatty-dot-pulse { 0%,80%,100% { opacity: 0.3; } 40% { opacity: 1; } }`}</style>}
     <div
       style={{ flex: 1, display: 'flex', flexDirection: 'column', position: 'relative', overflow: 'hidden' }}
       onDragOver={handleDragOver}
@@ -312,11 +317,11 @@ export function AgentChatPanel({
         ref={scrollContainerRef}
         style={{
           flex: 1, overflowY: 'auto',
-          paddingBottom: isEmpty && !isStreaming ? 0 : 180,
+          paddingBottom: showEmptyState ? 0 : 180,
         }}
         onClick={handleMessagesClick}
       >
-        {isEmpty && !isStreaming ? (
+        {showEmptyState ? (
           <div style={{
             display: 'flex', flexDirection: 'column', alignItems: 'center',
             justifyContent: 'center', minHeight: '100%', padding: isMobile ? '24px 16px' : 24,
@@ -381,6 +386,22 @@ export function AgentChatPanel({
                 )}
               </div>
             )}
+            {greetingPending && isEmpty && !isStreaming && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '8px 0' }}>
+                <span style={{
+                  display: 'inline-flex', gap: 4, alignItems: 'center',
+                  color: 'rgba(237,240,244,0.38)', fontSize: 13,
+                }}>
+                  {[0, 1, 2].map(i => (
+                    <span key={i} style={{
+                      width: 5, height: 5, borderRadius: '50%',
+                      background: 'rgba(237,240,244,0.38)',
+                      animation: `chatty-dot-pulse 1.2s ease-in-out ${i * 0.2}s infinite`,
+                    }} />
+                  ))}
+                </span>
+              </div>
+            )}
             {messages.filter(msg => !msg.hidden).map(msg => {
               const displayMsg = (msg.role === 'user' && msg.content.match(/^\[via (Telegram|WhatsApp) from [^\]]+\] /))
                 ? { ...msg, content: msg.content.replace(/^\[via (?:Telegram|WhatsApp) from [^\]]+\] /, '') }
@@ -414,7 +435,7 @@ export function AgentChatPanel({
       )}
 
       {/* Floating input */}
-      {(!isEmpty || isStreaming) && (
+      {(!showEmptyState) && (
         <div style={{
           position: 'absolute', bottom: 0, left: 0, right: 0,
           padding: isMobile ? '40px 12px 12px' : '60px 40px 22px',
@@ -427,5 +448,6 @@ export function AgentChatPanel({
         </div>
       )}
     </div>
+    </>
   );
 }

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -91,6 +91,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
   const [planMode, setPlanModeState] = useState(false);
   const [toolMode, setToolMode] = useState<ToolMode>('normal');
   const [contextUsage, setContextUsage] = useState<ContextUsage | null>(null);
+  const [greetingPending, setGreetingPending] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
   const streamInIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   useEffect(() => () => {
@@ -415,12 +416,14 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
       setTrainingType(type || 'topic');
       trainingKickoffMessageRef.current = kickoff || 'Hey there!';
       trainingKickoffRef.current = true;
+      setGreetingPending(true);
       setTrainingModeState(true);
     } else {
       setToolMode(savedToolModeRef.current);
       setMessages([]);
       setConversationId(null);
       setTrainingType('topic');
+      setGreetingPending(false);
       setTrainingModeState(false);
     }
   }, [toolMode]);
@@ -430,6 +433,7 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
     const msg = trainingKickoffMessageRef.current;
     trainingKickoffRef.current = false;
     const timer = setTimeout(() => {
+      setGreetingPending(false);
       sendMessage(msg, undefined, undefined, { hidden: true });
     }, 50);
     return () => clearTimeout(timer);
@@ -536,6 +540,8 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
     toolMode,
     setToolMode,
     setTrainingMode,
+    greetingPending,
+    setGreetingPending,
     planMode,
     setPlanMode,
     approvePlan,

--- a/frontend/src/agent/hooks/useConversations.ts
+++ b/frontend/src/agent/hooks/useConversations.ts
@@ -3,7 +3,7 @@
  * Adapted from CAKE OS — sender_email/sender_name removed (single-user).
  */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { api } from '../../core/api/client';
 import type { ChatMessage } from './useAgentChat';
 
@@ -24,6 +24,8 @@ export function useConversations(apiPrefix: string) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => { setLoaded(false); setConversations([]); setActiveId(null); }, [apiPrefix]);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<{ id: string; title: string; snippet: string }[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -34,6 +36,7 @@ export function useConversations(apiPrefix: string) {
       const data = await api<{ conversations: Conversation[] }>(`${apiPrefix}/conversations`);
       setConversations(data.conversations);
     } catch { /* silent */ }
+    finally { setLoaded(true); }
   }, [apiPrefix]);
 
   const selectConversation = useCallback(async (id: string): Promise<ChatMessage[]> => {
@@ -135,6 +138,7 @@ export function useConversations(apiPrefix: string) {
     activeId,
     setActiveId,
     loading,
+    loaded,
     searchQuery,
     searchResults,
     isSearching,


### PR DESCRIPTION
## Summary
- Agents now automatically send a greeting when the first real conversation starts after onboarding, replacing the empty "How can I help?" state
- Adds a `greetingPending` flag + typing indicator to prevent UI flash between onboarding completion and the greeting stream
- Guards against stale state on agent switching, conversation load races, and orphaned training exits

## Test plan
- [ ] Create a new agent with a role — verify the training kickoff shows the agent talking immediately (no "How can I help?" flash)
- [ ] Complete onboarding — after avatar picker, verify the agent automatically greets in normal mode
- [ ] Refresh the page on a fresh agent (no conversations) — verify auto-greeting fires
- [ ] Navigate between agents — verify greeting only fires for fresh agents, not existing ones
- [ ] Start a new chat on an established agent — verify "How can I help?" still appears normally