### PR TITLE
Port heartbeat robustness fixes from cake_os

### DIFF
--- a/backend/core/agents/background_runner.py
+++ b/backend/core/agents/background_runner.py
@@ -100,6 +100,7 @@ async def _run_turn(
                         output_tokens=total_output_tokens,
                         model_used=model_used,
                         tool_log=tool_log,
+                        error=not accumulated_text,
                     )
 
         if not tool_calls_this_turn:
@@ -109,6 +110,7 @@ async def _run_turn(
                 output_tokens=total_output_tokens,
                 model_used=model_used,
                 tool_log=tool_log,
+                error=not accumulated_text,
             )
 
         # Execute tools
@@ -144,6 +146,7 @@ async def _run_turn(
         output_tokens=total_output_tokens,
         model_used=model_used,
         tool_log=tool_log,
+        error=True,
     )
 
 

--- a/backend/core/agents/scheduled_actions/history.py
+++ b/backend/core/agents/scheduled_actions/history.py
@@ -85,7 +85,7 @@ def get_history(
         params.append(action_id)
     if status_filter:
         if status_filter == "action_taken":
-            query += " AND status NOT IN ('ok', 'skipped', 'running')"
+            query += " AND status NOT IN ('ok', 'skipped', 'running', 'lease_lost')"
         else:
             query += " AND status = ?"
             params.append(status_filter)

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -21,6 +21,8 @@ from . import history, notifications, service
 
 logger = logging.getLogger(__name__)
 
+_BG_TURN_ERRORS = frozenset({"(no response)", "(max iterations reached)"})
+
 _MAX_WORKERS = int(os.environ.get("SCHEDULED_ACTION_WORKERS", "4"))
 _executor = ThreadPoolExecutor(max_workers=_MAX_WORKERS, thread_name_prefix="heartbeat")
 
@@ -94,7 +96,7 @@ def process_due_actions() -> None:
             service.mark_executed(action["id"], "error", "auto-disabled: consecutive_errors >= 5", 0, lease_id=lease_id)
             continue
 
-        if not action.get("always_on") and not _in_active_hours(action):
+        if not _within_active_hours(action):
             service.release_lease(action["id"], lease_id, advance_next_run=True)
             continue
 
@@ -114,23 +116,27 @@ def process_due_actions() -> None:
         )
 
 
-def _in_active_hours(action: dict) -> bool:
-    tz_name = action.get("active_hours_tz", "America/Chicago")
+def _within_active_hours(action: dict) -> bool:
+    if action.get("always_on"):
+        return True
+
+    start_str = action.get("active_hours_start")
+    end_str = action.get("active_hours_end")
+    if not start_str or not end_str:
+        return True
+
+    tz_name = action.get("active_hours_tz") or "America/Chicago"
     try:
         tz = ZoneInfo(tz_name)
     except Exception:
-        tz = ZoneInfo("America/Chicago")
+        return True
 
     now = datetime.now(tz)
-    start_str = action.get("active_hours_start", "06:00")
-    end_str = action.get("active_hours_end", "20:00")
-
     try:
         start_h, start_m = map(int, str(start_str).split(":"))
         end_h, end_m = map(int, str(end_str).split(":"))
     except (ValueError, TypeError):
-        start_h, start_m = 6, 0
-        end_h, end_m = 20, 0
+        return True
 
     current_minutes = now.hour * 60 + now.minute
     start_minutes = start_h * 60 + start_m
@@ -241,48 +247,74 @@ def _process_heartbeat(action: dict) -> None:
         # Optional triage pass
         triage_data = None
         if action.get("triage_enabled", 1):
-            triage_result = run_background_turn(
-                system_prompt=(
-                    f"You are {agent['agent_name']}.\n\n"
-                    f"# Quick Heartbeat Triage\n\n"
-                    f"Quickly check the following items using your tools. "
-                    f"Respond with ONLY one of:\n"
-                    f"- NEEDS_ACTION: <brief reason>\n"
-                    f"- ALL_CLEAR\n\n"
-                    f"## Checklist\n\n{checklist}\n"
-                ),
-                user_message="Quick triage check — anything need attention?",
-                tool_defs=tool_defs,
-                registry=registry,
-                max_iterations=2,
-                provider_override=provider_override,
-                model_override=model_override,
-            )
-            triage_data = {
-                "result": "NEEDS_ACTION" if "NEEDS_ACTION" in triage_result.text.upper() else "ALL_CLEAR",
-                "model": triage_result.model_used,
-                "input_tokens": triage_result.input_tokens,
-                "output_tokens": triage_result.output_tokens,
-            }
-            if not triage_result.error and "NEEDS_ACTION" not in triage_result.text.upper():
-                duration_ms = int((time.monotonic() - start_time) * 1000)
-                completed = service.mark_executed(
-                    action["id"], "ok", "Triage: all clear", duration_ms,
-                    triage_result.input_tokens, triage_result.output_tokens, lease_id=lease_id,
+            triage_result = None
+            try:
+                triage_result = run_background_turn(
+                    system_prompt=(
+                        f"You are {agent['agent_name']}.\n\n"
+                        f"# Quick Heartbeat Triage\n\n"
+                        f"Quickly check the following items using your tools. "
+                        f"Respond with ONLY one of:\n"
+                        f"- NEEDS_ACTION: <brief reason>\n"
+                        f"- ALL_CLEAR\n\n"
+                        f"## Checklist\n\n{checklist}\n"
+                    ),
+                    user_message="Quick triage check — anything need attention?",
+                    tool_defs=tool_defs,
+                    registry=registry,
+                    max_iterations=2,
+                    provider_override=provider_override,
+                    model_override=model_override,
                 )
-                if completed and execution_id:
-                    history.record_complete(
-                        execution_id, status="ok",
-                        result_summary="Triage: all clear",
-                        result_full="Triage returned ALL_CLEAR — skipping full check.",
-                        tool_calls=[{"triage": triage_data}],
-                        model_used=triage_result.model_used,
-                        input_tokens=triage_result.input_tokens,
-                        output_tokens=triage_result.output_tokens,
-                        duration_ms=duration_ms,
-                    )
-                logger.info("Heartbeat %s: triage ALL_CLEAR (%dms)", agent_slug, duration_ms)
-                return
+            except Exception as e:
+                logger.warning("Triage failed for %s, proceeding to full check: %s",
+                               agent_slug, e)
+
+            if triage_result is not None:
+                if triage_result.error:
+                    logger.warning("Triage returned error for %s: %s", agent_slug,
+                                   triage_result.text[:100])
+                    triage_data = {
+                        "result": "ERROR",
+                        "model": triage_result.model_used,
+                        "input_tokens": triage_result.input_tokens,
+                        "output_tokens": triage_result.output_tokens,
+                    }
+                else:
+                    triage_data = {
+                        "result": "NEEDS_ACTION" if "NEEDS_ACTION" in triage_result.text.upper() else "ALL_CLEAR",
+                        "model": triage_result.model_used,
+                        "input_tokens": triage_result.input_tokens,
+                        "output_tokens": triage_result.output_tokens,
+                    }
+                    if "NEEDS_ACTION" not in triage_result.text.upper():
+                        duration_ms = int((time.monotonic() - start_time) * 1000)
+                        completed = service.mark_executed(
+                            action["id"], "ok", "Triage: all clear", duration_ms,
+                            triage_result.input_tokens, triage_result.output_tokens, lease_id=lease_id,
+                        )
+                        if completed:
+                            if execution_id:
+                                history.record_complete(
+                                    execution_id, status="ok",
+                                    result_summary="Triage: all clear",
+                                    result_full="Triage returned ALL_CLEAR — skipping full check.",
+                                    tool_calls=[{"triage": triage_data}],
+                                    model_used=triage_result.model_used,
+                                    input_tokens=triage_result.input_tokens,
+                                    output_tokens=triage_result.output_tokens,
+                                    duration_ms=duration_ms,
+                                )
+                            logger.info("Heartbeat %s: triage ALL_CLEAR (%dms)", agent_slug, duration_ms)
+                        else:
+                            logger.warning("Heartbeat %s: triage lease lost", agent_slug)
+                            if execution_id:
+                                history.record_complete(
+                                    execution_id, status="lease_lost",
+                                    result_summary="Triage: lease expired before completion",
+                                    duration_ms=duration_ms,
+                                )
+                        return
 
         # Full execution
         system_prompt = (
@@ -310,7 +342,7 @@ def _process_heartbeat(action: dict) -> None:
         duration_ms = int((time.monotonic() - start_time) * 1000)
 
         # Classification
-        if result.error:
+        if result.error or result.text in _BG_TURN_ERRORS:
             status = "error"
         elif "HEARTBEAT_OK" in result.text.upper():
             status = "ok"
@@ -329,6 +361,12 @@ def _process_heartbeat(action: dict) -> None:
 
         if not completed:
             logger.warning("Heartbeat %s: lease lost — discarding result", agent_slug)
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="lease_lost",
+                    result_summary="Lease expired before completion",
+                    duration_ms=duration_ms,
+                )
             return
 
         notified = notifications.evaluate_and_notify(action, status, result.text[:300], agent_slug)
@@ -350,9 +388,21 @@ def _process_heartbeat(action: dict) -> None:
     except Exception as e:
         duration_ms = int((time.monotonic() - start_time) * 1000)
         logger.error("Heartbeat %s failed: %s", agent_slug, e)
-        service.mark_executed(action["id"], "error", str(e)[:2000], duration_ms, lease_id=lease_id)
-        if execution_id:
-            history.record_complete(execution_id, status="error", result_summary=str(e)[:500], result_full=str(e), duration_ms=duration_ms)
+        completed = service.mark_executed(action["id"], "error", str(e)[:2000], duration_ms, lease_id=lease_id)
+        if not completed:
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="lease_lost",
+                    result_summary="Lease expired before error could be recorded",
+                    duration_ms=duration_ms,
+                )
+        else:
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="error",
+                    result_summary=str(e)[:500], result_full=str(e),
+                    duration_ms=duration_ms,
+                )
 
 
 def _process_cron(action: dict) -> None:
@@ -410,12 +460,21 @@ def _process_cron(action: dict) -> None:
         )
         duration_ms = int((time.monotonic() - start_time) * 1000)
 
-        status = "error" if result.error else "ok"
+        status = "error" if result.error or result.text in _BG_TURN_ERRORS else "ok"
         completed = service.mark_executed(
             action["id"], status, result.text[:2000], duration_ms,
             result.input_tokens, result.output_tokens, lease_id=lease_id,
         )
-        if completed and execution_id:
+        if not completed:
+            logger.warning("Cron %s/%s: lease lost — discarding result", agent_slug, action["id"][:8])
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="lease_lost",
+                    result_summary="Lease expired before completion",
+                    duration_ms=duration_ms,
+                )
+            return
+        if execution_id:
             history.record_complete(
                 execution_id, status=status,
                 result_summary=result.text[:500],
@@ -430,9 +489,21 @@ def _process_cron(action: dict) -> None:
     except Exception as e:
         duration_ms = int((time.monotonic() - start_time) * 1000)
         logger.error("Cron %s failed: %s", agent_slug, e)
-        service.mark_executed(action["id"], "error", str(e)[:2000], duration_ms, lease_id=lease_id)
-        if execution_id:
-            history.record_complete(execution_id, status="error", result_summary=str(e)[:500], result_full=str(e), duration_ms=duration_ms)
+        completed = service.mark_executed(action["id"], "error", str(e)[:2000], duration_ms, lease_id=lease_id)
+        if not completed:
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="lease_lost",
+                    result_summary="Lease expired before error could be recorded",
+                    duration_ms=duration_ms,
+                )
+        else:
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="error",
+                    result_summary=str(e)[:500], result_full=str(e),
+                    duration_ms=duration_ms,
+                )
 
 
 def _is_effectively_empty(content: str) -> bool:

--- a/backend/core/agents/scheduled_actions/router.py
+++ b/backend/core/agents/scheduled_actions/router.py
@@ -76,7 +76,8 @@ async def update_action(action_id: str, body: UpdateActionRequest, user=Depends(
 async def delete_action(action_id: str, user=Depends(get_current_user)):
     result = service.delete_action(action_id)
     if "error" in result:
-        raise HTTPException(status_code=404, detail=result["error"])
+        status = 404 if "not found" in result["error"].lower() else 409
+        raise HTTPException(status_code=status, detail=result["error"])
     return result
 
 

--- a/backend/core/agents/scheduled_actions/service.py
+++ b/backend/core/agents/scheduled_actions/service.py
@@ -151,6 +151,14 @@ def create_action(
 
     conn = db.get_db()
     with db.write_lock():
+        if action_type == "heartbeat":
+            existing = conn.execute(
+                "SELECT id FROM scheduled_actions WHERE agent = ? AND action_type = 'heartbeat'",
+                (agent,),
+            ).fetchone()
+            if existing:
+                return {"error": f"Agent '{agent}' already has a heartbeat (id={existing['id']})"}
+
         conn.execute(
             """INSERT INTO scheduled_actions
                (id, agent, created_by_email, action_type, name, description,
@@ -282,6 +290,8 @@ def delete_action(action_id: str) -> dict:
         row = conn.execute("SELECT * FROM scheduled_actions WHERE id = ?", (action_id,)).fetchone()
         if not row:
             return {"error": f"Action {action_id} not found"}
+        if row["action_type"] == "heartbeat":
+            return {"error": "Cannot delete heartbeat actions. Disable it instead with update_scheduled_action."}
         conn.execute("DELETE FROM scheduled_actions WHERE id = ?", (action_id,))
         conn.commit()
 

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1206,23 +1206,27 @@ def get_scheduling_instructions() -> str:
 Use `create_reminder` to set a follow-up for yourself. When the reminder fires, you'll receive the context and can take action. Use ISO 8601 format for due_at.
 
 ### Heartbeat (your main recurring loop)
-You already have a **heartbeat** that runs every 30 minutes and checks your HEARTBEAT.md file. This is your primary mechanism for recurring work.
+You have a **background heartbeat** — your primary mechanism for recurring work. It runs periodically (check `list_scheduled_actions` for your interval) and checks your `HEARTBEAT.md` file. Each item is evaluated and you can take action using your tools.
 
-To add a recurring task, **add it to your HEARTBEAT.md checklist** with time conditions (e.g., "Every weekday at 9 AM: send morning brief"). The heartbeat will pick it up automatically on its next pulse. Do NOT create a separate scheduled action for something the heartbeat can handle.
+To add a recurring task, use `write_context_file` to edit your HEARTBEAT.md checklist. Add items with time conditions (e.g., "Every weekday at 9 AM: send morning brief"). The heartbeat will pick it up automatically on its next pulse. Do NOT create a separate scheduled action for something the heartbeat can handle.
+
+Good checklist items are specific and actionable: "Check if user has unread emails from important contacts", "Look for overdue invoices", "Check today's calendar for double-bookings". Vague items like "check things" waste a cycle.
+
+If a user asks you to proactively monitor something, add it to HEARTBEAT.md. If they ask you to stop monitoring, remove the item. Use `list_scheduled_actions` to check your heartbeat status and interval.
 
 ### Scheduled Actions
-Use `create_scheduled_action` only when you need a task with its own independent schedule that doesn't fit the heartbeat pattern (e.g., a one-time future task with `schedule_type="once"`).
+Use `create_scheduled_action` only when you need a task with its own independent schedule that doesn't fit the heartbeat pattern (e.g., a one-time future task with `schedule_type="once"`). Always confirm with the user before creating one.
 
 ### Active Hours
 - Scheduled actions have an **active hours window** — they only run during this window.
 - Default is 6 AM to 8 PM. To change, set `active_hours_start` and `active_hours_end` (integers 0-23).
 - For 24/7 operation, set `always_on=true` — this bypasses active hours entirely.
-- Your heartbeat runs 24/7 by default (`always_on`). Time-gating belongs in your HEARTBEAT.md checklist items, not on the heartbeat itself.
+- Your heartbeat runs 24/7 by default (`always_on`). Time-gating belongs in your HEARTBEAT.md checklist items (e.g., "Only on weekdays before 10 AM: ..."), not on the heartbeat's active hours.
 
-Guidelines:
+### Guidelines
 - Always confirm with the user before creating scheduled actions
 - Use descriptive names for scheduled actions
-- Prefer adding items to HEARTBEAT.md over creating new scheduled actions
+- Prefer adding items to HEARTBEAT.md (via `write_context_file`) over creating new scheduled actions
 - For one-time future tasks, use `schedule_type="once"` with `run_at`
 """
 


### PR DESCRIPTION
## Summary

- **Triage error guard**: Detect error sentinels (`(no response)`, `(max iterations reached)`) from the background runner and fall through to full heartbeat execution instead of silently treating as ALL_CLEAR. Wrap triage in try/except so provider failures degrade gracefully.
- **Lease-lost history recording**: Record `lease_lost` status in execution history when `mark_executed` fails due to lease mismatch, instead of leaving dangling `running` records. Applied consistently across heartbeat triage, heartbeat full execution, and cron paths.
- **Background runner error flags**: Set `error=True` on max-iterations and empty-response returns so callers can reliably detect failures via `result.error` instead of matching sentinel strings.
- **Active hours consolidation**: Rename `_in_active_hours` → `_within_active_hours` with `always_on`, missing-config, and bad-timezone early returns. Simplify call site.
- **Heartbeat safety guards**: Enforce one heartbeat per agent in `create_action` (inside write_lock). Block deletion of heartbeat actions (409 instead of 404).
- **Scheduling instructions**: Update agent instructions to reference `write_context_file` for editing HEARTBEAT.md and `list_scheduled_actions` for checking status.

## Test plan

- [ ] Start dev server and verify heartbeat creates on agent onboarding
- [ ] Check `/api/scheduled-actions/dashboard` returns correct stats
- [ ] Verify duplicate heartbeat creation returns error
- [ ] Verify heartbeat delete returns 409
- [ ] Verify Python syntax: `python -c "from core.agents.scheduled_actions import processor, service"`