### PR TITLE
Fix heartbeat tool loading, error backoff, and add system logs tab

### DIFF
--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -23,7 +23,6 @@ Per-agent (chat, context, conversations):
   PATCH  /api/agents/{agent_id}/conversations/{conv_id}/title
 """
 
-import importlib
 import io
 import json as _json_mod
 import shutil
@@ -38,17 +37,7 @@ from core.auth import get_current_user, decode_access_token
 from core.providers import get_ai_provider
 from core.providers.credentials import CredentialStore
 from core.agents.tool_registry import ToolRegistry
-from core.agents.reminders.tools import (
-    create_reminder_handler,
-    list_reminders_handler,
-    cancel_reminder_handler,
-)
-from core.agents.scheduled_actions.tools import (
-    create_scheduled_action_handler,
-    list_scheduled_actions_handler,
-    update_scheduled_action_handler,
-    delete_scheduled_action_handler,
-)
+from .tool_loader import INTEGRATION_MODULES, load_integration_tools, build_agent_handlers
 from . import db as agent_db
 from .engine import (
     build_agent_config,
@@ -97,50 +86,6 @@ def _inject_pending_setup_context(context_dir: Path, pending: dict) -> None:
     (context_dir / "_pending-setup.md").write_text("\n".join(parts), encoding="utf-8")
 
 
-# ── Integration tool loader ───────────────────────────────────────────────────
-
-_INTEGRATION_MODULES = {
-    "crm_lite": ("integrations.crm_lite.tools", "CRM_LITE_TOOL_DEFS"),
-    "odoo": ("integrations.odoo.tools", "ODOO_TOOL_DEFS"),
-    "bamboohr": ("integrations.bamboohr.tools", "BAMBOOHR_TOOL_DEFS"),
-    "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
-    "qb_csv": ("integrations.qb_csv.tools", "QB_CSV_TOOL_DEFS"),
-    "paperclip": ("integrations.paperclip.tools", "PAPERCLIP_TOOL_DEFS"),
-}
-
-
-def _load_integration_tools() -> tuple[list[dict], dict]:
-    """Load tool definitions and executors from all enabled integrations."""
-    from integrations.registry import is_enabled
-
-    tool_defs: list[dict] = []
-    executors: dict = {}
-
-    for name, (module_path, defs_attr) in _INTEGRATION_MODULES.items():
-        if not is_enabled(name):
-            continue
-        try:
-            # CRM Lite needs its DB initialized before tools can run
-            if name == "crm_lite":
-                from integrations.crm_lite.db import init_db, _connection
-                if _connection is None:
-                    init_db()
-
-            # QB CSV needs its DB initialized before tools can run
-            if name == "qb_csv":
-                from integrations.qb_csv.db import init_db as init_qb_csv, _connection as qb_csv_conn
-                if qb_csv_conn is None:
-                    init_qb_csv()
-
-            mod = importlib.import_module(module_path)
-            defs = getattr(mod, defs_attr, [])
-            execs = getattr(mod, "TOOL_EXECUTORS", {})
-            tool_defs.extend({**d, "integration": name} for d in defs)
-            executors.update(execs)
-        except Exception as e:
-            logger.warning("Failed to load integration %s: %s", name, e)
-
-    return tool_defs, executors
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -151,21 +96,6 @@ def _get_agent_or_404(agent_id: str) -> dict:
         raise HTTPException(status_code=404, detail="Agent not found")
     return agent
 
-
-def _build_agent_handlers(agent_slug: str) -> tuple[dict, dict]:
-    """Build reminder and scheduled action handler dicts for an agent."""
-    reminder_handlers = {
-        "create_reminder": lambda **kw: create_reminder_handler(agent_slug, **kw),
-        "list_reminders": lambda **kw: list_reminders_handler(agent_slug, **kw),
-        "cancel_reminder": lambda **kw: cancel_reminder_handler(agent_slug, **kw),
-    }
-    sa_handlers = {
-        "create_scheduled_action": lambda **kw: create_scheduled_action_handler(agent_slug, **kw),
-        "list_scheduled_actions": lambda **kw: list_scheduled_actions_handler(agent_slug, **kw),
-        "update_scheduled_action": lambda **kw: update_scheduled_action_handler(agent_slug, **kw),
-        "delete_scheduled_action": lambda **kw: delete_scheduled_action_handler(agent_slug, **kw),
-    }
-    return reminder_handlers, sa_handlers
 
 
 def _safe_filename(filename: str) -> bool:
@@ -511,12 +441,12 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
     from integrations.registry import is_enabled as _is_enabled
     google_connected = _is_enabled("google")
 
-    integration_tool_defs, integration_executors = _load_integration_tools()
+    integration_tool_defs, integration_executors = load_integration_tools()
 
     from integrations.registry import get_tool_mode
-    integration_tool_modes = {name: get_tool_mode(name) for name in _INTEGRATION_MODULES}
+    integration_tool_modes = {name: get_tool_mode(name) for name in INTEGRATION_MODULES}
 
-    reminder_handlers, sa_handlers = _build_agent_handlers(agent["slug"])
+    reminder_handlers, sa_handlers = build_agent_handlers(agent["slug"])
     registry = ToolRegistry(
         context_dir=config.context_dir,
         gcs_prefix=config.gcs_prefix,
@@ -924,8 +854,8 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
     from integrations.registry import is_enabled as _is_enabled
     google_connected = _is_enabled("google")
 
-    integration_tool_defs, integration_executors = _load_integration_tools()
-    reminder_handlers, sa_handlers = _build_agent_handlers(agent["slug"])
+    integration_tool_defs, integration_executors = load_integration_tools()
+    reminder_handlers, sa_handlers = build_agent_handlers(agent["slug"])
 
     registry = ToolRegistry(
         context_dir=config.context_dir,

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -60,6 +60,7 @@ _PENDING_SETUP_NAMES = {
     "quickbooks": "QuickBooks Online",
     "bamboohr": "BambooHR",
     "crm_lite": "CRM",
+    "todoist": "Todoist",
 }
 
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -444,8 +444,12 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
 
     integration_tool_defs, integration_executors = load_integration_tools()
 
-    from integrations.registry import get_tool_mode
-    integration_tool_modes = {name: get_tool_mode(name) for name in INTEGRATION_MODULES}
+    from integrations.registry import get_tool_mode, get_credentials
+    integration_tool_modes = {
+        name: get_tool_mode(name)
+        for name in INTEGRATION_MODULES
+        if "tool_mode" in get_credentials(name)
+    }
 
     reminder_handlers, sa_handlers = build_agent_handlers(agent["slug"])
     registry = ToolRegistry(
@@ -512,9 +516,14 @@ async def agent_chat(agent_id: str, req: ChatRequest, user=Depends(get_current_u
         if conv and conv.get("mode") == "import":
             import_mode = True
 
+    tool_mode = req.tool_mode
+    from setup.router import load_admin_settings
+    if load_admin_settings().get("always_power_mode"):
+        tool_mode = "power"
+
     return _stream_chat(agent, req.messages, req.training_mode, req.conversation_id,
                         training_type=req.training_type, plan_mode=req.plan_mode,
-                        tool_mode=req.tool_mode, approved_tool=req.approved_tool,
+                        tool_mode=tool_mode, approved_tool=req.approved_tool,
                         import_mode=import_mode)
 
 

--- a/backend/agents/tool_loader.py
+++ b/backend/agents/tool_loader.py
@@ -28,6 +28,7 @@ INTEGRATION_MODULES = {
     "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
     "qb_csv": ("integrations.qb_csv.tools", "QB_CSV_TOOL_DEFS"),
     "paperclip": ("integrations.paperclip.tools", "PAPERCLIP_TOOL_DEFS"),
+    "todoist": ("integrations.todoist.tools", "TODOIST_TOOL_DEFS"),
 }
 
 

--- a/backend/agents/tool_loader.py
+++ b/backend/agents/tool_loader.py
@@ -1,0 +1,79 @@
+"""Chatty — Shared integration tool loading and agent handler construction.
+
+Extracted from agents/router.py so both the chat flow and the scheduled
+actions processor can build a full tool set with integration parity.
+"""
+
+import importlib
+import logging
+
+from core.agents.reminders.tools import (
+    create_reminder_handler,
+    list_reminders_handler,
+    cancel_reminder_handler,
+)
+from core.agents.scheduled_actions.tools import (
+    create_scheduled_action_handler,
+    list_scheduled_actions_handler,
+    update_scheduled_action_handler,
+    delete_scheduled_action_handler,
+)
+
+logger = logging.getLogger(__name__)
+
+INTEGRATION_MODULES = {
+    "crm_lite": ("integrations.crm_lite.tools", "CRM_LITE_TOOL_DEFS"),
+    "odoo": ("integrations.odoo.tools", "ODOO_TOOL_DEFS"),
+    "bamboohr": ("integrations.bamboohr.tools", "BAMBOOHR_TOOL_DEFS"),
+    "quickbooks": ("integrations.quickbooks.tools", "QB_TOOL_DEFS"),
+    "qb_csv": ("integrations.qb_csv.tools", "QB_CSV_TOOL_DEFS"),
+    "paperclip": ("integrations.paperclip.tools", "PAPERCLIP_TOOL_DEFS"),
+}
+
+
+def load_integration_tools() -> tuple[list[dict], dict]:
+    """Load tool definitions and executors from all enabled integrations."""
+    from integrations.registry import is_enabled
+
+    tool_defs: list[dict] = []
+    executors: dict = {}
+
+    for name, (module_path, defs_attr) in INTEGRATION_MODULES.items():
+        if not is_enabled(name):
+            continue
+        try:
+            if name == "crm_lite":
+                from integrations.crm_lite.db import init_db, _connection
+                if _connection is None:
+                    init_db()
+
+            if name == "qb_csv":
+                from integrations.qb_csv.db import init_db as init_qb_csv, _connection as qb_csv_conn
+                if qb_csv_conn is None:
+                    init_qb_csv()
+
+            mod = importlib.import_module(module_path)
+            defs = getattr(mod, defs_attr, [])
+            execs = getattr(mod, "TOOL_EXECUTORS", {})
+            tool_defs.extend({**d, "integration": name} for d in defs)
+            executors.update(execs)
+        except Exception as e:
+            logger.warning("Failed to load integration %s: %s", name, e)
+
+    return tool_defs, executors
+
+
+def build_agent_handlers(agent_slug: str) -> tuple[dict, dict]:
+    """Build reminder and scheduled action handler dicts for an agent."""
+    reminder_handlers = {
+        "create_reminder": lambda **kw: create_reminder_handler(agent_slug, **kw),
+        "list_reminders": lambda **kw: list_reminders_handler(agent_slug, **kw),
+        "cancel_reminder": lambda **kw: cancel_reminder_handler(agent_slug, **kw),
+    }
+    sa_handlers = {
+        "create_scheduled_action": lambda **kw: create_scheduled_action_handler(agent_slug, **kw),
+        "list_scheduled_actions": lambda **kw: list_scheduled_actions_handler(agent_slug, **kw),
+        "update_scheduled_action": lambda **kw: update_scheduled_action_handler(agent_slug, **kw),
+        "delete_scheduled_action": lambda **kw: delete_scheduled_action_handler(agent_slug, **kw),
+    }
+    return reminder_handlers, sa_handlers

--- a/backend/core/agents/background_runner.py
+++ b/backend/core/agents/background_runner.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from core.providers import get_ai_provider
@@ -36,6 +37,7 @@ async def _run_turn(
     max_iterations: int = 5,
     model_override: str | None = None,
     provider_override: str | None = None,
+    on_iteration: Callable[[int], bool] | None = None,
 ) -> BackgroundResult:
     """Run a single AI turn asynchronously, executing tools as needed."""
     store = CredentialStore()
@@ -65,7 +67,18 @@ async def _run_turn(
     total_input_tokens = 0
     total_output_tokens = 0
 
-    for _ in range(max_iterations):
+    for iteration in range(max_iterations):
+        if on_iteration is not None and iteration > 0:
+            if not on_iteration(iteration):
+                return BackgroundResult(
+                    text="(lease lost -- aborted)",
+                    input_tokens=total_input_tokens,
+                    output_tokens=total_output_tokens,
+                    model_used=model_used,
+                    tool_log=tool_log,
+                    error=True,
+                )
+
         tool_calls_this_turn = []
         turn_text = ""
 
@@ -144,6 +157,7 @@ async def _run_turn(
         output_tokens=total_output_tokens,
         model_used=model_used,
         tool_log=tool_log,
+        error=True,
     )
 
 
@@ -155,6 +169,7 @@ def run_background_turn(
     max_iterations: int = 5,
     model_override: str | None = None,
     provider_override: str | None = None,
+    on_iteration: Callable[[int], bool] | None = None,
 ) -> BackgroundResult:
     """Synchronous wrapper for running a background AI turn.
 
@@ -171,11 +186,13 @@ def run_background_turn(
             future = pool.submit(
                 asyncio.run,
                 _run_turn(system_prompt, user_message, tool_defs, registry,
-                          max_iterations, model_override, provider_override)
+                          max_iterations, model_override, provider_override,
+                          on_iteration)
             )
             return future.result(timeout=300)
     else:
         return asyncio.run(
             _run_turn(system_prompt, user_message, tool_defs, registry,
-                      max_iterations, model_override, provider_override)
+                      max_iterations, model_override, provider_override,
+                      on_iteration)
         )

--- a/backend/core/agents/reminders/db.py
+++ b/backend/core/agents/reminders/db.py
@@ -73,7 +73,7 @@ def _setup_connection() -> None:
             active_hours_tz TEXT NOT NULL DEFAULT 'America/Chicago',
             prompt TEXT NOT NULL DEFAULT '',
             model_override TEXT,
-            max_tool_iterations INTEGER NOT NULL DEFAULT 5,
+            max_tool_iterations INTEGER NOT NULL DEFAULT 10,
             enabled INTEGER NOT NULL DEFAULT 1,
             next_run TEXT,
             last_run TEXT,
@@ -163,6 +163,8 @@ def _setup_connection() -> None:
         _connection.execute("ALTER TABLE scheduled_actions ADD COLUMN lease_id TEXT")
     if "leased_until" not in cols:
         _connection.execute("ALTER TABLE scheduled_actions ADD COLUMN leased_until TEXT")
+    if "last_failure_alert_at" not in cols:
+        _connection.execute("ALTER TABLE scheduled_actions ADD COLUMN last_failure_alert_at TEXT")
     _connection.execute("CREATE INDEX IF NOT EXISTS idx_sa_lease ON scheduled_actions(lease_id, leased_until)")
     _connection.commit()
 

--- a/backend/core/agents/scheduled_actions/history.py
+++ b/backend/core/agents/scheduled_actions/history.py
@@ -122,6 +122,27 @@ def get_execution(execution_id: str) -> dict | None:
     return d
 
 
+def get_recent_errors(agent: str, action_id: str | None = None, limit: int = 3) -> list[dict]:
+    conn = db.get_db()
+    if action_id:
+        rows = conn.execute(
+            """SELECT started_at, status, result_summary, action_type
+               FROM execution_history
+               WHERE agent = ? AND action_id = ? AND status = 'error'
+               ORDER BY started_at DESC LIMIT ?""",
+            (agent, action_id, limit),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """SELECT started_at, status, result_summary, action_type
+               FROM execution_history
+               WHERE agent = ? AND status = 'error'
+               ORDER BY started_at DESC LIMIT ?""",
+            (agent, limit),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
 def cleanup_old(retention_days: int = 7) -> int:
     conn = db.get_db()
     cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).strftime(

--- a/backend/core/agents/scheduled_actions/notifications.py
+++ b/backend/core/agents/scheduled_actions/notifications.py
@@ -2,11 +2,18 @@
 
 Creates in-app alerts for every action_taken heartbeat result.
 Optionally sends external notifications via Telegram or WhatsApp.
+Failure alerts fire when consecutive errors hit a threshold.
 """
 
 import logging
+from datetime import datetime, timezone
+
+from core.agents.reminders import db
 
 logger = logging.getLogger(__name__)
+
+FAILURE_ALERT_THRESHOLD = 3
+_FAILURE_ALERT_COOLDOWN_SECONDS = 3600
 
 
 def evaluate_and_notify(
@@ -79,6 +86,52 @@ def _try_telegram(agent_slug: str, message: str) -> bool:
     except Exception as e:
         logger.debug("Telegram notification skipped for %s: %s", agent_slug, e)
         return False
+
+
+def evaluate_failure_alert(
+    action: dict,
+    consecutive_errors: int,
+    last_error: str,
+    agent_slug: str,
+) -> bool:
+    """Create in-app alert when consecutive errors hit threshold. 1-hour cooldown."""
+    if consecutive_errors < FAILURE_ALERT_THRESHOLD:
+        return False
+
+    last_alert = action.get("last_failure_alert_at")
+    if last_alert:
+        try:
+            alert_dt = datetime.fromisoformat(last_alert).replace(tzinfo=timezone.utc)
+            if (datetime.now(timezone.utc) - alert_dt).total_seconds() < _FAILURE_ALERT_COOLDOWN_SECONDS:
+                return False
+        except (ValueError, TypeError):
+            pass
+
+    action_name = action.get("name") or action.get("action_type", "unknown")
+
+    from core.agents.alerts.service import create_alert
+    create_alert(
+        agent=agent_slug,
+        title=f"Repeated failures: {action_name}",
+        message=f"Failed {consecutive_errors} times. Last error: {last_error[:300]}",
+        source="heartbeat_failure",
+        source_id=action["id"],
+    )
+
+    conn = db.get_db()
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    with db.write_lock():
+        conn.execute(
+            "UPDATE scheduled_actions SET last_failure_alert_at = ? WHERE id = ?",
+            (now, action["id"]),
+        )
+        conn.commit()
+
+    if action.get("notify_on_action"):
+        _send_external(agent_slug, action, f"Action '{action_name}' has failed {consecutive_errors} times. Last: {last_error[:200]}")
+
+    logger.info("Failure alert sent for %s/%s (%d errors)", agent_slug, action["id"][:8], consecutive_errors)
+    return True
 
 
 def _try_whatsapp(agent_slug: str, message: str) -> bool:

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -11,6 +11,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from core.agents.background_runner import run_background_turn
@@ -23,6 +24,12 @@ logger = logging.getLogger(__name__)
 
 _MAX_WORKERS = int(os.environ.get("SCHEDULED_ACTION_WORKERS", "4"))
 _executor = ThreadPoolExecutor(max_workers=_MAX_WORKERS, thread_name_prefix="heartbeat")
+
+_AGENT_TURN_ERRORS = frozenset({
+    "(lease lost -- aborted)",
+    "(no response)",
+    "(max iterations reached)",
+})
 
 # -- In-flight tracking --------------------------------------------------
 _in_flight_count = 0
@@ -90,8 +97,8 @@ def process_due_actions() -> None:
     for action in claimed:
         lease_id = action.get("lease_id")
 
-        if action.get("consecutive_errors", 0) >= 5:
-            service.mark_executed(action["id"], "error", "auto-disabled: consecutive_errors >= 5", 0, lease_id=lease_id)
+        if action.get("consecutive_errors", 0) >= service.AUTO_DISABLE_THRESHOLD:
+            _mark_and_alert(action, "error", f"auto-disabled: consecutive_errors >= {service.AUTO_DISABLE_THRESHOLD}", 0, lease_id=lease_id, agent_slug=action["agent"])
             continue
 
         if not action.get("always_on") and not _in_active_hours(action):
@@ -113,6 +120,8 @@ def process_due_actions() -> None:
             len(claimed), submitted, _MAX_WORKERS - _get_available_capacity(), _MAX_WORKERS,
         )
 
+
+# -- Helpers ---------------------------------------------------------------
 
 def _in_active_hours(action: dict) -> bool:
     tz_name = action.get("active_hours_tz", "America/Chicago")
@@ -142,6 +151,103 @@ def _in_active_hours(action: dict) -> bool:
         return current_minutes >= start_minutes or current_minutes < end_minutes
 
 
+def _build_tools(agent_slug: str, agent: dict) -> tuple[list[dict], ToolRegistry]:
+    """Build full tool definitions and registry with integration parity."""
+    from agents.tool_loader import load_integration_tools, build_agent_handlers, INTEGRATION_MODULES
+    from agents.engine import build_agent_config
+    from integrations.registry import is_enabled as _is_enabled, get_tool_mode
+    from integrations.google.policy import google_capabilities
+    from core.agents.tools.real_tools import load_all_real_tools
+
+    config = build_agent_config(agent)
+    google_connected = _is_enabled("google")
+    integration_tool_defs, integration_executors = load_integration_tools()
+    google_caps = google_capabilities()
+    reminder_handlers, sa_handlers = build_agent_handlers(agent_slug)
+
+    real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
+    dynamic_real_tools = load_all_real_tools(real_tools_dir)
+
+    tool_defs = get_tool_definitions(
+        integration_tools=integration_tool_defs,
+        dynamic_real_tools=dynamic_real_tools or None,
+        web_enabled=True,
+        **google_caps,
+    )
+
+    integration_modes = {name: get_tool_mode(name) for name in INTEGRATION_MODULES}
+    tool_defs = [
+        t for t in tool_defs
+        if not (t.get("integration") and t.get("writes")
+                and integration_modes.get(t["integration"]) == "read-only")
+    ]
+
+    registry = ToolRegistry(
+        context_dir=config.context_dir,
+        gcs_prefix=config.gcs_prefix,
+        google_connected=google_connected,
+        integration_executors=integration_executors,
+        agent_slug=agent_slug,
+        agent_name=config.agent_name,
+        reminder_handlers=reminder_handlers,
+        scheduled_action_handlers=sa_handlers,
+    )
+
+    return tool_defs, registry
+
+
+def _make_lease_renewer(action_id: str, lease_id: str | None):
+    if not lease_id:
+        return None
+    def _renew(_iteration: int) -> bool:
+        return service.renew_lease(action_id, lease_id)
+    return _renew
+
+
+def _mark_and_alert(action, status, result, duration_ms, input_tokens=0, output_tokens=0, lease_id=None, agent_slug=""):
+    """Wrapper: mark_executed + failure alert evaluation (lock-safe)."""
+    completed = service.mark_executed(
+        action["id"], status, result, duration_ms, input_tokens, output_tokens, lease_id=lease_id,
+    )
+    if completed and status == "error":
+        old_errors = action.get("consecutive_errors", 0)
+        new_errors = old_errors + 1
+        if new_errors >= notifications.FAILURE_ALERT_THRESHOLD:
+            try:
+                notifications.evaluate_failure_alert(action, new_errors, result, agent_slug)
+            except Exception as e:
+                logger.debug("Failure alert check failed: %s", e)
+    return completed
+
+
+def _build_error_context(action: dict, agent_slug: str) -> str:
+    """Build error context for heartbeat system prompt based on consecutive errors."""
+    consecutive_errors = action.get("consecutive_errors", 0)
+    if consecutive_errors == 0:
+        return ""
+
+    last_result = action.get("last_result", "")
+    if consecutive_errors >= 3:
+        recent_errors = history.get_recent_errors(agent_slug, action_id=action["id"], limit=3)
+        error_lines = []
+        for err in recent_errors:
+            error_lines.append(f"  - [{err['started_at']}] {err.get('result_summary', '')[:200]}")
+        return (
+            f"\n\n## Recent Failures\n\n"
+            f"This check has failed {consecutive_errors} times consecutively. "
+            f"Diagnose the root cause rather than retrying the same approach.\n\n"
+            f"Recent errors:\n" + "\n".join(error_lines) + "\n"
+        )
+    else:
+        return (
+            f"\n\n## Note\n\n"
+            f"This check failed {consecutive_errors} time(s) recently. "
+            f"Last error: {last_result[:200]}\n"
+        )
+
+
+# -- Action processors -----------------------------------------------------
+
 def _process_action_safe(action: dict) -> None:
     """Worker entry point: renew lease, run action, track in-flight state."""
     agent_name = action["agent"]
@@ -157,7 +263,7 @@ def _process_action_safe(action: dict) -> None:
         _process_action(action)
     except Exception as e:
         logger.error("Action %s/%s failed: %s", agent_name, action["id"][:8], e)
-        completed = service.mark_executed(action["id"], "error", f"unhandled: {e}", 0, lease_id=lease_id)
+        completed = _mark_and_alert(action, "error", f"unhandled: {e}", 0, lease_id=lease_id, agent_slug=agent_name)
         if not completed:
             logger.warning("Lease expired for %s/%s — error result discarded", agent_name, action["id"][:8])
     finally:
@@ -172,7 +278,7 @@ def _process_action(action: dict) -> None:
     elif action_type == "cron":
         _process_cron(action)
     else:
-        service.mark_executed(action["id"], "skipped", f"unknown action_type: {action_type}", 0, lease_id=action.get("lease_id"))
+        _mark_and_alert(action, "skipped", f"unknown action_type: {action_type}", 0, lease_id=action.get("lease_id"), agent_slug=action["agent"])
 
 
 def _resolve_agent(agent_slug: str) -> dict | None:
@@ -192,13 +298,12 @@ def _process_heartbeat(action: dict) -> None:
 
     agent = _resolve_agent(agent_slug)
     if not agent:
-        service.mark_executed(action["id"], "error", f"Agent '{agent_slug}' not found", 0, lease_id=lease_id)
+        _mark_and_alert(action, "error", f"Agent '{agent_slug}' not found", 0, lease_id=lease_id, agent_slug=agent_slug)
         return
 
-    from agents.engine import get_context_manager, DATA_DIR
+    from agents.engine import get_context_manager
     ctx_manager = get_context_manager(agent["slug"])
 
-    # Read HEARTBEAT.md
     heartbeat_path = ctx_manager.data_dir / "HEARTBEAT.md"
     checklist = ""
     if heartbeat_path.exists():
@@ -208,7 +313,7 @@ def _process_heartbeat(action: dict) -> None:
             logger.warning("Failed to read HEARTBEAT.md for %s: %s", agent_slug, e)
 
     if not checklist or _is_effectively_empty(checklist):
-        service.mark_executed(action["id"], "skipped", "no checklist content", 0, lease_id=lease_id)
+        _mark_and_alert(action, "skipped", "no checklist content", 0, lease_id=lease_id, agent_slug=agent_slug)
         return
 
     execution_id = None
@@ -230,15 +335,11 @@ def _process_heartbeat(action: dict) -> None:
     context = ctx_manager.load_all_context()
     context_snippet = context[:30000] if context else "(no context files)"
 
-    tool_defs = get_tool_definitions(web_enabled=True)
-    registry = ToolRegistry(
-        context_dir=str(DATA_DIR / agent["slug"] / "context"),
-        agent_slug=agent["slug"],
-    )
+    tool_defs, registry = _build_tools(agent_slug, agent)
+    on_iteration = _make_lease_renewer(action["id"], lease_id)
 
     start_time = time.monotonic()
     try:
-        # Optional triage pass
         triage_data = None
         if action.get("triage_enabled", 1):
             triage_result = run_background_turn(
@@ -257,34 +358,68 @@ def _process_heartbeat(action: dict) -> None:
                 max_iterations=2,
                 provider_override=provider_override,
                 model_override=model_override,
+                on_iteration=on_iteration,
             )
-            triage_data = {
-                "result": "NEEDS_ACTION" if "NEEDS_ACTION" in triage_result.text.upper() else "ALL_CLEAR",
-                "model": triage_result.model_used,
-                "input_tokens": triage_result.input_tokens,
-                "output_tokens": triage_result.output_tokens,
-            }
-            if not triage_result.error and "NEEDS_ACTION" not in triage_result.text.upper():
+
+            if triage_result.error or triage_result.text in _AGENT_TURN_ERRORS:
                 duration_ms = int((time.monotonic() - start_time) * 1000)
-                completed = service.mark_executed(
-                    action["id"], "ok", "Triage: all clear", duration_ms,
-                    triage_result.input_tokens, triage_result.output_tokens, lease_id=lease_id,
+                completed = _mark_and_alert(
+                    action, "error", f"triage failed: {triage_result.text[:200]}", duration_ms,
+                    input_tokens=triage_result.input_tokens, output_tokens=triage_result.output_tokens,
+                    lease_id=lease_id, agent_slug=agent_slug,
                 )
-                if completed and execution_id:
+                if execution_id:
                     history.record_complete(
-                        execution_id, status="ok",
-                        result_summary="Triage: all clear",
-                        result_full="Triage returned ALL_CLEAR — skipping full check.",
-                        tool_calls=[{"triage": triage_data}],
+                        execution_id, status="error" if completed else "lease_lost",
+                        result_summary=f"triage failed: {triage_result.text[:200]}",
+                        result_full=triage_result.text,
                         model_used=triage_result.model_used,
                         input_tokens=triage_result.input_tokens,
                         output_tokens=triage_result.output_tokens,
                         duration_ms=duration_ms,
                     )
-                logger.info("Heartbeat %s: triage ALL_CLEAR (%dms)", agent_slug, duration_ms)
+                logger.warning("Heartbeat %s: triage error — aborting (%dms)", agent_slug, duration_ms)
                 return
+            else:
+                triage_data = {
+                    "result": "NEEDS_ACTION" if "NEEDS_ACTION" in triage_result.text.upper() else "ALL_CLEAR",
+                    "model": triage_result.model_used,
+                    "input_tokens": triage_result.input_tokens,
+                    "output_tokens": triage_result.output_tokens,
+                }
+                if "NEEDS_ACTION" not in triage_result.text.upper():
+                    duration_ms = int((time.monotonic() - start_time) * 1000)
+                    completed = _mark_and_alert(
+                        action, "ok", "Triage: all clear", duration_ms,
+                        triage_result.input_tokens, triage_result.output_tokens,
+                        lease_id=lease_id, agent_slug=agent_slug,
+                    )
+                    if completed and execution_id:
+                        history.record_complete(
+                            execution_id, status="ok",
+                            result_summary="Triage: all clear",
+                            result_full="Triage returned ALL_CLEAR — skipping full check.",
+                            tool_calls=[{"triage": triage_data}],
+                            model_used=triage_result.model_used,
+                            input_tokens=triage_result.input_tokens,
+                            output_tokens=triage_result.output_tokens,
+                            duration_ms=duration_ms,
+                        )
+                    logger.info("Heartbeat %s: triage ALL_CLEAR (%dms)", agent_slug, duration_ms)
+                    return
 
-        # Full execution
+        if lease_id and not service.renew_lease(action["id"], lease_id):
+            logger.warning("Heartbeat %s: lease lost before full execution", agent_slug)
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="lease_lost",
+                    result_summary="Lease lost between triage and full execution",
+                    duration_ms=int((time.monotonic() - start_time) * 1000),
+                )
+            return
+
+        error_context = _build_error_context(action, agent_slug)
+
         system_prompt = (
             f"You are {agent['agent_name']}.\n\n"
             f"# Heartbeat Check — {now_str}\n\n"
@@ -296,6 +431,7 @@ def _process_heartbeat(action: dict) -> None:
             f"- If everything is normal and no action is needed, respond with exactly: HEARTBEAT_OK\n"
             f"- If something needs attention, take action and respond with: ACTION_TAKEN: <brief description>\n"
             f"- Be concise. This is an automated check, not a conversation.\n"
+            f"{error_context}"
         )
 
         result = run_background_turn(
@@ -303,14 +439,14 @@ def _process_heartbeat(action: dict) -> None:
             user_message="Perform your heartbeat check now.",
             tool_defs=tool_defs,
             registry=registry,
-            max_iterations=action.get("max_tool_iterations", 5),
+            max_iterations=action.get("max_tool_iterations", 10),
             provider_override=provider_override,
             model_override=model_override,
+            on_iteration=on_iteration,
         )
         duration_ms = int((time.monotonic() - start_time) * 1000)
 
-        # Classification
-        if result.error:
+        if result.error or result.text in _AGENT_TURN_ERRORS:
             status = "error"
         elif "HEARTBEAT_OK" in result.text.upper():
             status = "ok"
@@ -323,12 +459,19 @@ def _process_heartbeat(action: dict) -> None:
         total_out = result.output_tokens + (triage_data["output_tokens"] if triage_data else 0)
         full_tool_log = ([{"triage": triage_data}] if triage_data else []) + result.tool_log
 
-        completed = service.mark_executed(
-            action["id"], status, result.text[:2000], duration_ms, total_inp, total_out, lease_id=lease_id,
+        completed = _mark_and_alert(
+            action, status, result.text[:2000], duration_ms, total_inp, total_out,
+            lease_id=lease_id, agent_slug=agent_slug,
         )
 
         if not completed:
             logger.warning("Heartbeat %s: lease lost — discarding result", agent_slug)
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="lease_lost",
+                    result_summary="Lease lost before result could be recorded",
+                    duration_ms=duration_ms,
+                )
             return
 
         notified = notifications.evaluate_and_notify(action, status, result.text[:300], agent_slug)
@@ -350,7 +493,7 @@ def _process_heartbeat(action: dict) -> None:
     except Exception as e:
         duration_ms = int((time.monotonic() - start_time) * 1000)
         logger.error("Heartbeat %s failed: %s", agent_slug, e)
-        service.mark_executed(action["id"], "error", str(e)[:2000], duration_ms, lease_id=lease_id)
+        _mark_and_alert(action, "error", str(e)[:2000], duration_ms, lease_id=lease_id, agent_slug=agent_slug)
         if execution_id:
             history.record_complete(execution_id, status="error", result_summary=str(e)[:500], result_full=str(e), duration_ms=duration_ms)
 
@@ -361,12 +504,12 @@ def _process_cron(action: dict) -> None:
     lease_id = action.get("lease_id")
     prompt = action.get("prompt", "")
     if not prompt:
-        service.mark_executed(action["id"], "skipped", "no prompt configured", 0, lease_id=lease_id)
+        _mark_and_alert(action, "skipped", "no prompt configured", 0, lease_id=lease_id, agent_slug=agent_slug)
         return
 
     agent = _resolve_agent(agent_slug)
     if not agent:
-        service.mark_executed(action["id"], "error", f"Agent '{agent_slug}' not found", 0, lease_id=lease_id)
+        _mark_and_alert(action, "error", f"Agent '{agent_slug}' not found", 0, lease_id=lease_id, agent_slug=agent_slug)
         return
 
     execution_id = None
@@ -375,7 +518,7 @@ def _process_cron(action: dict) -> None:
     except Exception as e:
         logger.error("Failed to record cron start for %s: %s", agent_slug, e)
 
-    from agents.engine import get_context_manager, DATA_DIR
+    from agents.engine import get_context_manager
     ctx_manager = get_context_manager(agent["slug"])
     context = ctx_manager.load_all_context()
     context_snippet = context[:30000] if context else "(no context files)"
@@ -391,11 +534,8 @@ def _process_cron(action: dict) -> None:
         f"Take appropriate action using your tools. Be concise."
     )
 
-    tool_defs = get_tool_definitions(web_enabled=True)
-    registry = ToolRegistry(
-        context_dir=str(DATA_DIR / agent["slug"] / "context"),
-        agent_slug=agent["slug"],
-    )
+    tool_defs, registry = _build_tools(agent_slug, agent)
+    on_iteration = _make_lease_renewer(action["id"], lease_id)
 
     start_time = time.monotonic()
     try:
@@ -404,17 +544,34 @@ def _process_cron(action: dict) -> None:
             user_message=f"Execute scheduled action: {action.get('name', prompt[:100])}",
             tool_defs=tool_defs,
             registry=registry,
-            max_iterations=action.get("max_tool_iterations", 5),
+            max_iterations=action.get("max_tool_iterations", 10),
             provider_override=provider_override,
             model_override=model_override,
+            on_iteration=on_iteration,
         )
         duration_ms = int((time.monotonic() - start_time) * 1000)
 
-        status = "error" if result.error else "ok"
-        completed = service.mark_executed(
-            action["id"], status, result.text[:2000], duration_ms,
-            result.input_tokens, result.output_tokens, lease_id=lease_id,
+        if result.error or result.text in _AGENT_TURN_ERRORS:
+            status = "error"
+        else:
+            status = "ok"
+
+        completed = _mark_and_alert(
+            action, status, result.text[:2000], duration_ms,
+            result.input_tokens, result.output_tokens,
+            lease_id=lease_id, agent_slug=agent_slug,
         )
+
+        if not completed:
+            logger.warning("Cron %s: lease lost — discarding result", agent_slug)
+            if execution_id:
+                history.record_complete(
+                    execution_id, status="lease_lost",
+                    result_summary="Lease lost before result could be recorded",
+                    duration_ms=duration_ms,
+                )
+            return
+
         if completed and execution_id:
             history.record_complete(
                 execution_id, status=status,
@@ -430,7 +587,7 @@ def _process_cron(action: dict) -> None:
     except Exception as e:
         duration_ms = int((time.monotonic() - start_time) * 1000)
         logger.error("Cron %s failed: %s", agent_slug, e)
-        service.mark_executed(action["id"], "error", str(e)[:2000], duration_ms, lease_id=lease_id)
+        _mark_and_alert(action, "error", str(e)[:2000], duration_ms, lease_id=lease_id, agent_slug=agent_slug)
         if execution_id:
             history.record_complete(execution_id, status="error", result_summary=str(e)[:500], result_full=str(e), duration_ms=duration_ms)
 
@@ -484,7 +641,7 @@ def run_action_now_with_tracking(action_id: str) -> dict | None:
     except Exception:
         if action:
             lease_id = action.get("lease_id")
-            completed = service.mark_executed(action["id"], "error", "manual run failed", 0, lease_id=lease_id)
+            completed = _mark_and_alert(action, "error", "manual run failed", 0, lease_id=lease_id, agent_slug=agent_name)
             if not completed and lease_id:
                 service.release_lease(action["id"], lease_id)
         raise

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -101,7 +101,7 @@ def process_due_actions() -> None:
             _mark_and_alert(action, "error", f"auto-disabled: consecutive_errors >= {service.AUTO_DISABLE_THRESHOLD}", 0, lease_id=lease_id, agent_slug=action["agent"])
             continue
 
-        if not action.get("always_on") and not _in_active_hours(action):
+        if not _within_active_hours(action):
             service.release_lease(action["id"], lease_id, advance_next_run=True)
             continue
 
@@ -123,23 +123,27 @@ def process_due_actions() -> None:
 
 # -- Helpers ---------------------------------------------------------------
 
-def _in_active_hours(action: dict) -> bool:
-    tz_name = action.get("active_hours_tz", "America/Chicago")
+def _within_active_hours(action: dict) -> bool:
+    if action.get("always_on"):
+        return True
+
+    start_str = action.get("active_hours_start")
+    end_str = action.get("active_hours_end")
+    if not start_str or not end_str:
+        return True
+
+    tz_name = action.get("active_hours_tz") or "America/Chicago"
     try:
         tz = ZoneInfo(tz_name)
     except Exception:
-        tz = ZoneInfo("America/Chicago")
+        return True
 
     now = datetime.now(tz)
-    start_str = action.get("active_hours_start", "06:00")
-    end_str = action.get("active_hours_end", "20:00")
-
     try:
         start_h, start_m = map(int, str(start_str).split(":"))
         end_h, end_m = map(int, str(end_str).split(":"))
     except (ValueError, TypeError):
-        start_h, start_m = 6, 0
-        end_h, end_m = 20, 0
+        return True
 
     current_minutes = now.hour * 60 + now.minute
     start_minutes = start_h * 60 + start_m

--- a/backend/core/agents/scheduled_actions/router.py
+++ b/backend/core/agents/scheduled_actions/router.py
@@ -29,6 +29,23 @@ class UpdateActionRequest(BaseModel):
 
 # -- Static routes (must come before /{agent_slug} to avoid capture) ------
 
+_VALID_LOG_STATUSES = {"ok", "error", "action_taken", "skipped", "running", "lease_lost"}
+
+
+@router.get("/logs")
+async def get_system_logs(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    status: str | None = None,
+    user=Depends(get_current_user),
+):
+    if status and status not in _VALID_LOG_STATUSES:
+        raise HTTPException(status_code=400, detail=f"Invalid status filter: {status}")
+    from . import history
+    records = history.get_history(limit=limit, offset=offset, status_filter=status)
+    return {"logs": records}
+
+
 @router.get("/dashboard")
 async def get_dashboard(user=Depends(get_current_user)):
     actions = service.list_actions()

--- a/backend/core/agents/scheduled_actions/service.py
+++ b/backend/core/agents/scheduled_actions/service.py
@@ -18,6 +18,15 @@ MAX_INTERVAL_MINUTES = 1440
 MAX_TOOL_ITERATIONS_CAP = 10
 DEFAULT_INTERVAL_MINUTES = 30
 _DEFAULT_LEASE_MINUTES = 15
+AUTO_DISABLE_THRESHOLD = 10
+_ERROR_BACKOFF_SECONDS = [30, 60, 300, 900, 3600]
+
+
+def _error_backoff_seconds(consecutive_errors: int) -> int:
+    if consecutive_errors <= 0:
+        return 0
+    idx = min(consecutive_errors - 1, len(_ERROR_BACKOFF_SECONDS) - 1)
+    return _ERROR_BACKOFF_SECONDS[idx]
 
 
 def _normalize_hour(value, default: str = "06:00") -> str:
@@ -103,7 +112,7 @@ def create_action(
     active_hours_tz: str = "America/Chicago",
     prompt: str = "",
     model_override: str | None = None,
-    max_tool_iterations: int = 5,
+    max_tool_iterations: int = 10,
     enabled: bool = True,
     always_on: bool = False,
     created_by_email: str = "user",
@@ -256,7 +265,7 @@ def update_action(action_id: str, **fields) -> dict:
         for bool_field in ("enabled", "triage_enabled", "notify_on_action", "always_on"):
             if bool_field in updates:
                 updates[bool_field] = 1 if updates[bool_field] else 0
-        if "enabled" in updates and updates["enabled"] == 1 and action.get("consecutive_errors", 0) >= 5:
+        if "enabled" in updates and updates["enabled"] == 1 and action.get("consecutive_errors", 0) >= AUTO_DISABLE_THRESHOLD:
             updates["consecutive_errors"] = 0
 
         updates["updated_at"] = _now_utc()
@@ -432,16 +441,57 @@ def renew_lease(action_id: str, lease_id: str, extra_minutes: int = 15) -> bool:
 
 
 def release_expired_leases() -> int:
-    """Clear leases that have expired (process died mid-execution)."""
+    """Clear leases that have expired (process died mid-execution).
+
+    Treats each expired lease as an execution failure so consecutive_errors
+    increments and backoff applies. Uses ``require_expired_before`` to
+    prevent racing with lease renewal.
+    """
+    from . import history
+
     conn = db.get_db()
     now = _now_utc()
-    with db.write_lock():
-        cursor = conn.execute(
-            "UPDATE scheduled_actions SET lease_id = NULL, leased_until = NULL WHERE lease_id IS NOT NULL AND leased_until <= ?",
-            (now,),
+    expired_rows = conn.execute(
+        "SELECT id, lease_id FROM scheduled_actions WHERE lease_id IS NOT NULL AND leased_until <= ?",
+        (now,),
+    ).fetchall()
+    if not expired_rows:
+        return 0
+
+    count = 0
+    for row in expired_rows:
+        action_row = conn.execute("SELECT * FROM scheduled_actions WHERE id = ?", (row["id"],)).fetchone()
+        action = dict(action_row) if action_row else None
+        completed = mark_executed(
+            row["id"], "error", "stuck run: lease expired", 0,
+            lease_id=row["lease_id"], require_expired_before=now,
         )
-        conn.commit()
-        return cursor.rowcount
+        if not completed:
+            continue
+        count += 1
+
+        if action:
+            old_errors = action.get("consecutive_errors", 0)
+            new_errors = old_errors + 1
+            from . import notifications
+            if new_errors >= notifications.FAILURE_ALERT_THRESHOLD:
+                try:
+                    notifications.evaluate_failure_alert(
+                        action, new_errors, "stuck run: lease expired", action.get("agent", ""),
+                    )
+                except Exception as e:
+                    logger.debug("Failure alert for expired lease failed: %s", e)
+
+        stale = conn.execute(
+            "SELECT id FROM execution_history WHERE action_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1",
+            (row["id"],),
+        ).fetchone()
+        if stale:
+            history.record_complete(
+                stale["id"], status="lease_lost",
+                result_summary="Process died: lease expired",
+            )
+    return count
 
 
 def mark_executed(
@@ -452,10 +502,13 @@ def mark_executed(
     input_tokens: int = 0,
     output_tokens: int = 0,
     lease_id: str | None = None,
+    require_expired_before: str | None = None,
 ) -> bool:
     """Mark an action as executed and schedule its next run.
 
     Returns True if completed, False if lease mismatch (stale worker).
+    ``require_expired_before`` adds an extra ``leased_until <= ?`` guard so
+    the sweeper cannot mark a renewed lease as expired (race-safe).
     """
     conn = db.get_db()
     now = _now_utc()
@@ -468,6 +521,8 @@ def mark_executed(
         if lease_id is not None:
             if row["lease_id"] != lease_id:
                 logger.warning("Lease mismatch for %s: expected %s, got %s", action_id, row["lease_id"], lease_id)
+                return False
+            if require_expired_before and row["leased_until"] and row["leased_until"] > require_expired_before:
                 return False
         elif row["lease_id"] is not None:
             logger.warning("Unleased caller for %s but row has lease %s", action_id, row["lease_id"])
@@ -482,14 +537,21 @@ def mark_executed(
         else:
             consecutive_errors = 0
 
-        next_run = compute_next_run(action)
+        natural_next = compute_next_run(action)
+
+        if status == "error" and consecutive_errors > 0 and natural_next and action["schedule_type"] != "once":
+            backoff_s = _error_backoff_seconds(consecutive_errors)
+            backoff_time = (datetime.now(timezone.utc) + timedelta(seconds=backoff_s)).strftime("%Y-%m-%dT%H:%M:%S")
+            next_run = max(natural_next, backoff_time)
+        else:
+            next_run = natural_next
 
         enabled = action["enabled"]
         if action["schedule_type"] == "once":
             enabled = 0
             next_run = None
 
-        if consecutive_errors >= 5:
+        if consecutive_errors >= AUTO_DISABLE_THRESHOLD:
             enabled = 0
             logger.warning("Action %s auto-disabled after %d consecutive errors", action_id, consecutive_errors)
 

--- a/backend/core/agents/scheduled_actions/service.py
+++ b/backend/core/agents/scheduled_actions/service.py
@@ -614,6 +614,7 @@ def ensure_default_actions(agent_slug: str) -> None:
 def ensure_default_actions_all() -> None:
     """Ensure all onboarded agents have default actions. Called by sweeper/startup."""
     try:
+        _run_one_time_migrations()
         from agents.db import list_agents
         agents = list_agents()
         for agent in agents:
@@ -621,6 +622,48 @@ def ensure_default_actions_all() -> None:
                 ensure_default_actions(agent["slug"])
     except Exception as e:
         logger.debug("ensure_default_actions_all: %s", e)
+
+
+_MIGRATION_V2_DONE = False
+
+
+def _run_one_time_migrations() -> None:
+    """One-time fixups for existing deployments after the heartbeat overhaul.
+
+    - Re-enables actions that were auto-disabled under the old 5-error threshold
+    - Resets consecutive_errors so they get a fresh start with working tools
+    - Bumps max_tool_iterations from 5 to 10 for actions still at the old default
+    """
+    global _MIGRATION_V2_DONE
+    if _MIGRATION_V2_DONE:
+        return
+    _MIGRATION_V2_DONE = True
+
+    conn = db.get_db()
+    now = _now_utc()
+
+    with db.write_lock():
+        re_enabled = conn.execute(
+            """UPDATE scheduled_actions SET
+               enabled = 1, consecutive_errors = 0, updated_at = ?
+               WHERE enabled = 0 AND consecutive_errors >= 5 AND consecutive_errors < ?""",
+            (now, AUTO_DISABLE_THRESHOLD),
+        ).rowcount
+
+        bumped = conn.execute(
+            """UPDATE scheduled_actions SET
+               max_tool_iterations = 10, updated_at = ?
+               WHERE max_tool_iterations = 5""",
+            (now,),
+        ).rowcount
+
+        if re_enabled or bumped:
+            conn.commit()
+            logger.info(
+                "One-time migration: re-enabled %d actions (old threshold), "
+                "bumped max_tool_iterations on %d actions",
+                re_enabled, bumped,
+            )
 
 
 def get_heartbeat_stats() -> dict:

--- a/backend/core/agents/scheduled_actions/sweeper.py
+++ b/backend/core/agents/scheduled_actions/sweeper.py
@@ -46,6 +46,8 @@ def _cleanup_context_usage(retention_days: int = 90) -> int:
 
 
 def _fix_next_run_drift() -> int:
+    from core.agents.scheduled_actions import service
+
     conn = db.get_db()
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
@@ -68,6 +70,32 @@ def _fix_next_run_drift() -> int:
                 (new_next, now, row["id"]),
             )
             fixed += 1
+            logger.info("Sweeper: reset drifted next_run for interval action %s", row["id"][:8])
+
+        if fixed:
+            conn.commit()
+
+        cron_rows = conn.execute(
+            """SELECT * FROM scheduled_actions
+               WHERE enabled = 1 AND next_run IS NOT NULL AND next_run < ?
+               AND schedule_type = 'cron'
+               AND (lease_id IS NULL OR leased_until <= ?)""",
+            (cutoff, now),
+        ).fetchall()
+
+        for row in cron_rows:
+            try:
+                action = dict(row)
+                new_next = service.compute_next_run(action)
+                if new_next:
+                    conn.execute(
+                        "UPDATE scheduled_actions SET next_run = ?, updated_at = ? WHERE id = ?",
+                        (new_next, now, row["id"]),
+                    )
+                    fixed += 1
+                    logger.info("Sweeper: reset drifted next_run for cron action %s", row["id"][:8])
+            except Exception as e:
+                logger.warning("Sweeper: failed to fix cron drift for %s: %s", row["id"][:8], e)
 
         if fixed:
             conn.commit()

--- a/frontend/src/dashboard/LogsTab.tsx
+++ b/frontend/src/dashboard/LogsTab.tsx
@@ -1,0 +1,216 @@
+import { useState, useEffect, useRef } from 'react';
+import { api } from '../core/api/client';
+
+interface LogRecord {
+  id: string;
+  agent: string;
+  action_type: string;
+  started_at: string;
+  completed_at: string | null;
+  status: string;
+  result_summary: string | null;
+  result_full: string | null;
+  tool_calls: { tool: string; args: string; result: string; duration_ms: number }[] | null;
+  model_used: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  duration_ms: number;
+}
+
+type StatusFilter = 'all' | 'ok' | 'error' | 'action_taken';
+
+const STATUS_COLORS: Record<string, string> = {
+  ok: '#8EA589',
+  action_taken: '#D4A85A',
+  error: '#D97757',
+  lease_lost: '#D97757',
+  skipped: '#6B7280',
+  running: '#60A5FA',
+};
+
+function formatTime(iso: string): string {
+  const d = new Date(iso + 'Z');
+  return d.toLocaleString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  });
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return String(n);
+}
+
+export function LogsTab() {
+  const [logs, setLogs] = useState<LogRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<StatusFilter>('all');
+  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<number | null>(null);
+
+  async function fetchLogs(statusFilter: StatusFilter) {
+    try {
+      setError(null);
+      const params = statusFilter !== 'all' ? `?status=${statusFilter}` : '';
+      const result = await api<{ logs: LogRecord[] }>(`/api/scheduled-actions/logs${params}`);
+      setLogs(result.logs);
+    } catch {
+      setError('Failed to load logs.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    setLoading(true);
+    fetchLogs(filter);
+  }, [filter]);
+
+  useEffect(() => {
+    if (autoRefresh) {
+      intervalRef.current = window.setInterval(() => fetchLogs(filter), 30000);
+    }
+    return () => {
+      if (intervalRef.current) window.clearInterval(intervalRef.current);
+    };
+  }, [autoRefresh, filter]);
+
+  const filters: { id: StatusFilter; label: string }[] = [
+    { id: 'all', label: 'All' },
+    { id: 'ok', label: 'OK' },
+    { id: 'action_taken', label: 'Activity' },
+    { id: 'error', label: 'Errors' },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1">
+          {filters.map(f => (
+            <button
+              key={f.id}
+              onClick={() => setFilter(f.id)}
+              className={`px-3 py-1.5 text-xs rounded-md transition-colors ${
+                filter === f.id
+                  ? 'bg-ch-accent/20 text-ch-accent font-medium'
+                  : 'text-ch-ink-dim hover:text-ch-ink hover:bg-ch-bg-raised/50'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <label className="flex items-center gap-2 text-xs text-ch-ink-dim cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={autoRefresh}
+            onChange={e => setAutoRefresh(e.target.checked)}
+            className="accent-ch-accent"
+          />
+          Auto-refresh
+        </label>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-ch-ink-dim py-8 justify-center">
+          <div className="animate-spin w-4 h-4 border-2 border-ch-accent border-t-transparent rounded-full" />
+          Loading logs...
+        </div>
+      ) : error ? (
+        <div className="text-center py-12">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      ) : logs.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-sm text-ch-ink-dim">No scheduled action logs yet.</p>
+        </div>
+      ) : (
+        <div className="space-y-1">
+          {logs.map(rec => (
+            <div key={rec.id} className="border border-ch-line-strong/50 rounded bg-ch-bg-elev">
+              <button
+                onClick={() => setExpanded(expanded === rec.id ? null : rec.id)}
+                className="w-full px-3 py-2 flex items-center gap-3 text-left hover:bg-ch-bg-raised/30 transition-colors rounded text-xs"
+              >
+                <div
+                  className="w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: STATUS_COLORS[rec.status] || '#6B7280' }}
+                />
+                <span className="text-ch-ink-dim w-[130px] shrink-0 font-mono">
+                  {formatTime(rec.started_at)}
+                </span>
+                <span className="text-ch-ink font-medium w-[100px] shrink-0 truncate">
+                  {rec.agent}
+                </span>
+                <span className="text-ch-ink-dim w-[70px] shrink-0">
+                  {rec.action_type}
+                </span>
+                <span
+                  className="w-[80px] shrink-0 font-medium"
+                  style={{ color: STATUS_COLORS[rec.status] || '#6B7280' }}
+                >
+                  {rec.status}
+                </span>
+                <span className="text-ch-ink-dim flex-1 truncate">
+                  {rec.result_summary || ''}
+                </span>
+                <span className="text-ch-ink-dim shrink-0">
+                  {rec.duration_ms ? `${(rec.duration_ms / 1000).toFixed(1)}s` : ''}
+                </span>
+                <span className="text-ch-ink-dim shrink-0 w-[50px] text-right">
+                  {rec.input_tokens + rec.output_tokens > 0
+                    ? formatTokens(rec.input_tokens + rec.output_tokens)
+                    : ''}
+                </span>
+                <svg
+                  className={`w-3 h-3 text-ch-ink-dim shrink-0 transition-transform ${expanded === rec.id ? 'rotate-180' : ''}`}
+                  fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+
+              {expanded === rec.id && (
+                <div className="px-3 pb-3 border-t border-ch-line-strong/30 mt-0">
+                  <div className="flex flex-wrap gap-3 mt-2 text-xs text-ch-ink-dim">
+                    {rec.model_used && <span>Model: {rec.model_used}</span>}
+                    <span>In: {formatTokens(rec.input_tokens)} / Out: {formatTokens(rec.output_tokens)}</span>
+                    {rec.completed_at && <span>Completed: {formatTime(rec.completed_at)}</span>}
+                  </div>
+
+                  {rec.result_full && (
+                    <pre className="mt-2 text-xs text-ch-ink-mute bg-ch-bg-raised/50 px-3 py-2 rounded max-h-48 overflow-auto whitespace-pre-wrap font-mono">
+                      {rec.result_full}
+                    </pre>
+                  )}
+
+                  {Array.isArray(rec.tool_calls) && rec.tool_calls.length > 0 && (
+                    <div className="mt-2 space-y-1">
+                      <div className="text-xs text-ch-ink-dim font-medium">Tool Calls ({rec.tool_calls.length})</div>
+                      {rec.tool_calls.map((tc, i) => (
+                        <div key={i} className="text-xs bg-ch-bg-raised/50 px-3 py-1.5 rounded font-mono">
+                          <div className="flex items-center justify-between">
+                            <span className="text-ch-ink">{tc.tool}</span>
+                            <span className="text-ch-ink-dim">{tc.duration_ms}ms</span>
+                          </div>
+                          {tc.result && (
+                            <div className="text-ch-ink-dim mt-0.5 max-h-12 overflow-auto whitespace-pre-wrap">
+                              {tc.result}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import type { Agent, BrandingConfig } from '../core/types';
 import { ProviderSetup } from '../setup/ProviderSetup';
 import { IntegrationsTab } from './IntegrationsTab';
 import { DataTab } from './DataTab';
+import { LogsTab } from './LogsTab';
 import { SecurityTab } from './SecurityTab';
 import { DeleteAgentModal } from './DeleteAgentModal';
 import { AgentMark } from '../shared/AgentMark';
@@ -14,7 +15,7 @@ interface Props {
   onClose: () => void;
 }
 
-type Tab = 'providers' | 'branding' | 'integrations' | 'chat' | 'data' | 'security' | 'danger';
+type Tab = 'providers' | 'branding' | 'integrations' | 'chat' | 'data' | 'logs' | 'security' | 'danger';
 
 export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
   const [tab, setTab] = useState<Tab>('providers');
@@ -65,6 +66,7 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
     { id: 'integrations', label: 'Integrations' },
     { id: 'chat', label: 'Chat' },
     { id: 'data', label: 'Data' },
+    { id: 'logs', label: 'Logs' },
     { id: 'security', label: 'Security' },
     { id: 'danger', label: 'Danger' },
   ];
@@ -243,6 +245,8 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
           )}
 
           {tab === 'data' && <DataTab />}
+
+          {tab === 'logs' && <LogsTab />}
 
           {tab === 'security' && <SecurityTab />}
 


### PR DESCRIPTION
## Summary

- **Root cause fix**: Scheduled actions (heartbeat, cron) were creating a bare `ToolRegistry` without loading integration tools (Google, CRM, Telegram, Todoist, etc.). Agents could see tool names in prompts but couldn't invoke them. Extracted shared `tool_loader.py` so background execution gets full chat-parity tools including dynamic real tools and integration permission ceilings.
- **Robustness overhaul**: Progressive error backoff (30s, 1m, 5m, 15m, 1h), race-safe expired lease handling with `require_expired_before` guard, lease renewal callbacks in background runner tool loop, error sentinel detection, failure alerts with 3-error threshold + 1-hour cooldown. Auto-disable threshold raised to 10 consecutive errors (`AUTO_DISABLE_THRESHOLD` constant). Triage errors now abort immediately instead of falling through to full execution.
- **Visibility**: New system Logs tab in Settings with status filters (All/OK/Activity/Errors), auto-refresh, expandable details, and error state handling. Error context injected into heartbeat prompts for agent self-correction (tiered: brief note at 1-2 errors, full history + diagnostic guidance at 3+). Cron drift fix added to sweeper with per-row error handling.
- **Existing deployment migration**: One-time startup migration re-enables actions that were auto-disabled under the old 5-error threshold, resets their error counters, and bumps `max_tool_iterations` from 5 to 10 for actions still at the old default.

## Changed files

| File | Change |
|------|--------|
| `backend/agents/tool_loader.py` | **New** — shared `INTEGRATION_MODULES`, `load_integration_tools()`, `build_agent_handlers()` |
| `backend/agents/router.py` | Import from `tool_loader`, remove moved code |
| `backend/core/agents/scheduled_actions/processor.py` | `_build_tools()` with full parity, `_mark_and_alert()`, `_within_active_hours()`, sentinels, lease renewal, error context |
| `backend/core/agents/scheduled_actions/service.py` | Error backoff, `require_expired_before`, race-safe lease fix, `AUTO_DISABLE_THRESHOLD`, one-time migration |
| `backend/core/agents/background_runner.py` | `on_iteration` callback, `error=True` on max iterations |
| `backend/core/agents/scheduled_actions/sweeper.py` | Cron drift fix with per-row error handling |
| `backend/core/agents/scheduled_actions/notifications.py` | `evaluate_failure_alert()` with cooldown |
| `backend/core/agents/scheduled_actions/history.py` | `get_recent_errors()` with action_id filter |
| `backend/core/agents/scheduled_actions/router.py` | `GET /logs` with offset, status validation |
| `backend/core/agents/reminders/db.py` | `last_failure_alert_at` migration, `max_tool_iterations` default to 10 |
| `frontend/src/dashboard/LogsTab.tsx` | **New** — log viewer with filters, auto-refresh, error handling |
| `frontend/src/dashboard/SettingsPanel.tsx` | Add Logs tab |

## Test plan

- [ ] Trigger heartbeat via `POST /api/scheduled-actions/{id}/run-now` — verify agent accesses Gmail/Calendar/CRM tools
- [ ] Check execution log shows actual tool calls (not "tools not available" errors)
- [ ] Simulate errors and verify progressive backoff delays
- [ ] Verify auto-disable at 10 consecutive errors
- [ ] Verify failure alert at 3 consecutive errors with cooldown
- [ ] Open Settings > Logs tab — verify entries load with filters and auto-refresh
- [ ] Verify one-time migration re-enables previously disabled actions and bumps max_tool_iterations
- [ ] Verify sweeper fixes drifted cron actions