### PR TITLE
Fix active hours bug and improve scheduling instructions

### DIFF
--- a/backend/core/agents/scheduled_actions/service.py
+++ b/backend/core/agents/scheduled_actions/service.py
@@ -20,6 +20,25 @@ DEFAULT_INTERVAL_MINUTES = 30
 _DEFAULT_LEASE_MINUTES = 15
 
 
+def _normalize_hour(value, default: str = "06:00") -> str:
+    """Convert integer hour (0-23) or 'HH:MM' string to canonical 'HH:MM' format."""
+    if value is None:
+        return default
+    try:
+        if isinstance(value, int) or str(value).isdigit():
+            hour = int(value)
+            if 0 <= hour <= 23:
+                return f"{hour:02d}:00"
+            return default
+        hour_s, minute_s = str(value).split(":", 1)
+        hour, minute = int(hour_s), int(minute_s)
+        if 0 <= hour <= 23 and 0 <= minute <= 59:
+            return f"{hour:02d}:{minute:02d}"
+    except (ValueError, TypeError):
+        pass
+    return default
+
+
 def _now_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
 
@@ -86,6 +105,7 @@ def create_action(
     model_override: str | None = None,
     max_tool_iterations: int = 5,
     enabled: bool = True,
+    always_on: bool = False,
     created_by_email: str = "user",
     action_type: str = "cron",
 ) -> dict:
@@ -115,6 +135,8 @@ def create_action(
             return {"error": f"run_at must be a valid ISO 8601 datetime, got: {run_at}"}
 
     max_tool_iterations = min(max(max_tool_iterations, 1), MAX_TOOL_ITERATIONS_CAP)
+    active_hours_start = _normalize_hour(active_hours_start, "06:00")
+    active_hours_end = _normalize_hour(active_hours_end, "20:00")
 
     action_id = str(uuid.uuid4())
     action_dict = {
@@ -134,14 +156,15 @@ def create_action(
                (id, agent, created_by_email, action_type, name, description,
                 schedule_type, cron_expression, interval_minutes, run_at,
                 active_hours_start, active_hours_end, active_hours_tz,
-                prompt, model_override, max_tool_iterations, enabled, next_run)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                prompt, model_override, max_tool_iterations, enabled, always_on,
+                next_run)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 action_id, agent, created_by_email, action_type, name, description,
                 schedule_type, cron_expression, interval_minutes, run_at,
                 active_hours_start, active_hours_end, active_hours_tz,
                 prompt, model_override, max_tool_iterations,
-                1 if enabled else 0, next_run,
+                1 if enabled else 0, 1 if always_on else 0, next_run,
             ),
         )
         conn.commit()
@@ -224,6 +247,11 @@ def update_action(action_id: str, **fields) -> dict:
 
         if "max_tool_iterations" in updates:
             updates["max_tool_iterations"] = min(max(updates["max_tool_iterations"], 1), MAX_TOOL_ITERATIONS_CAP)
+
+        if "active_hours_start" in updates:
+            updates["active_hours_start"] = _normalize_hour(updates["active_hours_start"], "06:00")
+        if "active_hours_end" in updates:
+            updates["active_hours_end"] = _normalize_hour(updates["active_hours_end"], "20:00")
 
         for bool_field in ("enabled", "triage_enabled", "notify_on_action", "always_on"):
             if bool_field in updates:
@@ -492,6 +520,9 @@ def ensure_default_actions(agent_slug: str) -> None:
     """Create a default heartbeat action for an agent if none exists."""
     existing = list_actions(agent=agent_slug, action_type="heartbeat")
     if existing:
+        for action in existing:
+            if not action.get("always_on"):
+                update_action(action["id"], always_on=True)
         return
 
     create_action(
@@ -500,11 +531,10 @@ def ensure_default_actions(agent_slug: str) -> None:
         name="Heartbeat",
         description="Periodic check against HEARTBEAT.md checklist",
         interval_minutes=30,
-        active_hours_start="06:00",
-        active_hours_end="20:00",
         active_hours_tz="America/Chicago",
         prompt="Perform your heartbeat check now.",
         action_type="heartbeat",
+        always_on=True,
     )
     logger.info("Created default heartbeat for agent %s", agent_slug)
 

--- a/backend/core/agents/scheduled_actions/tools.py
+++ b/backend/core/agents/scheduled_actions/tools.py
@@ -16,10 +16,11 @@ def create_scheduled_action_handler(agent_name: str, **kwargs) -> dict:
         cron_expression=kwargs.get("cron_expression"),
         interval_minutes=kwargs.get("interval_minutes"),
         run_at=kwargs.get("run_at"),
-        active_hours_start=str(kwargs.get("active_hours_start", "06:00")),
-        active_hours_end=str(kwargs.get("active_hours_end", "20:00")),
+        active_hours_start=kwargs.get("active_hours_start"),
+        active_hours_end=kwargs.get("active_hours_end"),
         prompt=kwargs.get("prompt", ""),
         action_type="cron",
+        always_on=kwargs.get("always_on", False),
     )
 
 

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1121,8 +1121,9 @@ SCHEDULED_ACTION_TOOLS = [
                 "interval_minutes": {"type": "integer", "description": "Interval in minutes (for schedule_type='interval', min 5)"},
                 "run_at": {"type": "string", "description": "ISO 8601 datetime (for schedule_type='once')"},
                 "prompt": {"type": "string", "description": "The prompt to execute on each run"},
-                "active_hours_start": {"type": "integer", "description": "Start hour for active window (0-23, default: 6)"},
-                "active_hours_end": {"type": "integer", "description": "End hour for active window (0-23, default: 22)"},
+                "active_hours_start": {"type": "integer", "description": "Start hour for active window (0-23, default: 6). Actions only run during this window."},
+                "active_hours_end": {"type": "integer", "description": "End hour for active window (0-23, default: 20). Actions only run during this window."},
+                "always_on": {"type": "boolean", "description": "Set true for 24/7 operation, bypassing active hours. Default: false"},
             },
             "required": ["name", "prompt", "schedule_type"],
         },
@@ -1151,8 +1152,9 @@ SCHEDULED_ACTION_TOOLS = [
                 "prompt": {"type": "string", "description": "Updated prompt"},
                 "cron_expression": {"type": "string", "description": "Updated cron expression"},
                 "interval_minutes": {"type": "integer", "description": "Updated interval"},
-                "active_hours_start": {"type": "integer"},
-                "active_hours_end": {"type": "integer"},
+                "active_hours_start": {"type": "integer", "description": "Start hour for active window (0-23)"},
+                "active_hours_end": {"type": "integer", "description": "End hour for active window (0-23)"},
+                "always_on": {"type": "boolean", "description": "Set true for 24/7 operation, bypassing active hours"},
             },
             "required": ["action_id"],
         },
@@ -1199,16 +1201,29 @@ Guidelines:
 def get_scheduling_instructions() -> str:
     """Instructions for the AI on how to use reminders and scheduled actions."""
     return """## Scheduling & Reminders
-You can set reminders and create scheduled actions:
 
-- **Reminders**: Use `create_reminder` to set a follow-up for yourself. When the reminder fires, you'll receive the context and can take action. Use ISO 8601 format for due_at.
-- **Scheduled Actions**: Use `create_scheduled_action` to create recurring tasks. These run automatically on a cron schedule with your tools available. Use for periodic checks, reports, or maintenance tasks.
+### Reminders
+Use `create_reminder` to set a follow-up for yourself. When the reminder fires, you'll receive the context and can take action. Use ISO 8601 format for due_at.
+
+### Heartbeat (your main recurring loop)
+You already have a **heartbeat** that runs every 30 minutes and checks your HEARTBEAT.md file. This is your primary mechanism for recurring work.
+
+To add a recurring task, **add it to your HEARTBEAT.md checklist** with time conditions (e.g., "Every weekday at 9 AM: send morning brief"). The heartbeat will pick it up automatically on its next pulse. Do NOT create a separate scheduled action for something the heartbeat can handle.
+
+### Scheduled Actions
+Use `create_scheduled_action` only when you need a task with its own independent schedule that doesn't fit the heartbeat pattern (e.g., a one-time future task with `schedule_type="once"`).
+
+### Active Hours
+- Scheduled actions have an **active hours window** — they only run during this window.
+- Default is 6 AM to 8 PM. To change, set `active_hours_start` and `active_hours_end` (integers 0-23).
+- For 24/7 operation, set `always_on=true` — this bypasses active hours entirely.
+- Your heartbeat runs 24/7 by default (`always_on`). Time-gating belongs in your HEARTBEAT.md checklist items, not on the heartbeat itself.
 
 Guidelines:
 - Always confirm with the user before creating scheduled actions
 - Use descriptive names for scheduled actions
-- Set reasonable active hours to avoid running during off-hours
-- Prefer cron expressions for recurring tasks, 'once' for one-time future tasks
+- Prefer adding items to HEARTBEAT.md over creating new scheduled actions
+- For one-time future tasks, use `schedule_type="once"` with `run_at`
 """
 
 


### PR DESCRIPTION
## Summary
- Fix type conversion bug where integer active hours (e.g., `5`) were silently falling back to 06:00-20:00 defaults, causing early-morning scheduled actions to be skipped as "Outside active hours"
- Add `_normalize_hour()` with range validation at the service layer (DB boundary) to canonicalize all inputs to `"HH:MM"` format
- Expose `always_on` in the agent tool schema so agents can opt into 24/7 operation; migrate existing heartbeats to `always_on=True` on startup
- Rewrite scheduling instructions to teach agents the heartbeat/HEARTBEAT.md pattern instead of creating individual cron jobs

## Test plan
- [ ] Start backend and verify existing heartbeats are migrated to `always_on=1`
- [ ] Create a scheduled action with `active_hours_start=5, active_hours_end=6` and verify DB stores `"05:00"` / `"06:00"`
- [ ] Create a scheduled action with `active_hours_start=25` and verify fallback to `"06:00"` default
- [ ] Create a scheduled action with `always_on=true` and verify processor skips active hours check
- [ ] Verify agent system prompt includes updated scheduling instructions explaining heartbeat pattern