### PR TITLE
Add Paperclip integration for AI agent orchestration

### DIFF
--- a/PAPERCLIP.md
+++ b/PAPERCLIP.md
@@ -33,233 +33,377 @@ Paperclip (Control Plane)               Chatty (Agent Runtime)
 
 ---
 
-## Setup
+## Setup: Railway (Recommended)
 
-### Option A: Both on Railway (Recommended)
+This walks you through deploying both Chatty and Paperclip on Railway and connecting them. Total time: about 20 minutes.
 
-The simplest path for production use. Both services run on Railway with public URLs.
+### Part 1: Deploy Paperclip on Railway
 
-#### Step 1: Deploy Paperclip on Railway
+#### 1.1 Click the deploy button
 
-Deploy Paperclip using the Railway template:
+[![Deploy Paperclip on Railway](https://railway.com/button.svg)](https://railway.com/deploy/ZLeQVd?referralCode=HMgK-M)
 
-1. Go to [Railway](https://railway.app) → **New Project** → **Deploy from GitHub Repo**
-2. Select the `paperclip-railway` repo (or use the deploy button if public)
-3. Wait for the build to complete (~10-15 minutes for first build)
-4. **Generate a domain**: Click the service → **Settings** → **Networking** → **Generate Domain**
-5. Check the **deploy logs** for your admin invite URL:
+This deploys Paperclip from a pre-configured Railway template. Click the button above, then click **Deploy** in Railway.
+
+#### 1.2 Wait for the build
+
+The first build takes **10-15 minutes** — it compiles the full Paperclip application from source. You'll see build progress in Railway's dashboard. Subsequent deploys are much faster due to caching.
+
+#### 1.3 Generate a public domain
+
+Once the build finishes and the service shows **Online**:
+
+1. Click on the **paperclip-railway** service in your Railway project
+2. Click the **Settings** tab
+3. Scroll to **Networking**
+4. Click **Generate Domain**
+5. Railway assigns a URL like `paperclip-production-xxxx.up.railway.app`
+
+Copy this URL — you'll need it throughout the setup.
+
+#### 1.4 Find your admin invite URL
+
+After the first deploy, Paperclip automatically generates an admin invite link. To find it:
+
+1. Click on the **paperclip-railway** service
+2. Click **Deployments** tab
+3. Click **View logs** on the active deployment
+4. Look in the **deploy logs** (not build logs) for a block like this:
+
+```
+════════════════════════════════════════════════════════
+  ADMIN INVITE CREATED
+════════════════════════════════════════════════════════
+  https://your-paperclip-url.up.railway.app/invite/pcp_bootstrap_abc123...
+
+  Expires: 2026-04-29T...
+  Open this URL in your browser to create your account.
+════════════════════════════════════════════════════════
+```
+
+5. Copy the full invite URL (the line starting with `https://...`)
+
+> **Can't find the invite?** The invite is only generated on the very first deploy. If you missed it, you'll need to redeploy with a fresh database (delete the service and deploy again from the template).
+
+#### 1.5 Create your Paperclip account
+
+1. Paste the invite URL into your browser
+2. You'll see a signup form — enter your **name**, **email**, and **password**
+3. Click **Create Account**
+4. You're now signed into Paperclip as the instance admin
+
+### Part 2: Set Up Your Company in Paperclip
+
+#### 2.1 Complete the onboarding wizard
+
+After signing in, Paperclip walks you through creating your first company:
+
+1. **Company name** — Enter your company or project name (e.g., "My Agency", "TNC")
+2. **First agent** — The wizard creates a CEO agent automatically. Give them a name and role.
+3. Click through to finish onboarding
+
+You'll land on the company dashboard with your first agent visible in the left sidebar.
+
+#### 2.2 Switch your agent's adapter to HTTP
+
+This is the most important step. By default, Paperclip creates agents with the "Claude Code" adapter, which tries to run a CLI tool inside the container. **You need to switch it to HTTP** so Paperclip sends work to Chatty instead.
+
+1. Click on your agent in the left sidebar (e.g., "Tim Sparks")
+2. Click the **Configuration** tab
+3. Find the **Adapter** section
+4. Change the adapter type from **Claude Code** to **HTTP**
+5. Set the **URL** to your Chatty Railway instance's webhook endpoint:
    ```
-   ════════════════════════════════════════════
-     ADMIN INVITE CREATED
-   ════════════════════════════════════════════
-     https://your-paperclip.up.railway.app/invite/pcp_bootstrap_...
-   ════════════════════════════════════════════
+   https://your-chatty-url.up.railway.app/api/integrations/paperclip/heartbeat
    ```
-6. Open the invite URL in your browser and create your admin account
+6. Save the configuration
 
-#### Step 2: Set Up Your Company in Paperclip
+> **Why this matters:** If you skip this step, Paperclip will try to run the Claude CLI (which doesn't exist in the Railway container), fail repeatedly, and create hundreds of "Recover stalled issue" tasks. If this happens, pause the agent immediately and cancel the recovery issues.
 
-1. After signing in, Paperclip walks you through creating your first company and CEO agent
-2. The onboarding wizard creates a company and one agent (CEO) automatically
-3. **Important**: After onboarding, go to your CEO agent → **Configuration** tab → change the adapter from "Claude Code" to **HTTP**
-4. Set the webhook URL to your Chatty Railway instance: `https://your-chatty.up.railway.app/api/integrations/paperclip/heartbeat`
-5. Create additional agents as needed (PM, Engineer, etc.) — set all to HTTP adapter with the same Chatty webhook URL
+#### 2.3 Pause your agent (recommended)
 
-#### Step 3: Connect Chatty to Paperclip
+Keep your agent **paused** until Chatty is fully connected and mapped:
 
-1. Open Chatty → **Settings** → **Integrations** → scroll to **Paperclip**
-2. Click **Setup**
-3. Enter:
-   - **Paperclip URL**: `https://your-paperclip.up.railway.app`
-   - **Email**: Your Paperclip account email
+1. On your agent's page, click the **Pause** button (top right)
+2. This prevents Paperclip from sending heartbeats before Chatty is ready
+
+You'll resume the agent later after everything is connected.
+
+#### 2.4 Create additional agents (optional)
+
+To add more agents (PM, Engineer, Analyst, etc.):
+
+1. Click the **+** next to **AGENTS** in the left sidebar
+2. Set the agent's name, role, and title
+3. Set the reporting hierarchy (e.g., PM reports to CEO)
+4. **Switch each new agent to HTTP adapter** with the same Chatty webhook URL
+5. Keep them **paused**
+
+### Part 3: Connect Chatty to Paperclip
+
+#### 3.1 Open Chatty's integration settings
+
+1. Open your Chatty instance in a browser
+2. Log in with your Chatty password
+3. Click the **gear icon** (Settings) in the left sidebar
+4. Click the **Integrations** tab
+5. Scroll down to find **Paperclip**
+
+#### 3.2 Sign in to Paperclip from Chatty
+
+1. Click **Setup** on the Paperclip integration card
+2. Fill in the three fields:
+   - **Paperclip URL**: Your Paperclip Railway URL (e.g., `https://paperclip-production-xxxx.up.railway.app`)
+   - **Email**: The email you used to create your Paperclip account
    - **Password**: Your Paperclip account password
-4. Click **Connect** — Chatty logs into Paperclip and auto-detects your company
-5. Expand **Agent Mapping** and map each Paperclip agent to a Chatty agent
-6. Click **Save Mapping**
+3. Click **Connect**
 
-### Option B: Both Local (For Development)
+Chatty logs into Paperclip, gets a session, and auto-detects your company. You'll see the Paperclip card update to show it's connected.
 
-Best for tinkering, testing, and development.
+> **"Cannot reach Paperclip" error?** Make sure you included `https://` in the URL and that the Paperclip service is online in Railway.
+>
+> **"Login failed" error?** Double-check your email and password. These are your Paperclip credentials, not your Chatty password.
 
-#### Prerequisites
+#### 3.3 Map your agents
+
+Now tell Chatty which Chatty agent corresponds to which Paperclip agent:
+
+1. On the Paperclip integration card, click **Agent Mapping** to expand it
+2. You'll see a list of your Paperclip agents (e.g., "Tim Sparks (ceo)")
+3. For each Paperclip agent, select the matching Chatty agent from the dropdown
+4. Click **Save Mapping**
+
+If you don't see any Paperclip agents, make sure you completed the Paperclip onboarding wizard and created at least one agent.
+
+### Part 4: Test the connection
+
+#### 4.1 Chat with your agent about Paperclip
+
+1. Go back to Chatty's main screen
+2. Click on the Chatty agent you mapped (e.g., the one mapped to the CEO)
+3. Type: **"Check Paperclip for any tasks"**
+4. The agent should use the `paperclip_list_issues` tool and report what it finds
+
+If the agent successfully lists issues (or says there are none), the integration is working.
+
+#### 4.2 Create a test task in Paperclip
+
+1. Go to your Paperclip instance in the browser
+2. Click **Issues** in the left sidebar
+3. Click **+ New Issue** (or use the button at the top)
+4. Enter a title and description, assign it to your agent, set priority
+5. Go back to Chatty and ask your agent: **"Check Paperclip for new tasks"**
+6. The agent should see the issue you just created
+
+#### 4.3 Have your agent work on the task
+
+Ask your agent to claim and work on the task:
+
+- *"Claim that issue and start working on it"*
+- *"Update the issue status to in_progress"*
+- *"Post a comment on the issue with your findings"*
+
+Each of these uses a Paperclip tool (checkout, update, add_comment). In **Approval** mode (the default), Chatty will ask you to approve each write action before executing it.
+
+#### 4.4 Enable automated heartbeats (optional)
+
+Once you've verified interactive mode works:
+
+1. Go to Paperclip and **resume** your agent (click the Resume button)
+2. Paperclip will send periodic heartbeats (every 30 seconds by default) to Chatty's webhook
+3. Chatty runs the mapped agent headlessly — the agent checks its tasks, does work, and posts results
+4. Check the issue threads in Paperclip to see the agent's activity
+
+> **Important:** Only resume agents after the Chatty integration is connected and agent mapping is saved. Otherwise, the heartbeats will fail and create recovery issue cascades.
+
+---
+
+## Setup: Local Development
+
+For tinkering and development. Both services run on your machine.
+
+### Prerequisites
 
 - Python 3.10+ and Node.js 18+ (for Chatty)
 - Node.js 20+ and pnpm 9.15+ (for Paperclip)
 
-#### Step 1: Run Chatty
+If you don't have pnpm: `npm install -g pnpm`
+
+### Step 1: Start Chatty
 
 ```bash
 git clone https://github.com/WWilson1017/chatty.git
 cd chatty
 python run.py
-# Chatty runs at http://localhost:8000 (API) and http://localhost:5173 (UI in dev mode)
 ```
 
-#### Step 2: Run Paperclip
+Chatty runs at `http://localhost:8000`. Open it in your browser and complete the initial setup (set password, add an AI provider API key, create at least one agent).
+
+### Step 2: Start Paperclip
+
+In a separate terminal:
 
 ```bash
 git clone https://github.com/paperclipai/paperclip.git
 cd paperclip
 pnpm install
 pnpm dev
-# Paperclip runs at http://localhost:3100
 ```
 
-Paperclip runs in **local trusted mode** — no authentication required. Open `http://localhost:3100` in your browser to access the UI directly.
+Paperclip runs at `http://localhost:3100`. Open it in your browser — in local mode, no login is required.
 
-#### Step 3: Create Your Company
+### Step 3: Create your company in Paperclip
 
-1. Open Paperclip at `http://localhost:3100`
-2. Complete the onboarding wizard — it creates a company and CEO agent
-3. Go to your CEO agent → **Configuration** → change adapter to **HTTP**
+1. Open `http://localhost:3100`
+2. Complete the onboarding wizard (company name, first agent)
+3. Go to your agent → **Configuration** → change adapter to **HTTP**
 4. Set webhook URL: `http://localhost:8000/api/integrations/paperclip/heartbeat`
+5. **Pause** the agent
 
-#### Step 4: Connect Chatty
+### Step 4: Connect Chatty to Paperclip
 
-For local mode, Paperclip doesn't require authentication. In Chatty:
+1. In Chatty, go to **Settings** → **Integrations** → **Paperclip** → **Setup**
+2. Enter URL: `http://localhost:3100`
+3. Enter any email/password (local trusted mode doesn't validate credentials)
+4. Expand **Agent Mapping**, map agents, and save
 
-1. Go to **Settings** → **Integrations** → **Paperclip** → **Setup**
-2. Enter the Paperclip URL: `http://localhost:3100`
-3. For local trusted mode, you can use any email/password (the API doesn't require auth)
-4. Map your agents and save
+### Step 5: Test
 
-> **Note:** In local trusted mode, the email/password login step will fail since there's no auth. You may need to configure the integration manually or run Paperclip in authenticated mode locally. See the Paperclip docs for details.
-
-### Option C: Chatty on Railway + Paperclip on Railway
-
-This is the same as Option A. Both services get Railway public URLs and communicate over HTTPS. The Chatty webhook URL uses your Chatty Railway domain.
+Chat with your agent: *"Check Paperclip for any tasks assigned to you"*
 
 ---
 
 ## Usage Guide
 
-### Creating Your First AI Company
-
-Here's a recommended approach for setting up your first Paperclip company with Chatty agents:
-
-#### 1. Plan Your Org Structure
+### Planning Your Org Structure
 
 Start small. A good first setup:
 
 | Role | Paperclip Agent | Chatty Agent | Responsibilities |
 |------|----------------|--------------|------------------|
 | CEO | Strategic lead | Agent with leadership personality | Strategy, decisions, reviews |
-| PM | Project manager | Agent with organizational personality | Task breakdown, coordination, client comms |
-| Analyst | Engineer/Researcher | Agent with analytical personality | Research, reports, data analysis |
+| PM | Project manager | Agent with organizational personality | Task breakdown, coordination |
+| Analyst | Engineer/Researcher | Agent with analytical personality | Research, reports, analysis |
 
-#### 2. Create Chatty Agents First
-
-In Chatty, create your agents through the onboarding wizard:
-- Give each a distinct name and personality
-- Add knowledge files with company info, client details, and SOPs
-- Each agent should have a context file explaining how to use Paperclip tools
-
-#### 3. Create Matching Paperclip Agents
-
-In Paperclip's UI:
-- Create agents with matching roles
-- Set the reporting hierarchy (PM reports to CEO, Analyst reports to PM)
-- **Set all agents to HTTP adapter** with the Chatty webhook URL
-- Keep agents **paused** until everything is configured
-
-#### 4. Map Agents
-
-In Chatty's Paperclip integration settings:
-- Expand Agent Mapping
-- Map each Paperclip agent to its Chatty counterpart
-- Save the mapping
-
-#### 5. Create Issues
+### Creating Issues
 
 In Paperclip's UI, create issues (tasks) for your agents:
-- Set a title and description with clear deliverables
-- Assign to the appropriate agent
-- Set priority (critical, high, medium, low)
-- Issues start in **todo** status
 
-#### 6. Test Interactively
+- **Title**: Clear, actionable (e.g., "Q3 Revenue Strategy Review")
+- **Description**: Include context, scope, and expected deliverables
+- **Priority**: critical, high, medium, or low
+- **Assignee**: The agent responsible for the work
+- **Status**: Issues start as **todo**
 
-Before enabling automated heartbeats, test in chat mode:
-1. Open a Chatty agent's chat
-2. Ask: *"Check Paperclip for tasks assigned to you"*
-3. The agent should list its assigned issues
-4. Ask: *"Claim issue [ID] and start working on it"*
-5. Verify the agent uses `paperclip_checkout_issue` and `paperclip_update_issue` tools
-
-#### 7. Enable Heartbeats (Optional)
-
-Once interactive mode works:
-1. In Paperclip, **resume** your agents
-2. Paperclip will send periodic heartbeats to Chatty's webhook
-3. Chatty runs the mapped agent headlessly
-4. The agent checks its tasks, does work, and posts results as comments
-5. Check Paperclip's issue threads to see agent activity
-
-### Paperclip Tools Available to Agents
-
-When the Paperclip integration is enabled, all Chatty agents get these tools:
-
-| Tool | What It Does | Write? |
-|------|-------------|--------|
-| `paperclip_list_issues` | List issues with optional status/assignee filters | No |
-| `paperclip_get_issue` | Get full issue details including comments | No |
-| `paperclip_checkout_issue` | Atomically claim an issue | Yes |
-| `paperclip_update_issue` | Change status, title, description, or add inline comment | Yes |
-| `paperclip_add_comment` | Post a comment on an issue thread | Yes |
-
-Write tools require approval in **normal** permission mode (the default). Set Paperclip to **full control** mode in the integration settings if you want agents to act without approval.
-
-### Issue Statuses
+### Issue Workflow
 
 Issues flow through these statuses:
 
 ```
 backlog → todo → in_progress → in_review → done
-                                    ↓
-                                 blocked
+                       ↓
+                    blocked
 ```
 
-- **backlog** — Not yet prioritized
-- **todo** — Ready to start
-- **in_progress** — Agent is actively working
-- **in_review** — Work done, awaiting review
-- **done** — Completed
-- **blocked** — Cannot proceed, needs intervention
-- **cancelled** — Abandoned
+Your agents move issues through this workflow using Paperclip tools:
+1. Agent sees a **todo** issue assigned to them
+2. Agent claims it with `paperclip_checkout_issue` → moves to **in_progress**
+3. Agent works on it and posts updates via `paperclip_add_comment`
+4. Agent marks it done with `paperclip_update_issue` → moves to **done** or **in_review**
 
-### Tips
+### Paperclip Tools Available to Agents
 
-- **Start with interactive mode** — Chat with agents about their Paperclip tasks before enabling automated heartbeats. This lets you verify the tools work and the agents understand their assignments.
-- **Keep agents paused in Paperclip** until you've mapped them in Chatty. Otherwise, Paperclip will try to trigger heartbeats to a URL that isn't configured yet, creating cascading recovery issues.
-- **One company at a time** — Start with a single Paperclip company. The integration auto-detects your company during setup.
-- **Agent knowledge files** — Give each Chatty agent a context file explaining Paperclip and their role. Include their Paperclip agent ID so they know which issues are theirs.
-- **Permission modes** — Use "Approval" mode (default) when testing so you can see and approve each tool call. Switch to "Full Control" once you trust the agent's behavior.
+When connected, all Chatty agents automatically get these tools:
+
+| Tool | What It Does | Needs Approval? |
+|------|-------------|-----------------|
+| `paperclip_list_issues` | List issues with optional status/assignee filters | No |
+| `paperclip_get_issue` | Get full issue details including recent comments | No |
+| `paperclip_checkout_issue` | Atomically claim an issue for an agent | Yes |
+| `paperclip_update_issue` | Change status, title, description, or add inline comment | Yes |
+| `paperclip_add_comment` | Post a comment on an issue thread | Yes |
+
+In **Approval** mode (the default), Chatty shows you each write action and asks for confirmation before executing. Set the Paperclip permission level to **Full Control** in the integration settings if you want agents to act without asking.
+
+### Giving Agents Paperclip Context
+
+For best results, add a knowledge file to each Chatty agent explaining their Paperclip role. Create a file in the agent's context (Settings → Knowledge, or upload in chat) with content like:
+
+```markdown
+# Task Management
+
+We use Paperclip for task coordination. You have tools to interact with it:
+
+- Use paperclip_list_issues to check your assignments
+- Use paperclip_checkout_issue to claim a task before working on it
+- Use paperclip_update_issue to change status as you make progress
+- Use paperclip_add_comment to post updates and findings
+
+Your Paperclip agent ID is: [paste from Paperclip agent page]
+
+Always check for new tasks when asked, and update issue status as you work.
+```
+
+---
+
+## Reconnecting / Changing Instances
+
+If you need to switch to a different Paperclip instance or your session expires:
+
+1. Go to **Settings** → **Integrations** → **Paperclip**
+2. Click **Disconnect**
+3. Click **Setup** to connect to a new instance
+4. Re-enter the URL, email, and password
+5. Re-map your agents
 
 ---
 
 ## Troubleshooting
 
 ### "Cannot reach Paperclip" during setup
-- Check that the Paperclip URL is correct and the server is running
-- For Railway: make sure you've generated a domain in Railway's networking settings
-- For local: make sure Paperclip is running on the expected port (default: 3100)
+
+- Check that the URL is correct and includes `https://`
+- Make sure the Paperclip service is **Online** in Railway
+- For Railway: verify you've generated a public domain in **Settings** → **Networking**
+- For local: confirm Paperclip is running on the expected port (default: 3100)
 
 ### "Login failed: Invalid email or password"
-- Verify your Paperclip account credentials
-- For local trusted mode: Paperclip doesn't have auth, so the login step won't work. Use authenticated mode locally or configure manually.
+
+- Verify your Paperclip account credentials (not your Chatty password)
+- Make sure you completed the Paperclip invite signup (check the deploy logs for the invite URL)
 
 ### Recovery issue cascade in Paperclip
-- This happens when an agent's adapter fails repeatedly. Paperclip creates recovery issues for each failure.
-- **Fix**: Pause the agent in Paperclip, cancel the recovery issues, then fix the adapter config before resuming.
-- **Prevention**: Always configure agents with the HTTP adapter pointing at your Chatty webhook URL, and keep agents paused until Chatty is connected and mapped.
 
-### Agent tools return errors
-- Check that the Paperclip integration is enabled in Chatty (Settings → Integrations)
-- Verify the session hasn't expired — disconnect and reconnect if needed
-- Check the Chatty backend logs for detailed error messages
+This happens when an agent's adapter is misconfigured. Paperclip tries to trigger the agent, fails, creates a "Recover stalled issue" task, which also fails, creating another recovery issue, and so on.
 
-### Heartbeats not triggering agents
-- Verify the agent mapping is saved (Chatty Settings → Integrations → Paperclip → Agent Mapping)
-- Check that the Paperclip agent's HTTP adapter URL points to the correct Chatty webhook endpoint
-- For Railway-to-Railway: both services need public domains configured
-- The webhook endpoint doesn't require Chatty login — it authenticates via a shared secret header (optional)
+**To fix it:**
+1. **Pause** the agent immediately in Paperclip
+2. Cancel the recovery issues (select all → cancel)
+3. Go to the agent's **Configuration** tab
+4. Make sure the adapter is set to **HTTP** (not Claude Code or Codex)
+5. Make sure the webhook URL is correct and Chatty is running
+6. **Resume** the agent only after Chatty is connected and mapped
+
+**To prevent it:**
+- Always set agents to HTTP adapter before resuming
+- Always keep agents paused until Chatty is connected
+
+### Agent can't find any issues
+
+- Make sure issues are assigned to the correct Paperclip agent
+- Check that the agent mapping is saved in Chatty
+- Try asking the agent to list *all* issues, not just assigned ones: *"List all issues in Paperclip"*
+
+### Session expired
+
+Paperclip sessions can expire. If tools start returning auth errors:
+1. Go to Chatty **Settings** → **Integrations** → **Paperclip**
+2. Click **Disconnect**, then **Setup** to reconnect with your credentials
+
+### Heartbeats not working
+
+- The Paperclip agent's HTTP adapter URL must point to Chatty's webhook: `https://your-chatty.up.railway.app/api/integrations/paperclip/heartbeat`
+- Both services need public domains on Railway
+- Agent mapping must be saved in Chatty
+- The agent must be **resumed** (not paused) in Paperclip
+- Check Chatty's backend logs for webhook errors

--- a/PAPERCLIP.md
+++ b/PAPERCLIP.md
@@ -1,0 +1,265 @@
+# Paperclip Integration Guide
+
+Connect Chatty to [Paperclip](https://github.com/paperclipai/paperclip) to give your AI agents organizational structure, task management, and multi-agent coordination.
+
+## What is Paperclip?
+
+Paperclip is an open-source orchestration control plane for AI agent companies. While Chatty gives each agent a brain (LLM, tools, personality), Paperclip gives the *team* structure:
+
+- **Org charts** — Agents have roles (CEO, PM, engineer), titles, and reporting lines
+- **Issues** — Tasks with status, priority, assignments, and comments — like Linear or Jira, but for AI agents
+- **Heartbeats** — Paperclip periodically triggers agents to check their tasks and do work
+- **Governance** — Budget caps, audit trails, and approval flows
+
+Together, Chatty + Paperclip lets you run a coordinated team of AI agents that assign work, track progress, and communicate through structured task management.
+
+## How It Works
+
+```
+Paperclip (Control Plane)               Chatty (Agent Runtime)
+┌─────────────────────┐                 ┌──────────────────────────┐
+│ Issues / Tasks      │                 │ AI Agents with LLM       │
+│ Org Chart           │◄── tool calls ──│ + Paperclip tools        │
+│ Agent Management    │                 │                          │
+│ Budget Tracking     │── heartbeats ──►│ Webhook endpoint         │
+└─────────────────────┘                 └──────────────────────────┘
+```
+
+**Two modes of operation:**
+
+1. **Interactive (chat)** — Talk to a Chatty agent: *"Check Paperclip for my tasks"*. The agent uses Paperclip tools to list issues, claim work, update status, and post comments.
+
+2. **Automated (heartbeat)** — Paperclip sends HTTP webhooks to Chatty on a schedule. Chatty runs the mapped agent headlessly — the agent checks its assignments, does work, and posts results back to Paperclip.
+
+---
+
+## Setup
+
+### Option A: Both on Railway (Recommended)
+
+The simplest path for production use. Both services run on Railway with public URLs.
+
+#### Step 1: Deploy Paperclip on Railway
+
+Deploy Paperclip using the Railway template:
+
+1. Go to [Railway](https://railway.app) → **New Project** → **Deploy from GitHub Repo**
+2. Select the `paperclip-railway` repo (or use the deploy button if public)
+3. Wait for the build to complete (~10-15 minutes for first build)
+4. **Generate a domain**: Click the service → **Settings** → **Networking** → **Generate Domain**
+5. Check the **deploy logs** for your admin invite URL:
+   ```
+   ════════════════════════════════════════════
+     ADMIN INVITE CREATED
+   ════════════════════════════════════════════
+     https://your-paperclip.up.railway.app/invite/pcp_bootstrap_...
+   ════════════════════════════════════════════
+   ```
+6. Open the invite URL in your browser and create your admin account
+
+#### Step 2: Set Up Your Company in Paperclip
+
+1. After signing in, Paperclip walks you through creating your first company and CEO agent
+2. The onboarding wizard creates a company and one agent (CEO) automatically
+3. **Important**: After onboarding, go to your CEO agent → **Configuration** tab → change the adapter from "Claude Code" to **HTTP**
+4. Set the webhook URL to your Chatty Railway instance: `https://your-chatty.up.railway.app/api/integrations/paperclip/heartbeat`
+5. Create additional agents as needed (PM, Engineer, etc.) — set all to HTTP adapter with the same Chatty webhook URL
+
+#### Step 3: Connect Chatty to Paperclip
+
+1. Open Chatty → **Settings** → **Integrations** → scroll to **Paperclip**
+2. Click **Setup**
+3. Enter:
+   - **Paperclip URL**: `https://your-paperclip.up.railway.app`
+   - **Email**: Your Paperclip account email
+   - **Password**: Your Paperclip account password
+4. Click **Connect** — Chatty logs into Paperclip and auto-detects your company
+5. Expand **Agent Mapping** and map each Paperclip agent to a Chatty agent
+6. Click **Save Mapping**
+
+### Option B: Both Local (For Development)
+
+Best for tinkering, testing, and development.
+
+#### Prerequisites
+
+- Python 3.10+ and Node.js 18+ (for Chatty)
+- Node.js 20+ and pnpm 9.15+ (for Paperclip)
+
+#### Step 1: Run Chatty
+
+```bash
+git clone https://github.com/WWilson1017/chatty.git
+cd chatty
+python run.py
+# Chatty runs at http://localhost:8000 (API) and http://localhost:5173 (UI in dev mode)
+```
+
+#### Step 2: Run Paperclip
+
+```bash
+git clone https://github.com/paperclipai/paperclip.git
+cd paperclip
+pnpm install
+pnpm dev
+# Paperclip runs at http://localhost:3100
+```
+
+Paperclip runs in **local trusted mode** — no authentication required. Open `http://localhost:3100` in your browser to access the UI directly.
+
+#### Step 3: Create Your Company
+
+1. Open Paperclip at `http://localhost:3100`
+2. Complete the onboarding wizard — it creates a company and CEO agent
+3. Go to your CEO agent → **Configuration** → change adapter to **HTTP**
+4. Set webhook URL: `http://localhost:8000/api/integrations/paperclip/heartbeat`
+
+#### Step 4: Connect Chatty
+
+For local mode, Paperclip doesn't require authentication. In Chatty:
+
+1. Go to **Settings** → **Integrations** → **Paperclip** → **Setup**
+2. Enter the Paperclip URL: `http://localhost:3100`
+3. For local trusted mode, you can use any email/password (the API doesn't require auth)
+4. Map your agents and save
+
+> **Note:** In local trusted mode, the email/password login step will fail since there's no auth. You may need to configure the integration manually or run Paperclip in authenticated mode locally. See the Paperclip docs for details.
+
+### Option C: Chatty on Railway + Paperclip on Railway
+
+This is the same as Option A. Both services get Railway public URLs and communicate over HTTPS. The Chatty webhook URL uses your Chatty Railway domain.
+
+---
+
+## Usage Guide
+
+### Creating Your First AI Company
+
+Here's a recommended approach for setting up your first Paperclip company with Chatty agents:
+
+#### 1. Plan Your Org Structure
+
+Start small. A good first setup:
+
+| Role | Paperclip Agent | Chatty Agent | Responsibilities |
+|------|----------------|--------------|------------------|
+| CEO | Strategic lead | Agent with leadership personality | Strategy, decisions, reviews |
+| PM | Project manager | Agent with organizational personality | Task breakdown, coordination, client comms |
+| Analyst | Engineer/Researcher | Agent with analytical personality | Research, reports, data analysis |
+
+#### 2. Create Chatty Agents First
+
+In Chatty, create your agents through the onboarding wizard:
+- Give each a distinct name and personality
+- Add knowledge files with company info, client details, and SOPs
+- Each agent should have a context file explaining how to use Paperclip tools
+
+#### 3. Create Matching Paperclip Agents
+
+In Paperclip's UI:
+- Create agents with matching roles
+- Set the reporting hierarchy (PM reports to CEO, Analyst reports to PM)
+- **Set all agents to HTTP adapter** with the Chatty webhook URL
+- Keep agents **paused** until everything is configured
+
+#### 4. Map Agents
+
+In Chatty's Paperclip integration settings:
+- Expand Agent Mapping
+- Map each Paperclip agent to its Chatty counterpart
+- Save the mapping
+
+#### 5. Create Issues
+
+In Paperclip's UI, create issues (tasks) for your agents:
+- Set a title and description with clear deliverables
+- Assign to the appropriate agent
+- Set priority (critical, high, medium, low)
+- Issues start in **todo** status
+
+#### 6. Test Interactively
+
+Before enabling automated heartbeats, test in chat mode:
+1. Open a Chatty agent's chat
+2. Ask: *"Check Paperclip for tasks assigned to you"*
+3. The agent should list its assigned issues
+4. Ask: *"Claim issue [ID] and start working on it"*
+5. Verify the agent uses `paperclip_checkout_issue` and `paperclip_update_issue` tools
+
+#### 7. Enable Heartbeats (Optional)
+
+Once interactive mode works:
+1. In Paperclip, **resume** your agents
+2. Paperclip will send periodic heartbeats to Chatty's webhook
+3. Chatty runs the mapped agent headlessly
+4. The agent checks its tasks, does work, and posts results as comments
+5. Check Paperclip's issue threads to see agent activity
+
+### Paperclip Tools Available to Agents
+
+When the Paperclip integration is enabled, all Chatty agents get these tools:
+
+| Tool | What It Does | Write? |
+|------|-------------|--------|
+| `paperclip_list_issues` | List issues with optional status/assignee filters | No |
+| `paperclip_get_issue` | Get full issue details including comments | No |
+| `paperclip_checkout_issue` | Atomically claim an issue | Yes |
+| `paperclip_update_issue` | Change status, title, description, or add inline comment | Yes |
+| `paperclip_add_comment` | Post a comment on an issue thread | Yes |
+
+Write tools require approval in **normal** permission mode (the default). Set Paperclip to **full control** mode in the integration settings if you want agents to act without approval.
+
+### Issue Statuses
+
+Issues flow through these statuses:
+
+```
+backlog → todo → in_progress → in_review → done
+                                    ↓
+                                 blocked
+```
+
+- **backlog** — Not yet prioritized
+- **todo** — Ready to start
+- **in_progress** — Agent is actively working
+- **in_review** — Work done, awaiting review
+- **done** — Completed
+- **blocked** — Cannot proceed, needs intervention
+- **cancelled** — Abandoned
+
+### Tips
+
+- **Start with interactive mode** — Chat with agents about their Paperclip tasks before enabling automated heartbeats. This lets you verify the tools work and the agents understand their assignments.
+- **Keep agents paused in Paperclip** until you've mapped them in Chatty. Otherwise, Paperclip will try to trigger heartbeats to a URL that isn't configured yet, creating cascading recovery issues.
+- **One company at a time** — Start with a single Paperclip company. The integration auto-detects your company during setup.
+- **Agent knowledge files** — Give each Chatty agent a context file explaining Paperclip and their role. Include their Paperclip agent ID so they know which issues are theirs.
+- **Permission modes** — Use "Approval" mode (default) when testing so you can see and approve each tool call. Switch to "Full Control" once you trust the agent's behavior.
+
+---
+
+## Troubleshooting
+
+### "Cannot reach Paperclip" during setup
+- Check that the Paperclip URL is correct and the server is running
+- For Railway: make sure you've generated a domain in Railway's networking settings
+- For local: make sure Paperclip is running on the expected port (default: 3100)
+
+### "Login failed: Invalid email or password"
+- Verify your Paperclip account credentials
+- For local trusted mode: Paperclip doesn't have auth, so the login step won't work. Use authenticated mode locally or configure manually.
+
+### Recovery issue cascade in Paperclip
+- This happens when an agent's adapter fails repeatedly. Paperclip creates recovery issues for each failure.
+- **Fix**: Pause the agent in Paperclip, cancel the recovery issues, then fix the adapter config before resuming.
+- **Prevention**: Always configure agents with the HTTP adapter pointing at your Chatty webhook URL, and keep agents paused until Chatty is connected and mapped.
+
+### Agent tools return errors
+- Check that the Paperclip integration is enabled in Chatty (Settings → Integrations)
+- Verify the session hasn't expired — disconnect and reconnect if needed
+- Check the Chatty backend logs for detailed error messages
+
+### Heartbeats not triggering agents
+- Verify the agent mapping is saved (Chatty Settings → Integrations → Paperclip → Agent Mapping)
+- Check that the Paperclip agent's HTTP adapter URL points to the correct Chatty webhook endpoint
+- For Railway-to-Railway: both services need public domains configured
+- The webhook endpoint doesn't require Chatty login — it authenticates via a shared secret header (optional)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Create custom AI agents with their own personality, knowledge, and tools — pow
 - **Multi-provider AI** — Anthropic, OpenAI, Google Gemini, Ollama (local models), and Together AI
 - **Brandable** — Upload your logo, company name, and accent color to make it yours
 - **Built-in CRM** — Manage your pipeline: contacts, companies, tasks and deals all with your AI agent
-- **Integrations** — Gmail, Google Calendar, Google Drive, QuickBooks Online, WhatsApp, Telegram, Odoo, BambooHR
+- **Integrations** — Gmail, Google Calendar, Google Drive, QuickBooks Online, WhatsApp, Telegram, Odoo, BambooHR, [Paperclip](PAPERCLIP.md)
+- **Agent orchestration** — Connect to [Paperclip](PAPERCLIP.md) for org charts, task management, and multi-agent coordination
 - **Local-first** — SQLite database, no external services required
 - **One-click deploy** — Deploy to Railway for access from any device
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Create custom AI agents with their own personality, knowledge, and tools — pow
 - **Multi-provider AI** — Anthropic, OpenAI, Google Gemini, Ollama (local models), and Together AI
 - **Brandable** — Upload your logo, company name, and accent color to make it yours
 - **Built-in CRM** — Manage your pipeline: contacts, companies, tasks and deals all with your AI agent
-- **Integrations** — Gmail, Google Calendar, Google Drive, QuickBooks Online, WhatsApp, Telegram, Odoo, BambooHR, [Paperclip](PAPERCLIP.md)
-- **Agent orchestration** — Connect to [Paperclip](PAPERCLIP.md) for org charts, task management, and multi-agent coordination
+- **Integrations** — Gmail, Google Calendar, Google Drive, QuickBooks Online, WhatsApp, Telegram, Odoo, BambooHR, Paperclip
+- **Agent orchestration** — Connect to [Paperclip](https://github.com/paperclipai/paperclip) for org charts, task management, and multi-agent coordination
 - **Local-first** — SQLite database, no external services required
 - **One-click deploy** — Deploy to Railway for access from any device
 
@@ -99,6 +99,25 @@ Chatty connects to your existing business tools so your agents can answer questi
 `JWT_SECRET` and `ENCRYPTION_KEY` auto-generate if not set. Your data persists on a Railway volume.
 
 For detailed instructions, custom domains, and troubleshooting, see [DEPLOY.md](DEPLOY.md).
+
+## Agent Orchestration with Paperclip
+
+Run a coordinated team of AI agents with [Paperclip](https://github.com/paperclipai/paperclip) — the open-source orchestration control plane for AI agent companies.
+
+Chatty gives each agent a brain. Paperclip gives the team structure: **org charts**, **task assignments**, **budget tracking**, and **governance**. Together, your agents can assign work to each other, track progress through issues, and communicate through structured task threads.
+
+[![Deploy Paperclip on Railway](https://railway.com/button.svg)](https://railway.com/deploy/ZLeQVd?referralCode=HMgK-M)
+
+**Getting started:**
+
+1. Deploy Paperclip on Railway (button above) and create your company
+2. In Chatty, go to **Settings** > **Integrations** > **Paperclip** and sign in with your Paperclip credentials
+3. Map your Chatty agents to Paperclip agents
+4. Chat with any agent: *"Check Paperclip for my tasks"*
+
+Your agents get tools to list issues, claim tasks, update status, and post comments — all from within the chat. Paperclip can also trigger agents automatically via heartbeat webhooks.
+
+For the full setup guide, see [PAPERCLIP.md](PAPERCLIP.md).
 
 ## Contributing
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -105,6 +105,7 @@ _INTEGRATION_MODULES = {
     "bamboohr": ("integrations.bamboohr.tools", "BAMBOOHR_TOOL_DEFS"),
     "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
     "qb_csv": ("integrations.qb_csv.tools", "QB_CSV_TOOL_DEFS"),
+    "paperclip": ("integrations.paperclip.tools", "PAPERCLIP_TOOL_DEFS"),
 }
 
 

--- a/backend/core/encryption.py
+++ b/backend/core/encryption.py
@@ -39,6 +39,7 @@ SENSITIVE_FIELDS = frozenset({
     "access_token",     # integration OAuth (quickbooks)
     "refresh_token",    # integration OAuth (quickbooks)
     "client_secret",    # integration OAuth (quickbooks)
+    "webhook_secret",   # integration webhooks (paperclip)
 })
 
 

--- a/backend/core/encryption.py
+++ b/backend/core/encryption.py
@@ -40,6 +40,8 @@ SENSITIVE_FIELDS = frozenset({
     "refresh_token",    # integration OAuth (quickbooks)
     "client_secret",    # integration OAuth (quickbooks)
     "webhook_secret",   # integration webhooks (paperclip)
+    "session_cookie",   # session auth (paperclip)
+    "password",         # login credentials (paperclip)
 })
 
 

--- a/backend/integrations/paperclip/client.py
+++ b/backend/integrations/paperclip/client.py
@@ -1,0 +1,201 @@
+"""Chatty — Paperclip REST API client.
+
+Wraps Paperclip's REST API for issue management, agent listing, and
+company validation.  Credentials stored in data/integrations/paperclip.json.
+"""
+
+import logging
+from contextvars import ContextVar
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Per-request context set by the heartbeat webhook handler.
+# Client reads run_id to add X-Paperclip-Run-Id on mutating calls.
+paperclip_run_ctx: ContextVar[dict] = ContextVar("paperclip_run_ctx", default={})
+
+TIMEOUT = 30
+
+
+class PaperclipClient:
+    """Client for Paperclip's REST API."""
+
+    def __init__(self, base_url: str, company_id: str, bearer_token: str = ""):
+        self.base_url = base_url.rstrip("/")
+        self.company_id = company_id
+        self.bearer_token = bearer_token
+
+    def _headers(self, mutating: bool = False) -> dict:
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if self.bearer_token:
+            headers["Authorization"] = f"Bearer {self.bearer_token}"
+        if mutating:
+            headers["Content-Type"] = "application/json"
+            ctx = paperclip_run_ctx.get()
+            if ctx.get("run_id"):
+                headers["X-Paperclip-Run-Id"] = ctx["run_id"]
+        return headers
+
+    # ── Company ──────────────────────────────────────────────────────────
+
+    def get_company(self) -> dict:
+        """Validate company exists. Used during onboarding."""
+        try:
+            resp = httpx.get(
+                f"{self.base_url}/api/companies/{self.company_id}",
+                headers=self._headers(),
+                timeout=TIMEOUT,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    # ── Issues ───────────────────────────────────────────────────────────
+
+    def list_issues(
+        self,
+        status: str | None = None,
+        assignee_agent_id: str | None = None,
+        limit: int = 50,
+    ) -> dict:
+        params: dict[str, Any] = {"limit": limit}
+        if status:
+            params["status"] = status
+        if assignee_agent_id:
+            params["assigneeAgentId"] = assignee_agent_id
+        try:
+            resp = httpx.get(
+                f"{self.base_url}/api/companies/{self.company_id}/issues",
+                headers=self._headers(),
+                params=params,
+                timeout=TIMEOUT,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            issues = data if isinstance(data, list) else data.get("issues", data)
+            return {"ok": True, "issues": issues}
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    def get_issue(self, issue_id: str) -> dict:
+        try:
+            resp = httpx.get(
+                f"{self.base_url}/api/issues/{issue_id}",
+                headers=self._headers(),
+                timeout=TIMEOUT,
+            )
+            resp.raise_for_status()
+            issue = resp.json()
+
+            comments_resp = httpx.get(
+                f"{self.base_url}/api/issues/{issue_id}/comments",
+                headers=self._headers(),
+                params={"limit": 20, "order": "desc"},
+                timeout=TIMEOUT,
+            )
+            comments = []
+            if comments_resp.status_code == 200:
+                cdata = comments_resp.json()
+                comments = cdata if isinstance(cdata, list) else cdata.get("comments", [])
+
+            return {"ok": True, "issue": issue, "comments": comments}
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    def checkout_issue(
+        self,
+        issue_id: str,
+        agent_id: str,
+        expected_statuses: list[str] | None = None,
+    ) -> dict:
+        body: dict[str, Any] = {"agentId": agent_id}
+        if expected_statuses:
+            body["expectedStatuses"] = expected_statuses
+        else:
+            body["expectedStatuses"] = ["backlog", "todo"]
+        try:
+            resp = httpx.post(
+                f"{self.base_url}/api/issues/{issue_id}/checkout",
+                headers=self._headers(mutating=True),
+                json=body,
+                timeout=TIMEOUT,
+            )
+            resp.raise_for_status()
+            return {"ok": True, "issue": resp.json()}
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    def update_issue(self, issue_id: str, updates: dict) -> dict:
+        try:
+            resp = httpx.patch(
+                f"{self.base_url}/api/issues/{issue_id}",
+                headers=self._headers(mutating=True),
+                json=updates,
+                timeout=TIMEOUT,
+            )
+            resp.raise_for_status()
+            return {"ok": True, "issue": resp.json()}
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    def add_comment(self, issue_id: str, body: str) -> dict:
+        try:
+            resp = httpx.post(
+                f"{self.base_url}/api/issues/{issue_id}/comments",
+                headers=self._headers(mutating=True),
+                json={"body": body},
+                timeout=TIMEOUT,
+            )
+            resp.raise_for_status()
+            return {"ok": True, "comment": resp.json()}
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    # ── Agents ───────────────────────────────────────────────────────────
+
+    def list_agents(self) -> dict:
+        try:
+            resp = httpx.get(
+                f"{self.base_url}/api/companies/{self.company_id}/agents",
+                headers=self._headers(),
+                timeout=TIMEOUT,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            agents = data if isinstance(data, list) else data.get("agents", data)
+            return {"ok": True, "agents": agents}
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+
+def get_client() -> PaperclipClient | None:
+    """Return a configured client from stored credentials, or None."""
+    from integrations.registry import get_credentials, is_enabled
+
+    if not is_enabled("paperclip"):
+        return None
+    creds = get_credentials("paperclip")
+    if not creds.get("url") or not creds.get("company_id"):
+        return None
+    return PaperclipClient(
+        base_url=creds["url"],
+        company_id=creds["company_id"],
+        bearer_token=creds.get("api_key", ""),
+    )

--- a/backend/integrations/paperclip/client.py
+++ b/backend/integrations/paperclip/client.py
@@ -236,6 +236,36 @@ class PaperclipClient:
         except Exception as e:
             return {"error": str(e)}
 
+    def update_agent(self, agent_id: str, updates: dict) -> dict:
+        headers = self._headers(mutating=True)
+        headers["Origin"] = self.base_url
+        headers["Referer"] = f"{self.base_url}/"
+        try:
+            resp = httpx.patch(
+                f"{self.base_url}/api/agents/{agent_id}",
+                headers=headers,
+                json=updates,
+                timeout=TIMEOUT,
+            )
+            resp.raise_for_status()
+            return {"ok": True, "agent": resp.json()}
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    def configure_agent_webhook(self, agent_id: str, webhook_url: str, webhook_secret: str) -> dict:
+        """Switch an agent to HTTP adapter with the Chatty webhook URL and secret."""
+        return self.update_agent(agent_id, {
+            "adapterType": "http",
+            "adapterConfig": {
+                "url": webhook_url,
+                "method": "POST",
+                "timeoutMs": 120000,
+                "headers": {"X-Webhook-Secret": webhook_secret},
+            },
+        })
+
 
 def get_client() -> PaperclipClient | None:
     """Return a configured client from stored credentials, or None."""

--- a/backend/integrations/paperclip/client.py
+++ b/backend/integrations/paperclip/client.py
@@ -2,6 +2,9 @@
 
 Wraps Paperclip's REST API for issue management, agent listing, and
 company validation.  Credentials stored in data/integrations/paperclip.json.
+
+Auth: Paperclip uses Better Auth session cookies. The client logs in with
+email/password, gets a session token, and sends it as a cookie on all requests.
 """
 
 import logging
@@ -12,25 +15,75 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# Per-request context set by the heartbeat webhook handler.
-# Client reads run_id to add X-Paperclip-Run-Id on mutating calls.
 paperclip_run_ctx: ContextVar[dict] = ContextVar("paperclip_run_ctx", default={})
 
 TIMEOUT = 30
 
 
+def login(base_url: str, email: str, password: str) -> dict:
+    """Login to Paperclip via Better Auth. Returns session info or error."""
+    base_url = base_url.rstrip("/")
+    try:
+        resp = httpx.post(
+            f"{base_url}/api/auth/sign-in/email",
+            json={"email": email, "password": password},
+            timeout=TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        session_cookie = None
+        for name, value in resp.cookies.items():
+            if "session_token" in name:
+                session_cookie = f"{name}={value}"
+                break
+
+        if not session_cookie:
+            cookie_header = resp.headers.get("set-cookie", "")
+            for part in cookie_header.split(","):
+                part = part.strip()
+                if "session_token" in part:
+                    session_cookie = part.split(";")[0]
+                    break
+
+        if not session_cookie:
+            return {"error": "Login succeeded but no session cookie returned"}
+
+        companies = httpx.get(
+            f"{base_url}/api/companies",
+            headers={"Cookie": session_cookie},
+            timeout=TIMEOUT,
+        )
+        company_list = companies.json() if companies.status_code == 200 else []
+        if isinstance(company_list, dict):
+            company_list = company_list.get("companies", [])
+
+        return {
+            "ok": True,
+            "session_cookie": session_cookie,
+            "user": data.get("user", {}),
+            "companies": company_list,
+        }
+    except httpx.HTTPStatusError as e:
+        body = e.response.json() if e.response.headers.get("content-type", "").startswith("application/json") else {}
+        msg = body.get("message", e.response.text[:200])
+        return {"error": f"Login failed: {msg}"}
+    except Exception as e:
+        return {"error": f"Cannot reach Paperclip: {e}"}
+
+
 class PaperclipClient:
     """Client for Paperclip's REST API."""
 
-    def __init__(self, base_url: str, company_id: str, bearer_token: str = ""):
+    def __init__(self, base_url: str, company_id: str, session_cookie: str = ""):
         self.base_url = base_url.rstrip("/")
         self.company_id = company_id
-        self.bearer_token = bearer_token
+        self.session_cookie = session_cookie
 
     def _headers(self, mutating: bool = False) -> dict:
         headers: dict[str, str] = {"Accept": "application/json"}
-        if self.bearer_token:
-            headers["Authorization"] = f"Bearer {self.bearer_token}"
+        if self.session_cookie:
+            headers["Cookie"] = self.session_cookie
         if mutating:
             headers["Content-Type"] = "application/json"
             ctx = paperclip_run_ctx.get()
@@ -41,7 +94,6 @@ class PaperclipClient:
     # ── Company ──────────────────────────────────────────────────────────
 
     def get_company(self) -> dict:
-        """Validate company exists. Used during onboarding."""
         try:
             resp = httpx.get(
                 f"{self.base_url}/api/companies/{self.company_id}",
@@ -197,5 +249,5 @@ def get_client() -> PaperclipClient | None:
     return PaperclipClient(
         base_url=creds["url"],
         company_id=creds["company_id"],
-        bearer_token=creds.get("api_key", ""),
+        session_cookie=creds.get("session_cookie", ""),
     )

--- a/backend/integrations/paperclip/onboarding.py
+++ b/backend/integrations/paperclip/onboarding.py
@@ -1,40 +1,54 @@
 """Chatty — Paperclip integration setup.
 
-Validates the Paperclip connection and persists credentials.
+Logs into Paperclip with email/password, discovers companies, and persists session.
 """
 
 import logging
 
-from .client import PaperclipClient
+from .client import login
 
 logger = logging.getLogger(__name__)
 
 
-def setup(url: str, company_id: str, api_key: str = "") -> dict:
-    """Validate connection and save Paperclip credentials.
-
-    Returns {"ok": True} on success or {"error": "..."} on failure.
-    """
+def setup(url: str, email: str, password: str, company_id: str = "") -> dict:
+    """Login to Paperclip, discover companies, and save credentials."""
     from integrations.registry import get_credentials, save_credentials
 
-    client = PaperclipClient(
-        base_url=url,
-        company_id=company_id,
-        bearer_token=api_key,
-    )
-    result = client.get_company()
+    result = login(url, email, password)
     if "error" in result:
-        return {"error": f"Cannot reach Paperclip: {result['error']}"}
+        return result
 
-    company_name = result.get("name", "Unknown")
+    companies = result.get("companies", [])
+    user = result.get("user", {})
+
+    if not company_id and len(companies) == 1:
+        company_id = companies[0]["id"]
+    elif not company_id and len(companies) > 1:
+        return {
+            "ok": True,
+            "needs_company_selection": True,
+            "companies": [{"id": c["id"], "name": c["name"]} for c in companies],
+            "session_cookie": result["session_cookie"],
+            "user_name": user.get("name", ""),
+        }
+    elif not company_id:
+        return {"error": "No companies found in your Paperclip account. Create one in the Paperclip UI first."}
+
+    company_name = company_id
+    for c in companies:
+        if c["id"] == company_id:
+            company_name = c.get("name", company_id)
+            break
 
     existing = get_credentials("paperclip")
     existing.update({
         "enabled": True,
         "url": url,
+        "email": email,
         "company_id": company_id,
-        "api_key": api_key,
         "company_name": company_name,
+        "session_cookie": result["session_cookie"],
+        "user_name": user.get("name", ""),
     })
     if "agent_mapping" not in existing:
         existing["agent_mapping"] = {}
@@ -43,4 +57,4 @@ def setup(url: str, company_id: str, api_key: str = "") -> dict:
     save_credentials("paperclip", existing)
 
     logger.info("Paperclip integration configured: %s (%s)", company_name, url)
-    return {"ok": True, "company_name": company_name}
+    return {"ok": True, "company_name": company_name, "user_name": user.get("name", "")}

--- a/backend/integrations/paperclip/onboarding.py
+++ b/backend/integrations/paperclip/onboarding.py
@@ -1,0 +1,46 @@
+"""Chatty — Paperclip integration setup.
+
+Validates the Paperclip connection and persists credentials.
+"""
+
+import logging
+
+from .client import PaperclipClient
+
+logger = logging.getLogger(__name__)
+
+
+def setup(url: str, company_id: str, api_key: str = "") -> dict:
+    """Validate connection and save Paperclip credentials.
+
+    Returns {"ok": True} on success or {"error": "..."} on failure.
+    """
+    from integrations.registry import get_credentials, save_credentials
+
+    client = PaperclipClient(
+        base_url=url,
+        company_id=company_id,
+        bearer_token=api_key,
+    )
+    result = client.get_company()
+    if "error" in result:
+        return {"error": f"Cannot reach Paperclip: {result['error']}"}
+
+    company_name = result.get("name", "Unknown")
+
+    existing = get_credentials("paperclip")
+    existing.update({
+        "enabled": True,
+        "url": url,
+        "company_id": company_id,
+        "api_key": api_key,
+        "company_name": company_name,
+    })
+    if "agent_mapping" not in existing:
+        existing["agent_mapping"] = {}
+    if "webhook_secret" not in existing:
+        existing["webhook_secret"] = ""
+    save_credentials("paperclip", existing)
+
+    logger.info("Paperclip integration configured: %s (%s)", company_name, url)
+    return {"ok": True, "company_name": company_name}

--- a/backend/integrations/paperclip/onboarding.py
+++ b/backend/integrations/paperclip/onboarding.py
@@ -1,13 +1,20 @@
 """Chatty — Paperclip integration setup.
 
-Logs into Paperclip with email/password, discovers companies, and persists session.
+Logs into Paperclip with email/password, discovers companies, generates
+a webhook secret, and auto-configures Paperclip agents to use Chatty's
+webhook endpoint.
 """
 
 import logging
+import secrets
 
-from .client import login
+from .client import login, PaperclipClient
 
 logger = logging.getLogger(__name__)
+
+
+def _generate_webhook_secret() -> str:
+    return secrets.token_urlsafe(32)
 
 
 def setup(url: str, email: str, password: str, company_id: str = "") -> dict:
@@ -41,6 +48,8 @@ def setup(url: str, email: str, password: str, company_id: str = "") -> dict:
             break
 
     existing = get_credentials("paperclip")
+    webhook_secret = existing.get("webhook_secret") or _generate_webhook_secret()
+
     existing.update({
         "enabled": True,
         "url": url,
@@ -49,12 +58,58 @@ def setup(url: str, email: str, password: str, company_id: str = "") -> dict:
         "company_name": company_name,
         "session_cookie": result["session_cookie"],
         "user_name": user.get("name", ""),
+        "webhook_secret": webhook_secret,
     })
     if "agent_mapping" not in existing:
         existing["agent_mapping"] = {}
-    if "webhook_secret" not in existing:
-        existing["webhook_secret"] = ""
     save_credentials("paperclip", existing)
 
     logger.info("Paperclip integration configured: %s (%s)", company_name, url)
     return {"ok": True, "company_name": company_name, "user_name": user.get("name", "")}
+
+
+def configure_mapped_agents(chatty_base_url: str = "") -> dict:
+    """Configure all mapped Paperclip agents to use Chatty's webhook with the shared secret.
+
+    Called after agent mapping is saved. Updates each mapped Paperclip agent's
+    adapter to HTTP with the webhook URL and secret header.
+    """
+    from integrations.registry import get_credentials
+
+    creds = get_credentials("paperclip")
+    if not creds.get("url") or not creds.get("session_cookie"):
+        return {"error": "Paperclip not configured"}
+
+    mapping = creds.get("agent_mapping", {})
+    if not mapping:
+        return {"ok": True, "configured": 0}
+
+    webhook_secret = creds.get("webhook_secret", "")
+    if not webhook_secret:
+        return {"error": "No webhook secret configured"}
+
+    webhook_url = chatty_base_url.rstrip("/") + "/api/integrations/paperclip/heartbeat" if chatty_base_url else ""
+    if not webhook_url:
+        return {"ok": True, "configured": 0, "note": "No Chatty base URL provided — skipping agent adapter config"}
+
+    client = PaperclipClient(
+        base_url=creds["url"],
+        company_id=creds["company_id"],
+        session_cookie=creds["session_cookie"],
+    )
+
+    configured = 0
+    errors = []
+    for paperclip_agent_id in mapping:
+        result = client.configure_agent_webhook(paperclip_agent_id, webhook_url, webhook_secret)
+        if "ok" in result:
+            configured += 1
+            logger.info("Configured Paperclip agent %s with Chatty webhook", paperclip_agent_id)
+        else:
+            errors.append(f"{paperclip_agent_id}: {result.get('error', 'unknown')}")
+            logger.warning("Failed to configure agent %s: %s", paperclip_agent_id, result.get("error"))
+
+    out: dict = {"ok": True, "configured": configured}
+    if errors:
+        out["errors"] = errors
+    return out

--- a/backend/integrations/paperclip/tools.py
+++ b/backend/integrations/paperclip/tools.py
@@ -1,0 +1,199 @@
+"""Chatty — Paperclip agent tools.
+
+MVP tool set: list issues, get issue details, checkout, update, comment.
+Write tools marked with "writes": True for the approval flow.
+"""
+
+from .client import get_client
+
+# ── Tool definitions ─────────────────────────────────────────────────────────
+
+PAPERCLIP_TOOL_DEFS = [
+    # ── Read tools ───────────────────────────────────────────────────────
+    {
+        "name": "paperclip_list_issues",
+        "description": (
+            "List issues (tasks) in the Paperclip company. "
+            "Optionally filter by status or assigned agent. "
+            "Statuses: backlog, todo, in_progress, in_review, done, blocked, cancelled."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "description": "Filter by status (e.g. 'todo', 'in_progress')",
+                },
+                "assignee_agent_id": {
+                    "type": "string",
+                    "description": "Filter by assigned Paperclip agent ID",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (default 50)",
+                },
+            },
+            "required": [],
+        },
+        "kind": "integration",
+        "writes": False,
+    },
+    {
+        "name": "paperclip_get_issue",
+        "description": (
+            "Get full details of a Paperclip issue including title, description, "
+            "status, priority, assignee, documents, and recent comments."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "issue_id": {
+                    "type": "string",
+                    "description": "The Paperclip issue ID",
+                },
+            },
+            "required": ["issue_id"],
+        },
+        "kind": "integration",
+        "writes": False,
+    },
+    # ── Write tools ──────────────────────────────────────────────────────
+    {
+        "name": "paperclip_checkout_issue",
+        "description": (
+            "Atomically claim (checkout) a Paperclip issue for an agent. "
+            "Returns 409 if already claimed by another agent. "
+            "Requires the Paperclip agent ID performing the checkout."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "issue_id": {
+                    "type": "string",
+                    "description": "The issue ID to claim",
+                },
+                "agent_id": {
+                    "type": "string",
+                    "description": "The Paperclip agent ID claiming the issue",
+                },
+                "expected_statuses": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Allowed statuses for checkout (default: ['backlog', 'todo'])",
+                },
+            },
+            "required": ["issue_id", "agent_id"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+    {
+        "name": "paperclip_update_issue",
+        "description": (
+            "Update a Paperclip issue. Can change title, description, status, "
+            "priority, or add an inline comment. "
+            "Statuses: backlog, todo, in_progress, in_review, done, blocked, cancelled. "
+            "Priorities: critical, high, medium, low."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "issue_id": {
+                    "type": "string",
+                    "description": "The issue ID to update",
+                },
+                "title": {"type": "string", "description": "New title"},
+                "description": {"type": "string", "description": "New description"},
+                "status": {"type": "string", "description": "New status"},
+                "priority": {"type": "string", "description": "New priority"},
+                "comment": {
+                    "type": "string",
+                    "description": "Inline comment to add with the update",
+                },
+            },
+            "required": ["issue_id"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+    {
+        "name": "paperclip_add_comment",
+        "description": (
+            "Post a comment on a Paperclip issue. "
+            "Use @mentions to notify other agents."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "issue_id": {
+                    "type": "string",
+                    "description": "The issue ID to comment on",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "The comment text",
+                },
+            },
+            "required": ["issue_id", "body"],
+        },
+        "kind": "integration",
+        "writes": True,
+    },
+]
+
+
+# ── Executor functions ───────────────────────────────────────────────────────
+
+def _paperclip_list_issues(
+    status: str | None = None,
+    assignee_agent_id: str | None = None,
+    limit: int = 50,
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "Paperclip integration not configured"}
+    return client.list_issues(status=status, assignee_agent_id=assignee_agent_id, limit=limit)
+
+
+def _paperclip_get_issue(issue_id: str) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "Paperclip integration not configured"}
+    return client.get_issue(issue_id)
+
+
+def _paperclip_checkout_issue(
+    issue_id: str,
+    agent_id: str,
+    expected_statuses: list[str] | None = None,
+) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "Paperclip integration not configured"}
+    return client.checkout_issue(issue_id, agent_id, expected_statuses)
+
+
+def _paperclip_update_issue(issue_id: str, **updates) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "Paperclip integration not configured"}
+    body = {k: v for k, v in updates.items() if v is not None}
+    return client.update_issue(issue_id, body)
+
+
+def _paperclip_add_comment(issue_id: str, body: str) -> dict:
+    client = get_client()
+    if not client:
+        return {"error": "Paperclip integration not configured"}
+    return client.add_comment(issue_id, body)
+
+
+# ── Executor map ─────────────────────────────────────────────────────────────
+
+TOOL_EXECUTORS = {
+    "paperclip_list_issues": lambda **kw: _paperclip_list_issues(**kw),
+    "paperclip_get_issue": lambda **kw: _paperclip_get_issue(**kw),
+    "paperclip_checkout_issue": lambda **kw: _paperclip_checkout_issue(**kw),
+    "paperclip_update_issue": lambda **kw: _paperclip_update_issue(**kw),
+    "paperclip_add_comment": lambda **kw: _paperclip_add_comment(**kw),
+}

--- a/backend/integrations/paperclip/webhook.py
+++ b/backend/integrations/paperclip/webhook.py
@@ -106,13 +106,14 @@ async def handle_heartbeat(request: Request):
     except Exception:
         return JSONResponse({"status": "error", "error": "Invalid JSON"}, status_code=400)
 
-    # 1. Validate shared secret
+    # 1. Validate shared secret (required — auto-generated during setup)
     creds = get_credentials("paperclip")
     expected_secret = creds.get("webhook_secret", "")
-    if expected_secret:
-        actual_secret = request.headers.get("X-Webhook-Secret", "")
-        if actual_secret != expected_secret:
-            return JSONResponse({"status": "error", "error": "Unauthorized"}, status_code=403)
+    actual_secret = request.headers.get("X-Webhook-Secret", "")
+    if not expected_secret:
+        return JSONResponse({"status": "error", "error": "Webhook secret not configured"}, status_code=403)
+    if actual_secret != expected_secret:
+        return JSONResponse({"status": "error", "error": "Unauthorized"}, status_code=403)
 
     # 2. Map Paperclip agent → Chatty agent
     agent_id = payload.get("agentId", "")

--- a/backend/integrations/paperclip/webhook.py
+++ b/backend/integrations/paperclip/webhook.py
@@ -1,0 +1,214 @@
+"""Chatty — Paperclip heartbeat webhook handler.
+
+Receives heartbeat POSTs from Paperclip's built-in HTTP adapter and runs
+the mapped Chatty agent via run_sync() (the non-streaming execution path
+also used by Telegram).
+
+Self-contained: does not import private helpers from agents/router.py.
+"""
+
+import importlib
+import logging
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from agents import db as agent_db
+from agents.engine import build_agent_config, get_context_manager
+from core.providers import get_ai_provider
+from core.agents.tool_registry import ToolRegistry
+from core.agents.reminders.tools import (
+    create_reminder_handler,
+    list_reminders_handler,
+    cancel_reminder_handler,
+)
+from core.agents.scheduled_actions.tools import (
+    create_scheduled_action_handler,
+    list_scheduled_actions_handler,
+    update_scheduled_action_handler,
+    delete_scheduled_action_handler,
+)
+from core.agents import ai_service
+
+from .client import paperclip_run_ctx
+
+logger = logging.getLogger(__name__)
+
+
+# Integration module registry (same as agents/router.py + telegram/service.py)
+_INTEGRATION_MODULES = {
+    "crm_lite": ("integrations.crm_lite.tools", "CRM_LITE_TOOL_DEFS"),
+    "odoo": ("integrations.odoo.tools", "ODOO_TOOL_DEFS"),
+    "bamboohr": ("integrations.bamboohr.tools", "BAMBOOHR_TOOL_DEFS"),
+    "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
+    "qb_csv": ("integrations.qb_csv.tools", "QB_CSV_TOOL_DEFS"),
+    "paperclip": ("integrations.paperclip.tools", "PAPERCLIP_TOOL_DEFS"),
+}
+
+
+def _load_integration_tools() -> tuple[list[dict], dict]:
+    """Load tool definitions and executors from all enabled integrations."""
+    from integrations.registry import is_enabled
+
+    tool_defs: list[dict] = []
+    executors: dict = {}
+
+    for name, (module_path, defs_attr) in _INTEGRATION_MODULES.items():
+        if not is_enabled(name):
+            continue
+        try:
+            if name == "crm_lite":
+                from integrations.crm_lite.db import init_db, _connection
+                if _connection is None:
+                    init_db()
+            if name == "qb_csv":
+                from integrations.qb_csv.db import init_db as init_qb_csv, _connection as qb_csv_conn
+                if qb_csv_conn is None:
+                    init_qb_csv()
+
+            mod = importlib.import_module(module_path)
+            defs = getattr(mod, defs_attr, [])
+            execs = getattr(mod, "TOOL_EXECUTORS", {})
+            tool_defs.extend({**d, "integration": name} for d in defs)
+            executors.update(execs)
+        except Exception as e:
+            logger.warning("Failed to load integration %s: %s", name, e)
+
+    return tool_defs, executors
+
+
+def _build_agent_handlers(agent_slug: str):
+    reminder_handlers = {
+        "create_reminder": lambda **kw: create_reminder_handler(agent_slug, **kw),
+        "list_reminders": lambda **kw: list_reminders_handler(agent_slug, **kw),
+        "cancel_reminder": lambda **kw: cancel_reminder_handler(agent_slug, **kw),
+    }
+    sa_handlers = {
+        "create_scheduled_action": lambda **kw: create_scheduled_action_handler(agent_slug, **kw),
+        "list_scheduled_actions": lambda **kw: list_scheduled_actions_handler(agent_slug, **kw),
+        "update_scheduled_action": lambda **kw: update_scheduled_action_handler(agent_slug, **kw),
+        "delete_scheduled_action": lambda **kw: delete_scheduled_action_handler(agent_slug, **kw),
+    }
+    return reminder_handlers, sa_handlers
+
+
+async def handle_heartbeat(request: Request):
+    """Process a heartbeat from Paperclip's HTTP adapter.
+
+    Auth: shared secret header only (no Chatty JWT).
+    Execution: run_sync() with Paperclip tool mode forced to "power".
+    Response: synchronous JSON with result text.
+    """
+    from integrations.registry import get_credentials, get_tool_mode, is_enabled as _is_enabled
+
+    try:
+        payload = await request.json()
+    except Exception:
+        return JSONResponse({"status": "error", "error": "Invalid JSON"}, status_code=400)
+
+    # 1. Validate shared secret
+    creds = get_credentials("paperclip")
+    expected_secret = creds.get("webhook_secret", "")
+    if expected_secret:
+        actual_secret = request.headers.get("X-Webhook-Secret", "")
+        if actual_secret != expected_secret:
+            return JSONResponse({"status": "error", "error": "Unauthorized"}, status_code=403)
+
+    # 2. Map Paperclip agent → Chatty agent
+    agent_id = payload.get("agentId", "")
+    mapping = creds.get("agent_mapping", {})
+    chatty_slug = mapping.get(agent_id)
+    if not chatty_slug:
+        logger.warning("Paperclip heartbeat: unmapped agentId=%s", agent_id)
+        return JSONResponse(
+            {"status": "error", "error": f"No Chatty agent mapped for Paperclip agent {agent_id}"},
+            status_code=400,
+        )
+
+    # 3. Load agent
+    agent = agent_db.get_agent_by_slug(chatty_slug)
+    if not agent:
+        return JSONResponse(
+            {"status": "error", "error": f"Chatty agent '{chatty_slug}' not found"},
+            status_code=404,
+        )
+
+    slug = agent["slug"]
+    wake_reason = payload.get("wakeReason", "assigned")
+    issue_id = payload.get("issueId", "")
+
+    logger.info(
+        "Paperclip heartbeat: agent=%s reason=%s issue=%s",
+        slug, wake_reason, issue_id,
+    )
+
+    # 4. Set run context for Paperclip client (X-Paperclip-Run-Id header)
+    ctx_token = paperclip_run_ctx.set({
+        "run_id": payload.get("runId", ""),
+        "agent_id": agent_id,
+    })
+
+    try:
+        # 5. Build agent pipeline (mirrors telegram/service.py pattern)
+        config = build_agent_config(agent)
+        ctx_manager = get_context_manager(slug)
+
+        provider = get_ai_provider(
+            agent_provider=config.provider_override or None,
+            agent_model=config.model_override or None,
+        )
+        if not provider:
+            return JSONResponse(
+                {"status": "error", "error": "No AI provider configured"},
+                status_code=500,
+            )
+
+        google_connected = _is_enabled("google")
+        integration_tool_defs, integration_executors = _load_integration_tools()
+
+        # Force Paperclip writes to "power" — no approval UI in headless mode
+        integration_tool_modes = {name: get_tool_mode(name) for name in _INTEGRATION_MODULES}
+        integration_tool_modes["paperclip"] = "power"
+
+        reminder_handlers, sa_handlers = _build_agent_handlers(slug)
+        registry = ToolRegistry(
+            context_dir=config.context_dir,
+            google_connected=google_connected,
+            integration_executors=integration_executors,
+            agent_slug=slug,
+            reminder_handlers=reminder_handlers,
+            scheduled_action_handlers=sa_handlers,
+        )
+
+        # 6. Build task message
+        context_parts = [f"[Paperclip Heartbeat] Reason: {wake_reason}."]
+        if issue_id:
+            context_parts.append(f"Issue ID: {issue_id}.")
+        context_parts.append(
+            "Check your Paperclip assignments and work on them. "
+            "Use your Paperclip tools to list issues, claim tasks, update status, and post comments."
+        )
+        messages = [{"role": "user", "content": " ".join(context_parts)}]
+
+        # 7. Run agent synchronously
+        result_text = await ai_service.run_sync(
+            config=config,
+            provider=provider,
+            registry=registry,
+            ctx_manager=ctx_manager,
+            messages=messages,
+            integration_tool_defs=integration_tool_defs or None,
+            integration_tool_modes=integration_tool_modes,
+        )
+
+        logger.info("Paperclip heartbeat complete: agent=%s len=%d", slug, len(result_text or ""))
+        return {"status": "succeeded", "result": result_text or "No response generated."}
+
+    except Exception as e:
+        logger.error("Paperclip heartbeat failed: %s", e, exc_info=True)
+        return JSONResponse(
+            {"status": "error", "error": str(e)},
+            status_code=500,
+        )
+    finally:
+        paperclip_run_ctx.reset(ctx_token)

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -73,6 +73,12 @@ AVAILABLE_INTEGRATIONS = {
         "icon": "💬",
         "auth_type": "qr_session",
     },
+    "paperclip": {
+        "name": "Paperclip",
+        "description": "AI company orchestration — org chart, tasks, budgets, governance",
+        "icon": "📎",
+        "auth_type": "api_key",
+    },
 }
 
 

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -495,6 +495,7 @@ class PaperclipSetupRequest(BaseModel):
 
 class PaperclipMappingRequest(BaseModel):
     agent_mapping: dict[str, str]
+    chatty_base_url: str = ""
 
 
 @router.post("/paperclip/setup")
@@ -530,12 +531,18 @@ async def list_paperclip_agents(user=Depends(get_current_user)):
 
 @router.post("/paperclip/agent-mapping")
 async def save_paperclip_mapping(body: PaperclipMappingRequest, user=Depends(get_current_user)):
-    """Save Paperclip-agent → Chatty-agent mapping."""
+    """Save Paperclip-agent → Chatty-agent mapping and auto-configure agents."""
     from .registry import get_credentials, save_credentials
     creds = get_credentials("paperclip")
     creds["agent_mapping"] = body.agent_mapping
     save_credentials("paperclip", creds)
-    return {"ok": True}
+
+    config_result = {}
+    if body.chatty_base_url:
+        from .paperclip.onboarding import configure_mapped_agents
+        config_result = configure_mapped_agents(chatty_base_url=body.chatty_base_url)
+
+    return {"ok": True, **config_result}
 
 
 @router.post("/paperclip/heartbeat")

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -12,7 +12,7 @@ import logging
 from pathlib import Path
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from core.auth import get_current_user
@@ -79,8 +79,8 @@ async def disable_integration(name: str, user=Depends(get_current_user)):
 @router.post("/{name}/tool-mode")
 async def set_integration_tool_mode(name: str, body: ToolModeRequest, user=Depends(get_current_user)):
     """Set the tool_mode permission ceiling for an integration."""
-    if name not in ("odoo", "quickbooks"):
-        raise HTTPException(status_code=400, detail="Tool mode is only supported for Odoo and QuickBooks")
+    if name not in ("odoo", "quickbooks", "paperclip"):
+        raise HTTPException(status_code=400, detail="Tool mode is only supported for Odoo, QuickBooks, and Paperclip")
     if body.tool_mode not in ("read-only", "normal", "power"):
         raise HTTPException(status_code=400, detail=f"Invalid tool_mode: {body.tool_mode}")
     integrations = {i["id"]: i for i in list_integrations()}
@@ -476,5 +476,72 @@ async def get_tool_defs(name: str, user=Depends(get_current_user)):
     elif name == "qb_csv":
         from .qb_csv.tools import QB_CSV_TOOL_DEFS
         return {"tools": QB_CSV_TOOL_DEFS}
+    elif name == "paperclip":
+        from .paperclip.tools import PAPERCLIP_TOOL_DEFS
+        return {"tools": PAPERCLIP_TOOL_DEFS}
     else:
         return {"tools": []}
+
+
+# ── Paperclip ────────────────────────────────────────────────────────────────
+
+
+class PaperclipSetupRequest(BaseModel):
+    url: str = Field(..., max_length=2048)
+    company_id: str
+    api_key: str = ""
+
+
+class PaperclipMappingRequest(BaseModel):
+    agent_mapping: dict[str, str]
+
+
+@router.post("/paperclip/setup")
+async def setup_paperclip(body: PaperclipSetupRequest, user=Depends(get_current_user)):
+    """Configure and validate Paperclip connection."""
+    from .paperclip.onboarding import setup
+    result = setup(url=body.url, company_id=body.company_id, api_key=body.api_key)
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Setup failed"))
+    return result
+
+
+@router.post("/paperclip/disconnect")
+async def disconnect_paperclip(user=Depends(get_current_user)):
+    """Disconnect Paperclip: remove stored credentials."""
+    from .registry import save_credentials
+    save_credentials("paperclip", {})
+    return {"ok": True}
+
+
+@router.get("/paperclip/agents")
+async def list_paperclip_agents(user=Depends(get_current_user)):
+    """Proxy: list agents in the connected Paperclip company (for mapping UI)."""
+    from .paperclip.client import get_client
+    client = get_client()
+    if not client:
+        raise HTTPException(status_code=400, detail="Paperclip not configured")
+    result = client.list_agents()
+    if "error" in result:
+        raise HTTPException(status_code=502, detail=result["error"])
+    return result
+
+
+@router.post("/paperclip/agent-mapping")
+async def save_paperclip_mapping(body: PaperclipMappingRequest, user=Depends(get_current_user)):
+    """Save Paperclip-agent → Chatty-agent mapping."""
+    from .registry import get_credentials, save_credentials
+    creds = get_credentials("paperclip")
+    creds["agent_mapping"] = body.agent_mapping
+    save_credentials("paperclip", creds)
+    return {"ok": True}
+
+
+@router.post("/paperclip/heartbeat")
+async def paperclip_heartbeat(request: Request):
+    """Receive heartbeat from Paperclip's HTTP adapter.
+
+    NO JWT auth — authenticates via shared secret header only.
+    """
+    from .paperclip.webhook import handle_heartbeat
+    return await handle_heartbeat(request)

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -488,8 +488,9 @@ async def get_tool_defs(name: str, user=Depends(get_current_user)):
 
 class PaperclipSetupRequest(BaseModel):
     url: str = Field(..., max_length=2048)
-    company_id: str
-    api_key: str = ""
+    email: str
+    password: str
+    company_id: str = ""
 
 
 class PaperclipMappingRequest(BaseModel):
@@ -498,11 +499,11 @@ class PaperclipMappingRequest(BaseModel):
 
 @router.post("/paperclip/setup")
 async def setup_paperclip(body: PaperclipSetupRequest, user=Depends(get_current_user)):
-    """Configure and validate Paperclip connection."""
+    """Login to Paperclip with email/password and configure the integration."""
     from .paperclip.onboarding import setup
-    result = setup(url=body.url, company_id=body.company_id, api_key=body.api_key)
-    if not result.get("ok"):
-        raise HTTPException(status_code=400, detail=result.get("error", "Setup failed"))
+    result = setup(url=body.url, email=body.email, password=body.password, company_id=body.company_id)
+    if "error" in result:
+        raise HTTPException(status_code=400, detail=result["error"])
     return result
 
 

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -82,6 +82,8 @@ _INTEGRATION_MODULES = {
     "odoo": ("integrations.odoo.tools", "ODOO_TOOL_DEFS"),
     "bamboohr": ("integrations.bamboohr.tools", "BAMBOOHR_TOOL_DEFS"),
     "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
+    "qb_csv": ("integrations.qb_csv.tools", "QB_CSV_TOOL_DEFS"),
+    "paperclip": ("integrations.paperclip.tools", "PAPERCLIP_TOOL_DEFS"),
 }
 
 

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -59,6 +59,8 @@ _INTEGRATION_MODULES = {
     "odoo": ("integrations.odoo.tools", "ODOO_TOOL_DEFS"),
     "bamboohr": ("integrations.bamboohr.tools", "BAMBOOHR_TOOL_DEFS"),
     "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
+    "qb_csv": ("integrations.qb_csv.tools", "QB_CSV_TOOL_DEFS"),
+    "paperclip": ("integrations.paperclip.tools", "PAPERCLIP_TOOL_DEFS"),
 }
 
 

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -43,9 +43,9 @@ export function IntegrationsTab() {
   const [odooManualMode, setOdooManualMode] = useState(false);
   const [bambooSubdomain, setBambooSubdomain] = useState('');
   const [bambooKey, setBambooKey] = useState('');
-  const [pcUrl, setPcUrl] = useState('http://localhost:3100');
-  const [pcCompanyId, setPcCompanyId] = useState('');
-  const [pcApiKey, setPcApiKey] = useState('');
+  const [pcUrl, setPcUrl] = useState('');
+  const [pcEmail, setPcEmail] = useState('');
+  const [pcPassword, setPcPassword] = useState('');
   const [pcAgentMapping, setPcAgentMapping] = useState<Record<string, string>>({});
   const [pcPaperclipAgents, setPcPaperclipAgents] = useState<{ id: string; name: string; role: string }[]>([]);
   const [pcMappingExpanded, setPcMappingExpanded] = useState(false);
@@ -214,8 +214,9 @@ export function IntegrationsTab() {
     try {
       await api('/api/integrations/paperclip/setup', {
         method: 'POST',
-        body: JSON.stringify({ url: pcUrl, company_id: pcCompanyId, api_key: pcApiKey }),
+        body: JSON.stringify({ url: pcUrl, email: pcEmail, password: pcPassword }),
       });
+      setPcPassword('');
       setSetupFor(null);
       const data = await api<{ integrations: Integration[] }>('/api/integrations');
       setIntegrations(data.integrations);
@@ -239,6 +240,19 @@ export function IntegrationsTab() {
       });
       setError('');
     } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Failed to save mapping'); }
+    finally { setSaving(false); }
+  }
+
+  async function disconnectPaperclip() {
+    setSaving(true); setError('');
+    try {
+      await api('/api/integrations/paperclip/disconnect', { method: 'POST' });
+      setPcMappingExpanded(false);
+      setPcPaperclipAgents([]);
+      setPcAgentMapping({});
+      const data = await api<{ integrations: Integration[] }>('/api/integrations');
+      setIntegrations(data.integrations);
+    } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Disconnect failed'); }
     finally { setSaving(false); }
   }
 
@@ -488,6 +502,22 @@ export function IntegrationsTab() {
                     </div>
                   ))}
                 </div>
+              </div>
+            )}
+
+            {/* Paperclip disconnect + reconfigure */}
+            {integration.id === 'paperclip' && integration.configured && (
+              <div style={{ marginTop: 8, display: 'flex', gap: 8, alignItems: 'center' }}>
+                <button onClick={() => setSetupFor('paperclip')} style={{
+                  fontSize: 11, padding: '4px 8px', borderRadius: 4,
+                  background: 'transparent', color: 'rgba(237,240,244,0.38)',
+                  border: 'none', cursor: 'pointer',
+                }}>Reconfigure</button>
+                <button onClick={disconnectPaperclip} disabled={saving} style={{
+                  fontSize: 11, padding: '4px 8px', borderRadius: 4,
+                  background: 'transparent', color: '#D97757',
+                  border: 'none', cursor: 'pointer', opacity: saving ? 0.5 : 1,
+                }}>Disconnect</button>
               </div>
             )}
 
@@ -790,14 +820,14 @@ export function IntegrationsTab() {
                 {integration.id === 'paperclip' && (
                   <>
                     <p style={{ fontSize: 12, color: 'rgba(237,240,244,0.50)', lineHeight: 1.5, marginBottom: 4 }}>
-                      Connect to a Paperclip instance to orchestrate your agents with org charts, task management, and governance.
+                      Sign in to your Paperclip instance. Chatty will auto-detect your company.
                     </p>
-                    <input placeholder="Paperclip URL (http://localhost:3100)" value={pcUrl} onChange={e => setPcUrl(e.target.value)} style={inputStyle} />
-                    <input placeholder="Company ID" value={pcCompanyId} onChange={e => setPcCompanyId(e.target.value)} style={inputStyle} />
-                    <input placeholder="Bearer token (optional for local)" type="password" value={pcApiKey} onChange={e => setPcApiKey(e.target.value)} style={inputStyle} />
+                    <input placeholder="Paperclip URL (https://your-instance.up.railway.app)" value={pcUrl} onChange={e => setPcUrl(e.target.value)} style={inputStyle} />
+                    <input placeholder="Email" value={pcEmail} onChange={e => setPcEmail(e.target.value)} style={inputStyle} />
+                    <input placeholder="Password" type="password" value={pcPassword} onChange={e => setPcPassword(e.target.value)} style={inputStyle} />
                     <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
                       <button onClick={() => setSetupFor(null)} style={{ flex: 1, padding: '8px 16px', fontSize: 13, borderRadius: 4, border: '1px solid rgba(230,235,242,0.14)', background: 'transparent', color: 'rgba(237,240,244,0.62)', cursor: 'pointer' }}>Cancel</button>
-                      <button onClick={setupPaperclip} disabled={saving || !pcCompanyId.trim()} style={{ flex: 1, padding: '8px 16px', fontSize: 13, borderRadius: 4, background: 'var(--color-ch-accent, #C8D1D9)', color: '#0E1013', border: 'none', cursor: 'pointer', fontWeight: 500, opacity: saving || !pcCompanyId.trim() ? 0.5 : 1 }}>{saving ? 'Connecting...' : 'Connect'}</button>
+                      <button onClick={setupPaperclip} disabled={saving || !pcUrl.trim() || !pcEmail.trim() || !pcPassword.trim()} style={{ flex: 1, padding: '8px 16px', fontSize: 13, borderRadius: 4, background: 'var(--color-ch-accent, #C8D1D9)', color: '#0E1013', border: 'none', cursor: 'pointer', fontWeight: 500, opacity: saving || !pcUrl.trim() || !pcEmail.trim() || !pcPassword.trim() ? 0.5 : 1 }}>{saving ? 'Connecting...' : 'Connect'}</button>
                     </div>
                   </>
                 )}

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -234,9 +234,10 @@ export function IntegrationsTab() {
   async function savePaperclipMapping() {
     setSaving(true); setError('');
     try {
+      const chattyBaseUrl = window.location.origin;
       await api('/api/integrations/paperclip/agent-mapping', {
         method: 'POST',
-        body: JSON.stringify({ agent_mapping: pcAgentMapping }),
+        body: JSON.stringify({ agent_mapping: pcAgentMapping, chatty_base_url: chattyBaseUrl }),
       });
       setError('');
     } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Failed to save mapping'); }

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -19,6 +19,7 @@ const INTEGRATION_ICONS: Record<string, React.ComponentType<{ size?: number; cla
   telegram: IconMail,
   gmail: IconMail,
   calendar: IconBook,
+  paperclip: IconZap,
 };
 
 const mono = (size: number, color = 'rgba(237,240,244,0.38)') => ({
@@ -42,6 +43,12 @@ export function IntegrationsTab() {
   const [odooManualMode, setOdooManualMode] = useState(false);
   const [bambooSubdomain, setBambooSubdomain] = useState('');
   const [bambooKey, setBambooKey] = useState('');
+  const [pcUrl, setPcUrl] = useState('http://localhost:3100');
+  const [pcCompanyId, setPcCompanyId] = useState('');
+  const [pcApiKey, setPcApiKey] = useState('');
+  const [pcAgentMapping, setPcAgentMapping] = useState<Record<string, string>>({});
+  const [pcPaperclipAgents, setPcPaperclipAgents] = useState<{ id: string; name: string; role: string }[]>([]);
+  const [pcMappingExpanded, setPcMappingExpanded] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [showQbCredForm, setShowQbCredForm] = useState(false);
@@ -199,6 +206,39 @@ export function IntegrationsTab() {
       const data = await api<{ integrations: Integration[] }>('/api/integrations');
       setIntegrations(data.integrations);
     } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Setup failed'); }
+    finally { setSaving(false); }
+  }
+
+  async function setupPaperclip() {
+    setSaving(true); setError('');
+    try {
+      await api('/api/integrations/paperclip/setup', {
+        method: 'POST',
+        body: JSON.stringify({ url: pcUrl, company_id: pcCompanyId, api_key: pcApiKey }),
+      });
+      setSetupFor(null);
+      const data = await api<{ integrations: Integration[] }>('/api/integrations');
+      setIntegrations(data.integrations);
+    } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Setup failed'); }
+    finally { setSaving(false); }
+  }
+
+  async function loadPaperclipAgents() {
+    try {
+      const data = await api<{ ok: boolean; agents: { id: string; name: string; role: string }[] }>('/api/integrations/paperclip/agents');
+      setPcPaperclipAgents(data.agents || []);
+    } catch { setPcPaperclipAgents([]); }
+  }
+
+  async function savePaperclipMapping() {
+    setSaving(true); setError('');
+    try {
+      await api('/api/integrations/paperclip/agent-mapping', {
+        method: 'POST',
+        body: JSON.stringify({ agent_mapping: pcAgentMapping }),
+      });
+      setError('');
+    } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Failed to save mapping'); }
     finally { setSaving(false); }
   }
 
@@ -419,7 +459,7 @@ export function IntegrationsTab() {
             </div>
 
             {/* Permission level selector for Odoo and QuickBooks */}
-            {(integration.id === 'odoo' || integration.id === 'quickbooks') && integration.enabled && integration.configured && integration.connection_status !== 'broken' && (
+            {(integration.id === 'odoo' || integration.id === 'quickbooks' || integration.id === 'paperclip') && integration.enabled && integration.configured && integration.connection_status !== 'broken' && (
               <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', gap: 10 }}>
                 <span style={{ ...mono(9), whiteSpace: 'nowrap' }}>Permissions</span>
                 <div style={{
@@ -448,6 +488,65 @@ export function IntegrationsTab() {
                     </div>
                   ))}
                 </div>
+              </div>
+            )}
+
+            {/* Paperclip agent mapping */}
+            {integration.id === 'paperclip' && integration.enabled && integration.configured && (
+              <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid rgba(230,235,242,0.07)' }}>
+                <div
+                  onClick={() => {
+                    const next = !pcMappingExpanded;
+                    setPcMappingExpanded(next);
+                    if (next) {
+                      loadPaperclipAgents();
+                      api<{ agents: Agent[] }>('/api/agents').then(d => setAgents(d.agents));
+                    }
+                  }}
+                  style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }}
+                >
+                  <span style={{ ...mono(9), color: 'rgba(237,240,244,0.62)' }}>
+                    {pcMappingExpanded ? '▾' : '▸'} Agent Mapping
+                  </span>
+                  <span style={{ fontSize: 10, color: 'rgba(237,240,244,0.38)' }}>
+                    (required for heartbeats)
+                  </span>
+                </div>
+                {pcMappingExpanded && (
+                  <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    {pcPaperclipAgents.length === 0 ? (
+                      <p style={{ color: 'rgba(237,240,244,0.38)', fontSize: 12 }}>No Paperclip agents found. Create agents in the Paperclip UI first.</p>
+                    ) : (
+                      <>
+                        {pcPaperclipAgents.map(pa => (
+                          <div key={pa.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <span style={{ fontSize: 12, color: 'rgba(237,240,244,0.62)', minWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                              {pa.name} ({pa.role})
+                            </span>
+                            <span style={{ fontSize: 11, color: 'rgba(237,240,244,0.38)' }}>→</span>
+                            <select
+                              value={pcAgentMapping[pa.id] || ''}
+                              onChange={e => setPcAgentMapping(prev => ({ ...prev, [pa.id]: e.target.value }))}
+                              style={{ flex: 1, padding: '4px 8px', fontSize: 12, borderRadius: 4, border: '1px solid rgba(230,235,242,0.14)', background: 'rgba(230,235,242,0.04)', color: 'rgba(237,240,244,0.86)' }}
+                            >
+                              <option value="">Not mapped</option>
+                              {agents.map(a => (
+                                <option key={a.slug} value={a.slug}>{a.agent_name}</option>
+                              ))}
+                            </select>
+                          </div>
+                        ))}
+                        <button
+                          onClick={savePaperclipMapping}
+                          disabled={saving}
+                          style={{ alignSelf: 'flex-end', padding: '4px 14px', fontSize: 11, borderRadius: 3, background: 'var(--color-ch-accent, #C8D1D9)', color: '#0E1013', border: 'none', cursor: 'pointer', fontWeight: 500, opacity: saving ? 0.5 : 1, marginTop: 4 }}
+                        >
+                          {saving ? 'Saving...' : 'Save Mapping'}
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
             )}
 
@@ -685,6 +784,20 @@ export function IntegrationsTab() {
                     <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
                       <button onClick={() => setSetupFor(null)} style={{ flex: 1, padding: '8px 16px', fontSize: 13, borderRadius: 4, border: '1px solid rgba(230,235,242,0.14)', background: 'transparent', color: 'rgba(237,240,244,0.62)', cursor: 'pointer' }}>Cancel</button>
                       <button onClick={setupBambooHR} disabled={saving} style={{ flex: 1, padding: '8px 16px', fontSize: 13, borderRadius: 4, background: 'var(--color-ch-accent, #C8D1D9)', color: '#0E1013', border: 'none', cursor: 'pointer', fontWeight: 500, opacity: saving ? 0.5 : 1 }}>{saving ? 'Connecting...' : 'Connect'}</button>
+                    </div>
+                  </>
+                )}
+                {integration.id === 'paperclip' && (
+                  <>
+                    <p style={{ fontSize: 12, color: 'rgba(237,240,244,0.50)', lineHeight: 1.5, marginBottom: 4 }}>
+                      Connect to a Paperclip instance to orchestrate your agents with org charts, task management, and governance.
+                    </p>
+                    <input placeholder="Paperclip URL (http://localhost:3100)" value={pcUrl} onChange={e => setPcUrl(e.target.value)} style={inputStyle} />
+                    <input placeholder="Company ID" value={pcCompanyId} onChange={e => setPcCompanyId(e.target.value)} style={inputStyle} />
+                    <input placeholder="Bearer token (optional for local)" type="password" value={pcApiKey} onChange={e => setPcApiKey(e.target.value)} style={inputStyle} />
+                    <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+                      <button onClick={() => setSetupFor(null)} style={{ flex: 1, padding: '8px 16px', fontSize: 13, borderRadius: 4, border: '1px solid rgba(230,235,242,0.14)', background: 'transparent', color: 'rgba(237,240,244,0.62)', cursor: 'pointer' }}>Cancel</button>
+                      <button onClick={setupPaperclip} disabled={saving || !pcCompanyId.trim()} style={{ flex: 1, padding: '8px 16px', fontSize: 13, borderRadius: 4, background: 'var(--color-ch-accent, #C8D1D9)', color: '#0E1013', border: 'none', cursor: 'pointer', fontWeight: 500, opacity: saving || !pcCompanyId.trim() ? 0.5 : 1 }}>{saving ? 'Connecting...' : 'Connect'}</button>
                     </div>
                   </>
                 )}


### PR DESCRIPTION
## Summary

- Adds Paperclip integration connecting Chatty agents to Paperclip's orchestration control plane (org charts, task management, budgets, governance)
- 5 agent tools (list issues, get issue, checkout, update, add comment) with session cookie auth via email/password login
- Heartbeat webhook endpoint for automated agent execution via `run_sync()`, secured with auto-generated shared secret
- When agent mapping is saved, Chatty auto-configures Paperclip agents' HTTP adapter with the webhook URL and secret — no manual copy/paste
- Frontend setup card with email/password login, disconnect/reconfigure, and agent mapping UI
- Comprehensive setup guide (PAPERCLIP.md) with step-by-step Railway deployment and local dev instructions
- Railway deploy button in README linking to published Paperclip template

## Test plan

- [ ] Deploy Paperclip on Railway using the template button
- [ ] Complete Paperclip onboarding, note the default adapter is Claude Code
- [ ] Connect Chatty to Paperclip via Settings > Integrations > Paperclip (email/password)
- [ ] Map a Chatty agent to a Paperclip agent and save — verify Paperclip agent's adapter auto-switches to HTTP with webhook secret
- [ ] Chat with agent: "Check Paperclip for tasks" — verify `paperclip_list_issues` tool works
- [ ] Create issue in Paperclip, verify agent can see and claim it
- [ ] Test disconnect and reconnect flow
- [ ] Verify unauthenticated POST to `/api/integrations/paperclip/heartbeat` returns 403