### PR TITLE
Make CRM demo data obvious and easy to clear

### DIFF
--- a/backend/integrations/crm_lite/router.py
+++ b/backend/integrations/crm_lite/router.py
@@ -349,6 +349,33 @@ async def demo_clear(user=Depends(_require_crm)):
     return {"ok": True}
 
 
+class ClearAllBody(BaseModel):
+    confirmation: str
+
+
+@router.post("/clear-all")
+async def clear_all(body: ClearAllBody, user=Depends(_require_crm)):
+    if body.confirmation != "clear crm":
+        raise HTTPException(status_code=400, detail="Invalid confirmation phrase")
+
+    from integrations.registry import get_credentials, save_credentials
+    from .db import _get_db, write_lock
+
+    db = _get_db()
+    with write_lock():
+        db.execute("DELETE FROM activity_log")
+        db.execute("DELETE FROM tasks")
+        db.execute("DELETE FROM deals")
+        db.execute("DELETE FROM contacts")
+        db.execute("DELETE FROM sqlite_sequence WHERE name IN ('contacts','deals','tasks','activity_log')")
+        db.commit()
+
+    creds = get_credentials("crm_lite")
+    creds["demo_mode"] = False
+    save_credentials("crm_lite", creds)
+    return {"ok": True}
+
+
 # ── CSV Import ────────────────────────────────────────────────────────────────
 
 @router.post("/import")

--- a/frontend/src/crm/CrmLayout.tsx
+++ b/frontend/src/crm/CrmLayout.tsx
@@ -3,7 +3,7 @@ import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import { api } from '../core/api/client';
 import { useIsMobile } from '../shared/useIsMobile';
 import { MobileMenuDrawer } from '../shared/MobileMenuDrawer';
-import { INK, INK_SOFT, INK_MUTE, LINE, LINE_STRONG, ACCENT, FONT_DISPLAY, FONT_SANS, FONT_MONO, SAGE, GOLD } from '../shared/styles';
+import { INK, INK_SOFT, INK_MUTE, LINE, LINE_STRONG, ACCENT, FONT_DISPLAY, FONT_SANS, SAGE, GOLD } from '../shared/styles';
 import { modalOverlay, modalContent, btnPrimary, btnSecondary } from './styles';
 
 const NAV_ITEMS = [
@@ -83,6 +83,56 @@ function DemoDialog({ onClear, onDismiss }: {
   );
 }
 
+function DemoBanner({ onClear, isMobile }: {
+  onClear: () => Promise<void>; isMobile: boolean;
+}) {
+  const [clearing, setClearing] = useState(false);
+  const [error, setError] = useState(false);
+
+  async function handleClear() {
+    setClearing(true);
+    setError(false);
+    try {
+      await onClear();
+    } catch {
+      setError(true);
+      setClearing(false);
+    }
+  }
+
+  return (
+    <div style={{
+      background: 'rgba(212,168,90,0.08)',
+      borderBottom: '1px solid rgba(212,168,90,0.15)',
+      padding: isMobile ? '10px 16px' : '8px 28px',
+      display: 'flex',
+      flexDirection: isMobile ? 'column' : 'row',
+      alignItems: isMobile ? 'flex-start' : 'center',
+      justifyContent: 'space-between',
+      gap: isMobile ? 8 : 16,
+    }}>
+      <span style={{
+        fontFamily: FONT_SANS, fontSize: 13, color: error ? '#D97757' : GOLD, lineHeight: 1.4,
+      }}>
+        {error
+          ? 'Failed to clear example data. Please try again.'
+          : <>You're viewing example data &mdash; contacts, deals, and tasks are samples.</>}
+      </span>
+      <button
+        onClick={handleClear}
+        disabled={clearing}
+        style={{
+          background: 'rgba(212,168,90,0.12)', color: GOLD,
+          border: '1px solid rgba(212,168,90,0.20)', borderRadius: 4,
+          padding: '4px 14px', fontSize: 12, fontFamily: FONT_SANS,
+          fontWeight: 500, cursor: clearing ? 'wait' : 'pointer',
+          opacity: clearing ? 0.6 : 1, whiteSpace: 'nowrap',
+        }}
+      >{clearing ? 'Clearing...' : 'Clear example data'}</button>
+    </div>
+  );
+}
+
 export function CrmLayout() {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
@@ -126,18 +176,6 @@ export function CrmLayout() {
               fontFamily: FONT_DISPLAY,
               fontSize: isMobile ? 20 : 18, letterSpacing: '-0.01em', color: INK,
             }}>CRM</div>
-            {demoMode && dialogDismissed && (
-              <button
-                onClick={() => setDialogDismissed(false)}
-                style={{
-                  background: 'rgba(212,168,90,0.10)', color: GOLD,
-                  border: '1px solid rgba(212,168,90,0.20)', borderRadius: 4,
-                  padding: '2px 8px', fontSize: 10, fontFamily: FONT_MONO,
-                  letterSpacing: '0.08em', textTransform: 'uppercase',
-                  cursor: 'pointer',
-                }}
-              >Example data</button>
-            )}
           </div>
           {!isMobile && (
             <>
@@ -204,6 +242,16 @@ export function CrmLayout() {
 
       {isMobile && showMenu && (
         <MobileMenuDrawer onClose={() => setShowMenu(false)} navigate={navigate} />
+      )}
+
+      {demoMode && dialogDismissed && (
+        <DemoBanner
+          onClear={async () => {
+            await handleClearDemo();
+            setDemoMode(false);
+          }}
+          isMobile={isMobile}
+        />
       )}
 
       <div key={refreshKey} style={{ flex: 1, overflow: 'auto', position: 'relative' }}>

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -20,6 +20,10 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
   const [tab, setTab] = useState<Tab>('providers');
   const [deleteAgent, setDeleteAgent] = useState<Agent | null>(null);
   const [dangerAgents, setDangerAgents] = useState<Agent[]>([]);
+  const [crmConfirm, setCrmConfirm] = useState('');
+  const [crmClearing, setCrmClearing] = useState(false);
+  const [crmCleared, setCrmCleared] = useState(false);
+  const [crmError, setCrmError] = useState('');
 
   useEffect(() => {
     if (tab === 'danger') {
@@ -303,6 +307,87 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
                       </div>
                     ))}
                   </div>
+                )}
+              </div>
+
+              {/* Clear CRM data */}
+              <div style={{ borderTop: '1px solid rgba(230,235,242,0.07)', paddingTop: 24 }}>
+                <h3 style={{
+                  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                  fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
+                  color: 'rgba(237,240,244,0.38)', marginBottom: 12,
+                }}>Clear CRM data</h3>
+
+                {crmCleared ? (
+                  <p style={{ fontSize: 13, color: 'rgba(142,165,137,0.9)', margin: 0 }}>
+                    All CRM data has been cleared.
+                  </p>
+                ) : (
+                  <>
+                    <p style={{ fontSize: 13, color: 'rgba(237,240,244,0.52)', margin: '0 0 12px', lineHeight: 1.5 }}>
+                      Delete all contacts, deals, tasks, and activity from the CRM. This cannot be undone.
+                    </p>
+                    <div style={{
+                      background: 'rgba(217,119,87,0.08)',
+                      border: '1px solid rgba(217,119,87,0.2)',
+                      borderRadius: 6, padding: '10px 14px', marginBottom: 12,
+                    }}>
+                      <p style={{ fontSize: 12, color: '#D97757', margin: 0, lineHeight: 1.5 }}>
+                        Type <strong style={{
+                          fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                          background: 'rgba(217,119,87,0.12)',
+                          padding: '1px 6px', borderRadius: 3,
+                        }}>clear crm</strong> to confirm.
+                      </p>
+                    </div>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                      <input
+                        type="text"
+                        value={crmConfirm}
+                        onChange={e => setCrmConfirm(e.target.value)}
+                        placeholder="clear crm"
+                        autoComplete="off"
+                        style={{
+                          flex: 1, boxSizing: 'border-box',
+                          background: 'rgba(20,24,30,0.78)',
+                          border: '1px solid rgba(230,235,242,0.14)',
+                          color: '#EDF0F4', borderRadius: 4,
+                          padding: '8px 14px', fontSize: 13, outline: 'none',
+                          fontFamily: "'Inter Tight', system-ui, sans-serif",
+                        }}
+                      />
+                      <button
+                        disabled={crmClearing || crmConfirm.toLowerCase() !== 'clear crm'}
+                        onClick={async () => {
+                          setCrmClearing(true);
+                          setCrmError('');
+                          try {
+                            await api('/api/crm/clear-all', {
+                              method: 'POST',
+                              body: JSON.stringify({ confirmation: 'clear crm' }),
+                            });
+                            setCrmCleared(true);
+                            setTimeout(() => window.location.reload(), 1500);
+                          } catch (err: unknown) {
+                            setCrmError(err instanceof Error ? err.message : 'Failed to clear CRM data');
+                          } finally {
+                            setCrmClearing(false);
+                          }
+                        }}
+                        style={{
+                          padding: '8px 16px', borderRadius: 4,
+                          background: crmConfirm.toLowerCase() === 'clear crm' ? '#D97757' : 'rgba(217,119,87,0.3)',
+                          color: crmConfirm.toLowerCase() === 'clear crm' ? '#0E1013' : 'rgba(14,16,19,0.5)',
+                          border: 'none', fontWeight: 500, fontSize: 13,
+                          cursor: crmConfirm.toLowerCase() === 'clear crm' ? 'pointer' : 'default',
+                          fontFamily: "'Inter Tight', system-ui, sans-serif",
+                          transition: 'background 0.15s, color 0.15s',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >{crmClearing ? 'Clearing...' : 'Clear all'}</button>
+                    </div>
+                    {crmError && <p style={{ color: '#D97757', fontSize: 13, marginTop: 8 }}>{crmError}</p>}
+                  </>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Replace the tiny gold "Example data" badge with a persistent inline banner visible on all CRM pages when demo data is present, with a one-click "Clear example data" button and error feedback
- Add a "Clear CRM data" section to Settings > Danger tab — type `clear crm` to confirm, server-side validated via new `POST /api/crm/clear-all` endpoint, page reloads after clearing to prevent stale views

## Test plan

- [ ] Initialize CRM Lite and verify the first-visit modal dialog still appears
- [ ] Click "Keep exploring" and confirm the gold banner appears below the nav on all CRM pages (Dashboard, Contacts, Pipeline, Tasks)
- [ ] Click "Clear example data" on the banner — data clears, banner disappears, pages show empty states
- [ ] Re-initialize CRM, dismiss dialog, then clear from Settings > Danger > Clear CRM data (type `clear crm`)
- [ ] Verify page reloads after Settings clear and CRM shows empty state
- [ ] Test on mobile — banner text and button should stack vertically
- [ ] Verify the `/api/crm/clear-all` endpoint rejects requests without the correct confirmation phrase