### PR TITLE
Fix Telegram send reliability and switch to HTML formatting

### DIFF
--- a/backend/integrations/telegram/client.py
+++ b/backend/integrations/telegram/client.py
@@ -9,9 +9,15 @@ import logging
 
 import httpx
 
+from .format import markdown_to_telegram_html
+
 logger = logging.getLogger(__name__)
 
 MAX_CHUNK_LENGTH = 4096  # Telegram's message limit
+
+
+class TelegramSendError(Exception):
+    """Raised when a Telegram sendMessage call fails after all fallbacks."""
 
 
 def _base_url(bot_token: str) -> str:
@@ -21,7 +27,9 @@ def _base_url(bot_token: str) -> str:
 def send_message(chat_id: int | str, text: str, bot_token: str) -> list[dict]:
     """Send a text message to a Telegram chat.
 
-    Long messages are chunked.  Returns a list of Telegram response dicts.
+    Converts Markdown to Telegram HTML for formatting.  Falls back to plain
+    text if HTML conversion or parsing fails.  Raises ``TelegramSendError``
+    on delivery failure so callers can react.
     """
     if not bot_token:
         logger.warning("No Telegram bot token — cannot send message")
@@ -31,17 +39,28 @@ def send_message(chat_id: int | str, text: str, bot_token: str) -> list[dict]:
     results = []
     for chunk in chunks:
         try:
-            resp = httpx.post(
-                f"{_base_url(bot_token)}/sendMessage",
-                json={
-                    "chat_id": chat_id,
-                    "text": chunk,
-                    "parse_mode": "Markdown",
-                },
-                timeout=30,
-            )
-            # If Markdown parse fails, retry without parse_mode
-            if resp.status_code == 400 and "parse" in resp.text.lower():
+            html_chunk = markdown_to_telegram_html(chunk)
+        except Exception:
+            html_chunk = None
+
+        try:
+            if html_chunk and len(html_chunk) <= MAX_CHUNK_LENGTH:
+                resp = httpx.post(
+                    f"{_base_url(bot_token)}/sendMessage",
+                    json={
+                        "chat_id": chat_id,
+                        "text": html_chunk,
+                        "parse_mode": "HTML",
+                    },
+                    timeout=30,
+                )
+                if resp.status_code == 400 and "parse" in resp.text.lower():
+                    resp = httpx.post(
+                        f"{_base_url(bot_token)}/sendMessage",
+                        json={"chat_id": chat_id, "text": chunk},
+                        timeout=30,
+                    )
+            else:
                 resp = httpx.post(
                     f"{_base_url(bot_token)}/sendMessage",
                     json={"chat_id": chat_id, "text": chunk},
@@ -50,8 +69,8 @@ def send_message(chat_id: int | str, text: str, bot_token: str) -> list[dict]:
             resp.raise_for_status()
             results.append(resp.json())
         except httpx.HTTPError as e:
-            logger.error("Telegram send failed: %s", e)
-            results.append({"error": str(e)})
+            logger.error("Telegram send failed (chat_id=%s): %s", chat_id, e)
+            raise TelegramSendError(f"Failed to send to chat {chat_id}") from e
 
     return results
 

--- a/backend/integrations/telegram/format.py
+++ b/backend/integrations/telegram/format.py
@@ -1,0 +1,86 @@
+"""Markdown-to-Telegram-HTML converter.
+
+Converts standard Markdown (as produced by AI models) into Telegram's
+supported HTML subset.  Falls back gracefully — callers should catch
+exceptions and send plain text if conversion fails.
+"""
+
+import re
+
+_PLACEHOLDER_PREFIX = "\x00TGFMT"
+
+
+def _escape_html(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def markdown_to_telegram_html(text: str) -> str:
+    """Convert standard Markdown to Telegram-compatible HTML.
+
+    Handles bold, italic, strikethrough, inline code, fenced code blocks,
+    links, headers, and blockquotes.  Returns HTML suitable for Telegram's
+    ``parse_mode="HTML"``.
+    """
+    if not text:
+        return text
+
+    placeholders: list[str] = []
+
+    def _placeholder(html: str) -> str:
+        idx = len(placeholders)
+        placeholders.append(html)
+        return f"{_PLACEHOLDER_PREFIX}{idx}\x00"
+
+    # 1. Extract fenced code blocks before anything else
+    def _fenced_code(m: re.Match) -> str:
+        lang = m.group(1) or ""
+        code = _escape_html(m.group(2))
+        if lang:
+            return _placeholder(f'<pre><code class="language-{_escape_html(lang)}">{code}</code></pre>')
+        return _placeholder(f"<pre><code>{code}</code></pre>")
+
+    result = re.sub(r"```(\w*)\n(.*?)```", _fenced_code, text, flags=re.DOTALL)
+
+    # 2. Extract inline code
+    def _inline_code(m: re.Match) -> str:
+        return _placeholder(f"<code>{_escape_html(m.group(1))}</code>")
+
+    result = re.sub(r"`([^`]+)`", _inline_code, result)
+
+    # 3. Extract links (before HTML-escaping to avoid double-escaping URLs)
+    def _link(m: re.Match) -> str:
+        label = _escape_html(m.group(1))
+        href = _escape_html(m.group(2))
+        return _placeholder(f'<a href="{href}">{label}</a>')
+
+    result = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _link, result)
+
+    # 4. HTML-escape remaining text
+    result = _escape_html(result)
+
+    # 5. Block elements — headers
+    result = re.sub(r"^#{1,6}\s+(.+)$", r"<b>\1</b>", result, flags=re.MULTILINE)
+
+    # 6. Block elements — blockquotes (merge consecutive lines)
+    def _blockquote(m: re.Match) -> str:
+        lines = m.group(0).split("\n")
+        inner = "\n".join(re.sub(r"^&gt;\s?", "", line) for line in lines)
+        return f"<blockquote>{inner}</blockquote>"
+
+    result = re.sub(r"^&gt;\s?.+(?:\n&gt;\s?.+)*", _blockquote, result, flags=re.MULTILINE)
+
+    # 7. Inline elements — bold before italic
+    result = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", result)
+    result = re.sub(r"__(.+?)__", r"<b>\1</b>", result)
+
+    # Italic — single * only (skip _ to avoid false positives in URLs)
+    result = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<i>\1</i>", result)
+
+    # Strikethrough
+    result = re.sub(r"~~(.+?)~~", r"<s>\1</s>", result)
+
+    # 8. Restore placeholders
+    for idx, html in enumerate(placeholders):
+        result = result.replace(f"{_PLACEHOLDER_PREFIX}{idx}\x00", html)
+
+    return result

--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -200,10 +200,8 @@ def _safe_process_telegram(
                 finally:
                     loop.close()
 
-                try:
-                    send_message(chat_id, response, bot_token)
-                finally:
-                    group.record_response(chat_id, agent["id"])
+                send_message(chat_id, response, bot_token)
+                group.record_response(chat_id, agent["id"])
             finally:
                 with _busy_lock:
                     if _busy_chats.get(busy_key) == busy_started:

--- a/backend/tests/test_telegram_client.py
+++ b/backend/tests/test_telegram_client.py
@@ -1,0 +1,91 @@
+"""Tests for the Telegram client send_message function."""
+
+from unittest.mock import patch, MagicMock
+
+import httpx
+import pytest
+
+from integrations.telegram.client import send_message, TelegramSendError
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = text
+    resp.json.return_value = json_data or {"ok": True}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp,
+        )
+    return resp
+
+
+class TestSendMessageSuccess:
+    @patch("integrations.telegram.client.httpx.post")
+    def test_sends_with_html_parse_mode(self, mock_post):
+        mock_post.return_value = _mock_response()
+        send_message(123, "hello", "bot:token")
+
+        call_json = mock_post.call_args[1]["json"]
+        assert call_json["parse_mode"] == "HTML"
+        assert call_json["chat_id"] == 123
+
+    @patch("integrations.telegram.client.httpx.post")
+    def test_returns_response_list(self, mock_post):
+        mock_post.return_value = _mock_response(json_data={"ok": True, "result": {}})
+        results = send_message(123, "hello", "bot:token")
+        assert len(results) == 1
+        assert results[0]["ok"] is True
+
+
+class TestSendMessageFallback:
+    @patch("integrations.telegram.client.httpx.post")
+    def test_html_parse_error_falls_back_to_plain_text(self, mock_post):
+        parse_error = _mock_response(400, text='{"description": "can\'t parse entities"}')
+        parse_error.raise_for_status = MagicMock()
+        success = _mock_response()
+        mock_post.side_effect = [parse_error, success]
+
+        results = send_message(123, "**bold**", "bot:token")
+        assert len(results) == 1
+
+        second_call_json = mock_post.call_args_list[1][1]["json"]
+        assert "parse_mode" not in second_call_json
+
+
+class TestSendMessageErrors:
+    @patch("integrations.telegram.client.httpx.post")
+    def test_http_error_raises_telegram_send_error(self, mock_post):
+        mock_post.return_value = _mock_response(500)
+        with pytest.raises(TelegramSendError):
+            send_message(123, "hello", "bot:token")
+
+    @patch("integrations.telegram.client.httpx.post")
+    def test_network_error_raises_telegram_send_error(self, mock_post):
+        mock_post.side_effect = httpx.ConnectError("connection refused")
+        with pytest.raises(TelegramSendError):
+            send_message(123, "hello", "bot:token")
+
+    @patch("integrations.telegram.client.httpx.post")
+    def test_html_and_plain_both_fail_raises(self, mock_post):
+        parse_error = _mock_response(400, text='{"description": "can\'t parse entities"}')
+        parse_error.raise_for_status = MagicMock()
+        server_error = _mock_response(500)
+        mock_post.side_effect = [parse_error, server_error]
+
+        with pytest.raises(TelegramSendError):
+            send_message(123, "**bold**", "bot:token")
+
+
+class TestSendMessageEdgeCases:
+    def test_no_bot_token_returns_empty(self):
+        results = send_message(123, "hello", "")
+        assert results == []
+
+    @patch("integrations.telegram.client.httpx.post")
+    def test_chunked_long_message(self, mock_post):
+        mock_post.return_value = _mock_response()
+        long_text = "word " * 2000
+        send_message(123, long_text, "bot:token")
+        assert mock_post.call_count >= 2

--- a/backend/tests/test_telegram_format.py
+++ b/backend/tests/test_telegram_format.py
@@ -1,0 +1,112 @@
+"""Tests for the Telegram Markdown-to-HTML converter."""
+
+from integrations.telegram.format import markdown_to_telegram_html
+
+
+class TestHtmlEscaping:
+    def test_ampersand(self):
+        assert markdown_to_telegram_html("a & b") == "a &amp; b"
+
+    def test_angle_brackets(self):
+        assert markdown_to_telegram_html("a < b > c") == "a &lt; b &gt; c"
+
+    def test_script_tag(self):
+        assert markdown_to_telegram_html("<script>alert('x')</script>") == "&lt;script&gt;alert('x')&lt;/script&gt;"
+
+    def test_empty_string(self):
+        assert markdown_to_telegram_html("") == ""
+
+
+class TestBoldItalic:
+    def test_bold_double_asterisk(self):
+        assert markdown_to_telegram_html("**bold**") == "<b>bold</b>"
+
+    def test_bold_double_underscore(self):
+        assert markdown_to_telegram_html("__bold__") == "<b>bold</b>"
+
+    def test_italic_single_asterisk(self):
+        assert markdown_to_telegram_html("*italic*") == "<i>italic</i>"
+
+    def test_bold_and_italic(self):
+        result = markdown_to_telegram_html("**bold** and *italic*")
+        assert "<b>bold</b>" in result
+        assert "<i>italic</i>" in result
+
+    def test_strikethrough(self):
+        assert markdown_to_telegram_html("~~struck~~") == "<s>struck</s>"
+
+
+class TestCode:
+    def test_inline_code(self):
+        assert markdown_to_telegram_html("`some code`") == "<code>some code</code>"
+
+    def test_inline_code_html_escaped(self):
+        assert markdown_to_telegram_html("`a < b`") == "<code>a &lt; b</code>"
+
+    def test_fenced_code_block(self):
+        text = "```python\nprint('hello')\n```"
+        result = markdown_to_telegram_html(text)
+        assert '<pre><code class="language-python">' in result
+        assert "print('hello')" in result
+        assert "</code></pre>" in result
+
+    def test_fenced_code_no_language(self):
+        text = "```\nsome code\n```"
+        result = markdown_to_telegram_html(text)
+        assert "<pre><code>" in result
+        assert "some code" in result
+
+    def test_code_block_preserves_content(self):
+        text = "```\n**not bold** & <not tag>\n```"
+        result = markdown_to_telegram_html(text)
+        assert "**not bold**" in result
+        assert "&amp;" in result
+        assert "&lt;not tag&gt;" in result
+        assert "<b>" not in result
+
+
+class TestLinks:
+    def test_basic_link(self):
+        result = markdown_to_telegram_html("[click](https://example.com)")
+        assert result == '<a href="https://example.com">click</a>'
+
+    def test_link_with_special_chars_in_url(self):
+        result = markdown_to_telegram_html("[x](https://a.com/?q=1&r=2)")
+        assert 'href="https://a.com/?q=1&amp;r=2"' in result
+
+
+class TestBlockElements:
+    def test_header_h1(self):
+        assert markdown_to_telegram_html("# Title") == "<b>Title</b>"
+
+    def test_header_h3(self):
+        assert markdown_to_telegram_html("### Sub") == "<b>Sub</b>"
+
+    def test_blockquote_single_line(self):
+        result = markdown_to_telegram_html("> quoted text")
+        assert "<blockquote>" in result
+        assert "quoted text" in result
+
+    def test_blockquote_multiline(self):
+        result = markdown_to_telegram_html("> line one\n> line two")
+        assert "<blockquote>" in result
+        assert "line one" in result
+        assert "line two" in result
+        assert result.count("<blockquote>") == 1
+
+
+class TestRealisticAiResponse:
+    def test_mixed_response(self):
+        text = (
+            "Your 8:10 AM skin check on May 22 is already on the family calendar:\n\n"
+            "* **Will skin check** — Nashville Skin — Jessica Swindell\n"
+            "* **May 22 (Friday)** at 8:10 AM\n"
+            "* **No conflicts** — first work meeting isn't until 10 AM\n\n"
+            "You're good to go."
+        )
+        result = markdown_to_telegram_html(text)
+        assert "<b>Will skin check</b>" in result
+        assert "<b>May 22 (Friday)</b>" in result
+        assert "<b>No conflicts</b>" in result
+        assert "You're good to go." in result
+        assert "**" not in result


### PR DESCRIPTION
## Summary

- **Fix silent send failures**: `send_message()` now raises `TelegramSendError` instead of silently swallowing errors, so the router's fallback "I had trouble processing that" message actually fires
- **Switch to HTML formatting**: Replace Telegram's legacy Markdown v1 (incompatible with AI output) with a Markdown-to-HTML converter using `parse_mode: "HTML"`, with automatic plain-text fallback
- **Fix group response recording**: Move `group.record_response()` out of a `finally` block so it only records on successful delivery

## Test plan

- [ ] Run `pytest backend/tests/` — 77 tests pass (29 new)
- [ ] Send a Telegram message to an agent, verify formatted response arrives
- [ ] Test with a tool-using query (e.g., calendar lookup) that generates bold/bullet responses
- [ ] Verify fallback: if HTML parse fails, message still delivers as plain text
- [ ] Verify error handling: if Telegram API is down, user sees "I had trouble" instead of silence