### PR TITLE
Fix Windows compatibility across backend

### DIFF
--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -53,14 +53,22 @@ def _safe_import_filename(filename: str) -> bool:
 def _safe_scan_path(path: str) -> Path:
     """Resolve and validate a path for scan_directory. Must be under user's home."""
     home = Path.home()
-    if home == Path("/"):
+    if home == Path(home.anchor):
         raise ValueError("Cannot determine safe home directory — running as root is not supported for directory scanning")
     resolved = Path(path).expanduser().resolve()
     if not resolved.is_relative_to(home):
         raise ValueError(f"Path must be under your home directory ({home})")
-    for blocked in ("/etc", "/var", "/usr", "/System", "/Library"):
-        if str(resolved).startswith(blocked):
-            raise ValueError(f"Cannot scan system directory: {blocked}")
+    if os.name == "nt":
+        blocked_dirs = (
+            os.environ.get("SystemRoot", r"C:\Windows"),
+            os.environ.get("ProgramFiles", r"C:\Program Files"),
+            os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+        )
+    else:
+        blocked_dirs = ("/etc", "/var", "/usr", "/System", "/Library")
+    for b in blocked_dirs:
+        if resolved == Path(b) or resolved.is_relative_to(Path(b)):
+            raise ValueError(f"Cannot scan system directory: {b}")
     if not resolved.is_dir():
         raise FileNotFoundError(f"Directory not found: {resolved}")
     return resolved

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -60,14 +60,14 @@ def _safe_scan_path(path: str) -> Path:
         raise ValueError(f"Path must be under your home directory ({home})")
     if os.name == "nt":
         blocked_dirs = (
-            os.environ.get("SystemRoot", r"C:\Windows"),
-            os.environ.get("ProgramFiles", r"C:\Program Files"),
-            os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+            os.environ.get("SystemRoot") or r"C:\Windows",
+            os.environ.get("ProgramFiles") or r"C:\Program Files",
+            os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)",
         )
     else:
         blocked_dirs = ("/etc", "/var", "/usr", "/System", "/Library")
     for b in blocked_dirs:
-        if resolved == Path(b) or resolved.is_relative_to(Path(b)):
+        if resolved.is_relative_to(Path(b)):
             raise ValueError(f"Cannot scan system directory: {b}")
     if not resolved.is_dir():
         raise FileNotFoundError(f"Directory not found: {resolved}")

--- a/backend/core/agents/tools/file_cache.py
+++ b/backend/core/agents/tools/file_cache.py
@@ -34,7 +34,7 @@ def cache_file(cache_dir: str, raw: bytes, filename: str, mime_type: str) -> str
         "size_bytes": len(raw),
         "cached_at": time.time(),
     }
-    with open(meta_path, "w") as f:
+    with open(meta_path, "w", encoding="utf-8") as f:
         json.dump(meta, f)
 
     try:
@@ -64,7 +64,7 @@ def load_cached_file(cache_dir: str, file_ref: str) -> dict | None:
         return None
 
     try:
-        with open(meta_path) as f:
+        with open(meta_path, encoding="utf-8") as f:
             meta = json.load(f)
     except Exception:
         return None
@@ -98,7 +98,7 @@ def cleanup_expired(cache_dir: str) -> int:
         if not entry.name.endswith(".meta.json"):
             continue
         try:
-            with open(entry.path) as f:
+            with open(entry.path, encoding="utf-8") as f:
                 meta = json.load(f)
             if meta.get("cached_at", 0) < cutoff:
                 ref = entry.name.removesuffix(".meta.json")

--- a/backend/core/encryption.py
+++ b/backend/core/encryption.py
@@ -106,7 +106,7 @@ class EncryptionKeyManager:
         if not KEY_FILE_PATH.exists():
             return None
         try:
-            key = KEY_FILE_PATH.read_text().strip().encode()
+            key = KEY_FILE_PATH.read_text(encoding="utf-8").strip().encode()
             Fernet(key)  # validate
             logger.info("Using encryption key from file: %s", KEY_FILE_PATH)
             return key
@@ -132,8 +132,15 @@ class EncryptionKeyManager:
 
         if not stored_in_keychain:
             DATA_DIR.mkdir(parents=True, exist_ok=True)
-            KEY_FILE_PATH.write_text(key.decode())
-            KEY_FILE_PATH.chmod(0o600)
+            KEY_FILE_PATH.write_text(key.decode(), encoding="utf-8")
+            if os.name != "nt":
+                KEY_FILE_PATH.chmod(0o600)
+            else:
+                logger.warning(
+                    "Key file %s written with default ACLs — "
+                    "restrict access manually on shared machines",
+                    KEY_FILE_PATH,
+                )
             logger.info(
                 "Generated new encryption key, stored in file: %s", KEY_FILE_PATH
             )

--- a/backend/core/providers/credentials.py
+++ b/backend/core/providers/credentials.py
@@ -46,7 +46,7 @@ class CredentialStore:
     def _load(self) -> dict:
         if PROFILES_PATH.exists():
             try:
-                raw = json.loads(PROFILES_PATH.read_text())
+                raw = json.loads(PROFILES_PATH.read_text(encoding="utf-8"))
                 decrypted = decrypt_dict(raw)
                 # Auto-migrate plaintext credentials to encrypted on disk
                 if needs_migration(raw):

--- a/backend/core/providers/router.py
+++ b/backend/core/providers/router.py
@@ -335,7 +335,7 @@ async def sync_openai_cli(user=Depends(get_current_user)):
         if not cred_path.exists():
             continue
         try:
-            data = json.loads(cred_path.read_text())
+            data = json.loads(cred_path.read_text(encoding="utf-8"))
             auth_mode = data.get("auth_mode", "")
 
             # Prefer an explicit API key if set

--- a/backend/main.py
+++ b/backend/main.py
@@ -191,7 +191,7 @@ async def lifespan(app: FastAPI):
     if volume_marker.exists():
         logger.info("Persistent volume verified (marker file present)")
     else:
-        volume_marker.write_text(f"chatty:{datetime.now(timezone.utc).isoformat()}")
+        volume_marker.write_text(f"chatty:{datetime.now(timezone.utc).isoformat()}", encoding="utf-8")
         if settings.is_railway:
             logger.info(
                 "First boot — wrote volume marker to %s. "

--- a/run.py
+++ b/run.py
@@ -70,7 +70,7 @@ def setup_env():
         print("  .env file already exists, skipping.")
         return
     if ENV_EXAMPLE.exists():
-        content = ENV_EXAMPLE.read_text()
+        content = ENV_EXAMPLE.read_text(encoding="utf-8")
     else:
         content = (
             "AUTH_PASSWORD=changeme\n"
@@ -85,7 +85,7 @@ def setup_env():
         # Quote the value to handle special characters (=, #, spaces)
         safe_password = password.replace("'", "'\\''")
         content = content.replace("AUTH_PASSWORD=changeme", f"AUTH_PASSWORD='{safe_password}'")
-    ENV_FILE.write_text(content)
+    ENV_FILE.write_text(content, encoding="utf-8")
     print("  Created .env file.")
 
 


### PR DESCRIPTION
## Summary
- Add explicit `encoding="utf-8"` to all `open()`, `read_text()`, and `write_text()` calls to prevent locale-dependent encoding on Windows (defaults to `cp1252`)
- Fix platform-aware path handling: use `Path.anchor` for root detection, env vars (`%SystemRoot%`, `%ProgramFiles%`) for system directory blocking, and `Path.is_relative_to()` instead of string prefix matching
- Skip `chmod(0o600)` on Windows (unsupported) with a warning log for key file ACL awareness

## Test plan
- [ ] Verify backend starts cleanly on Linux/macOS (no regressions)
- [ ] Verify `_safe_scan_path` blocks system directories on both platforms
- [ ] Verify encryption key generation works on Windows without keyring
- [ ] Verify JSON credential files read/write correctly with non-ASCII content