### PR TITLE
Add multi-Google-account support

### DIFF
--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -7,6 +7,7 @@ directory and chat history database under data/agents/{slug}/.
 Single-user: no email primary key. ID is a UUID.
 """
 
+import json
 import logging
 import re
 import sqlite3
@@ -79,6 +80,7 @@ def _setup_connection() -> None:
         ("calendar_write_enabled", "INTEGER NOT NULL DEFAULT 0"),
         ("drive_enabled", "INTEGER NOT NULL DEFAULT 0"),
         ("drive_write_enabled", "INTEGER NOT NULL DEFAULT 0"),
+        ("google_accounts", "TEXT NOT NULL DEFAULT '{}'"),
     ]:
         try:
             _connection.execute(f"ALTER TABLE agents ADD COLUMN {col} {typedef}")
@@ -127,6 +129,18 @@ def _unique_slug(name: str) -> str:
     return f"{base}-{uuid.uuid4().hex[:8]}"
 
 
+def _normalize_agent(row: dict) -> dict:
+    """Parse JSON text columns into dicts for API responses."""
+    d = dict(row)
+    raw = d.get("google_accounts", "{}")
+    try:
+        d["google_accounts"] = json.loads(raw) if isinstance(raw, str) else (raw or {})
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Malformed google_accounts for agent %s, treating as empty", d.get("id"))
+        d["google_accounts"] = {}
+    return d
+
+
 def create_agent(agent_name: str, personality: str = "") -> dict:
     """Create a new agent. Returns the created row as dict."""
     agent_id = str(uuid.uuid4())
@@ -144,13 +158,13 @@ def create_agent(agent_name: str, personality: str = "") -> dict:
 def get_agent(agent_id: str) -> dict | None:
     """Get agent by ID. Returns dict or None."""
     row = _get_db().execute("SELECT * FROM agents WHERE id = ?", (agent_id,)).fetchone()
-    return dict(row) if row else None
+    return _normalize_agent(row) if row else None
 
 
 def get_agent_by_slug(slug: str) -> dict | None:
     """Get agent by slug. Returns dict or None."""
     row = _get_db().execute("SELECT * FROM agents WHERE slug = ?", (slug,)).fetchone()
-    return dict(row) if row else None
+    return _normalize_agent(row) if row else None
 
 
 def list_agents() -> list[dict]:
@@ -158,7 +172,7 @@ def list_agents() -> list[dict]:
     rows = _get_db().execute(
         "SELECT * FROM agents ORDER BY created_at DESC"
     ).fetchall()
-    return [dict(r) for r in rows]
+    return [_normalize_agent(r) for r in rows]
 
 
 UPDATABLE_FIELDS = {
@@ -167,6 +181,7 @@ UPDATABLE_FIELDS = {
     "gmail_enabled", "gmail_send_enabled",
     "calendar_enabled", "calendar_write_enabled",
     "drive_enabled", "drive_write_enabled",
+    "google_accounts",
     "whatsapp_session_id",
     "telegram_enabled", "telegram_bot_token", "telegram_bot_username",
     "telegram_group_enabled", "telegram_respond_to_bots", "telegram_max_bot_turns",

--- a/backend/agents/engine.py
+++ b/backend/agents/engine.py
@@ -60,6 +60,8 @@ def build_agent_config(agent_row: dict) -> AgentConfig:
     topics = get_onboarding_topics()
     personality = agent_row.get("personality") or get_onboarding_personality(agent_row["agent_name"])
 
+    google_accounts = agent_row.get("google_accounts") or {}
+
     return AgentConfig(
         agent_id=agent_row["id"],
         agent_name=agent_row["agent_name"],
@@ -73,6 +75,7 @@ def build_agent_config(agent_row: dict) -> AgentConfig:
         calendar_write_enabled=bool(agent_row.get("calendar_write_enabled", 0)),
         drive_enabled=bool(agent_row.get("drive_enabled", 0)),
         drive_write_enabled=bool(agent_row.get("drive_write_enabled", 0)),
+        google_accounts=google_accounts,
         context_dir=str(_context_dir(slug)),
         gcs_prefix=_gcs_prefix(slug) + "context/",
         chat_db_path=str(_agent_dir(slug) / "chat.db"),

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -196,6 +196,7 @@ class UpdateAgentRequest(BaseModel):
     calendar_write_enabled: bool | None = None
     drive_enabled: bool | None = None
     drive_write_enabled: bool | None = None
+    google_accounts: dict | None = None
     telegram_enabled: bool | None = None
     telegram_group_enabled: bool | None = None
     telegram_respond_to_bots: bool | None = None
@@ -295,9 +296,30 @@ async def get_agent(agent_id: str, user=Depends(get_current_user)):
 @router.put("/{agent_id}")
 async def update_agent(agent_id: str, body: UpdateAgentRequest, user=Depends(get_current_user)):
     """Update agent settings."""
+    import json as _json
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
+
+    if "google_accounts" in updates:
+        ga = updates["google_accounts"]
+        _ALLOWED_GA_KEYS = {"gmail", "calendar", "drive"}
+        if not isinstance(ga, dict) or not set(ga.keys()).issubset(_ALLOWED_GA_KEYS):
+            raise HTTPException(status_code=400, detail="google_accounts keys must be a subset of {gmail, calendar, drive}")
+        if not all(isinstance(v, str) for v in ga.values()):
+            raise HTTPException(status_code=400, detail="google_accounts values must be strings")
+        from integrations.registry import list_google_accounts
+        existing = list_google_accounts()
+        for svc, acct_id in ga.items():
+            if not acct_id:
+                continue
+            if acct_id not in existing:
+                raise HTTPException(status_code=400, detail=f"Invalid Google account assignment for {svc}")
+            grants = existing[acct_id].get("scope_grants", {})
+            if grants.get(svc, "none") == "none":
+                raise HTTPException(status_code=400, detail=f"Invalid Google account assignment for {svc}")
+        updates["google_accounts"] = _json.dumps(ga)
+
     for field in (
         "onboarding_complete",
         "gmail_enabled", "gmail_send_enabled",
@@ -508,8 +530,11 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
     if not provider:
         raise HTTPException(status_code=400, detail="No AI provider configured")
 
-    from integrations.registry import is_enabled as _is_enabled
-    google_connected = _is_enabled("google")
+    ga = config.google_accounts
+    gmail_account_id = ga.get("gmail", "")
+    calendar_account_id = ga.get("calendar", "")
+    drive_account_id = ga.get("drive", "")
+    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
@@ -521,6 +546,9 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
         context_dir=config.context_dir,
         gcs_prefix=config.gcs_prefix,
         google_connected=google_connected,
+        gmail_account_id=gmail_account_id,
+        calendar_account_id=calendar_account_id,
+        drive_account_id=drive_account_id,
         integration_executors=integration_executors,
         agent_slug=agent["slug"],
         agent_name=config.agent_name,
@@ -921,8 +949,11 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
     config = build_agent_config(agent)
 
     store = CredentialStore()
-    from integrations.registry import is_enabled as _is_enabled
-    google_connected = _is_enabled("google")
+    ga = config.google_accounts
+    gmail_account_id = ga.get("gmail", "")
+    calendar_account_id = ga.get("calendar", "")
+    drive_account_id = ga.get("drive", "")
+    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
 
     integration_tool_defs, integration_executors = _load_integration_tools()
     reminder_handlers, sa_handlers = _build_agent_handlers(agent["slug"])
@@ -931,6 +962,9 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
         context_dir=config.context_dir,
         gcs_prefix=config.gcs_prefix,
         google_connected=google_connected,
+        gmail_account_id=gmail_account_id,
+        calendar_account_id=calendar_account_id,
+        drive_account_id=drive_account_id,
         integration_executors=integration_executors,
         agent_slug=agent["slug"],
         reminder_handlers=reminder_handlers,
@@ -939,10 +973,17 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
 
     from core.agents.tool_definitions import get_tool_definitions, build_writes_map
     from integrations.google.policy import google_capabilities
-    google_caps = google_capabilities()
+    gmail_caps = google_capabilities(gmail_account_id)
+    cal_caps = google_capabilities(calendar_account_id)
+    drive_caps = google_capabilities(drive_account_id)
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
-        **google_caps,
+        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
+        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
+        calendar_read_enabled=cal_caps["calendar_read_enabled"],
+        calendar_write_enabled=cal_caps["calendar_write_enabled"],
+        drive_read_enabled=drive_caps["drive_read_enabled"],
+        drive_write_enabled=drive_caps["drive_write_enabled"],
     )
     writes_map = build_writes_map(tool_defs)
     if not writes_map.get(req.tool, False):

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -573,12 +573,19 @@ async def chat(
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
 
     from integrations.google.policy import google_capabilities
-    google_caps = google_capabilities()
+    gmail_caps = google_capabilities(config.google_accounts.get("gmail", ""))
+    cal_caps = google_capabilities(config.google_accounts.get("calendar", ""))
+    drive_caps = google_capabilities(config.google_accounts.get("drive", ""))
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
         import_mode=import_mode,
-        **google_caps,
+        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
+        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
+        calendar_read_enabled=cal_caps["calendar_read_enabled"],
+        calendar_write_enabled=cal_caps["calendar_write_enabled"],
+        drive_read_enabled=drive_caps["drive_read_enabled"],
+        drive_write_enabled=drive_caps["drive_write_enabled"],
     )
     kind_map = _build_kind_map(tool_defs)
     writes_map = build_writes_map(tool_defs)
@@ -985,11 +992,18 @@ async def run_sync(
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
 
     from integrations.google.policy import google_capabilities
-    google_caps = google_capabilities()
+    gmail_caps = google_capabilities(config.google_accounts.get("gmail", ""))
+    cal_caps = google_capabilities(config.google_accounts.get("calendar", ""))
+    drive_caps = google_capabilities(config.google_accounts.get("drive", ""))
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
-        **google_caps,
+        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
+        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
+        calendar_read_enabled=cal_caps["calendar_read_enabled"],
+        calendar_write_enabled=cal_caps["calendar_write_enabled"],
+        drive_read_enabled=drive_caps["drive_read_enabled"],
+        drive_write_enabled=drive_caps["drive_write_enabled"],
     )
 
     # Apply integration permission ceilings — messaging channels have no approval UI,

--- a/backend/core/agents/config.py
+++ b/backend/core/agents/config.py
@@ -33,6 +33,9 @@ class AgentConfig:
     drive_enabled: bool = False
     drive_write_enabled: bool = False
 
+    # Per-service Google account assignments {"gmail": "acc_id", "calendar": "acc_id", "drive": "acc_id"}
+    google_accounts: dict = field(default_factory=dict)
+
     # Context directory (absolute path)
     context_dir: str = ""
 

--- a/backend/core/agents/router_factory.py
+++ b/backend/core/agents/router_factory.py
@@ -80,12 +80,18 @@ def create_agent_router(
         if not provider:
             raise HTTPException(status_code=400, detail="No AI provider configured")
 
-        from integrations.registry import is_enabled as _is_enabled
-        google_connected = _is_enabled("google")
+        ga = config.google_accounts
+        gmail_account_id = ga.get("gmail", "")
+        calendar_account_id = ga.get("calendar", "")
+        drive_account_id = ga.get("drive", "")
+        google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
 
         registry = ToolRegistry(
             context_dir=config.context_dir,
             google_connected=google_connected,
+            gmail_account_id=gmail_account_id,
+            calendar_account_id=calendar_account_id,
+            drive_account_id=drive_account_id,
         )
 
         # Anthropic API key for smart title generation (haiku)

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -73,6 +73,9 @@ class ToolRegistry:
         context_dir: str,
         gcs_prefix: str = "",
         google_connected: bool = False,
+        gmail_account_id: str = "",
+        calendar_account_id: str = "",
+        drive_account_id: str = "",
         integration_executors: dict | None = None,
         agent_slug: str = "",
         agent_name: str = "",
@@ -82,6 +85,9 @@ class ToolRegistry:
         self.context_dir = context_dir
         self.gcs_prefix = gcs_prefix
         self.google_connected = google_connected
+        self.gmail_account_id = gmail_account_id
+        self.calendar_account_id = calendar_account_id
+        self.drive_account_id = drive_account_id
         self.integration_executors: dict = integration_executors or {}
         self.agent_slug = agent_slug
         self.agent_name = agent_name
@@ -238,42 +244,43 @@ class ToolRegistry:
         return {"error": f"Unknown shared_context tool: {tool_name}"}
 
     def _execute_gmail(self, tool_name: str, args: dict) -> dict:
-        if not self.google_connected:
-            return {"error": "Google not connected. Connect at Settings → Integrations → Google.",
+        aid = self.gmail_account_id
+        if not aid:
+            return {"error": "No Gmail account assigned. Assign one at Settings → Integrations → Google.",
                     "needs_reconnect": True}
         if tool_name == "search_emails":
-            return search_emails(query=args["query"], max_results=args.get("max_results", 10))
+            return search_emails(aid, query=args["query"], max_results=args.get("max_results", 10))
         elif tool_name == "get_email":
-            return get_email(message_id=args["message_id"])
+            return get_email(aid, message_id=args["message_id"])
         elif tool_name == "get_email_thread":
-            return get_email_thread(thread_id=args["thread_id"])
+            return get_email_thread(aid, thread_id=args["thread_id"])
         elif tool_name == "send_email":
             return send_email(
-                to=args["to"], subject=args["subject"], body=args["body"],
+                aid, to=args["to"], subject=args["subject"], body=args["body"],
                 cc=args.get("cc", ""), bcc=args.get("bcc", ""),
             )
         elif tool_name == "reply_to_email":
             return reply_to_email(
-                message_id=args["message_id"], body=args["body"],
+                aid, message_id=args["message_id"], body=args["body"],
                 reply_all=args.get("reply_all", False),
             )
         elif tool_name == "create_draft":
             return create_draft(
-                to=args["to"], subject=args["subject"], body=args["body"],
+                aid, to=args["to"], subject=args["subject"], body=args["body"],
                 cc=args.get("cc", ""), bcc=args.get("bcc", ""),
             )
         elif tool_name == "mark_email_as_read":
-            return mark_email_as_read(message_id=args["message_id"])
+            return mark_email_as_read(aid, message_id=args["message_id"])
         elif tool_name == "batch_mark_emails_as_read":
-            return batch_mark_emails_as_read(message_ids=args["message_ids"])
+            return batch_mark_emails_as_read(aid, message_ids=args["message_ids"])
         elif tool_name == "download_email_attachment":
             return download_email_attachment(
-                message_id=args["message_id"], filename=args["filename"],
+                aid, message_id=args["message_id"], filename=args["filename"],
                 cache_dir=self.file_cache_dir,
             )
         elif tool_name == "send_email_with_attachment":
             return send_email_with_attachment(
-                to=args["to"], subject=args["subject"], body=args["body"],
+                aid, to=args["to"], subject=args["subject"], body=args["body"],
                 attachment_filename=args.get("attachment_filename", ""),
                 attachment_base64=args.get("attachment_base64", ""),
                 attachment_mime_type=args.get("attachment_mime_type", "application/pdf"),
@@ -283,7 +290,7 @@ class ToolRegistry:
             )
         elif tool_name == "reply_to_email_with_attachment":
             return reply_to_email_with_attachment(
-                message_id=args["message_id"], body=args["body"],
+                aid, message_id=args["message_id"], body=args["body"],
                 attachment_filename=args.get("attachment_filename", ""),
                 attachment_base64=args.get("attachment_base64", ""),
                 attachment_mime_type=args.get("attachment_mime_type", "application/pdf"),
@@ -294,24 +301,25 @@ class ToolRegistry:
         return {"error": f"Unknown gmail tool: {tool_name}"}
 
     def _execute_calendar(self, tool_name: str, args: dict) -> dict:
-        if not self.google_connected:
-            return {"error": "Google not connected. Connect at Settings → Integrations → Google.",
+        aid = self.calendar_account_id
+        if not aid:
+            return {"error": "No Calendar account assigned. Assign one at Settings → Integrations → Google.",
                     "needs_reconnect": True}
         if tool_name == "list_calendar_events":
             return list_calendar_events(
-                calendar_id=args.get("calendar_id", "primary"),
+                aid, calendar_id=args.get("calendar_id", "primary"),
                 max_results=args.get("max_results", 10),
                 time_min=args.get("time_min", ""),
                 time_max=args.get("time_max", ""),
             )
         elif tool_name == "get_calendar_event":
             return get_calendar_event(
-                event_id=args["event_id"],
+                aid, event_id=args["event_id"],
                 calendar_id=args.get("calendar_id", "primary"),
             )
         elif tool_name == "search_calendar_events":
             return search_calendar_events(
-                query=args["query"],
+                aid, query=args["query"],
                 time_min=args.get("time_min", ""),
                 time_max=args.get("time_max", ""),
                 max_results=args.get("max_results", 20),
@@ -319,21 +327,21 @@ class ToolRegistry:
             )
         elif tool_name == "find_free_slot":
             return find_free_slot(
-                duration_minutes=args["duration_minutes"],
+                aid, duration_minutes=args["duration_minutes"],
                 between_start=args["between_start"],
                 between_end=args["between_end"],
                 calendar_ids=args.get("calendar_ids"),
             )
         elif tool_name == "create_calendar_event":
             return create_calendar_event(
-                summary=args["summary"], start=args["start"], end=args["end"],
+                aid, summary=args["summary"], start=args["start"], end=args["end"],
                 description=args.get("description", ""), location=args.get("location", ""),
                 attendees=args.get("attendees"),
                 calendar_id=args.get("calendar_id", "primary"),
             )
         elif tool_name == "update_calendar_event":
             return update_calendar_event(
-                event_id=args["event_id"],
+                aid, event_id=args["event_id"],
                 calendar_id=args.get("calendar_id", "primary"),
                 summary=args.get("summary"), start=args.get("start"), end=args.get("end"),
                 description=args.get("description"), location=args.get("location"),
@@ -341,57 +349,58 @@ class ToolRegistry:
             )
         elif tool_name == "delete_calendar_event":
             return delete_calendar_event(
-                event_id=args["event_id"],
+                aid, event_id=args["event_id"],
                 calendar_id=args.get("calendar_id", "primary"),
             )
         return {"error": f"Unknown calendar tool: {tool_name}"}
 
     def _execute_drive(self, tool_name: str, args: dict) -> dict:
-        if not self.google_connected:
-            return {"error": "Google not connected. Connect at Settings → Integrations → Google.",
+        aid = self.drive_account_id
+        if not aid:
+            return {"error": "No Drive account assigned. Assign one at Settings → Integrations → Google.",
                     "needs_reconnect": True}
         if tool_name == "search_drive_files":
             return search_drive_files(
-                query=args["query"],
+                aid, query=args["query"],
                 max_results=args.get("max_results", 20),
             )
         elif tool_name == "list_drive_folder":
             return list_drive_folder(
-                folder_id=args.get("folder_id", "root"),
+                aid, folder_id=args.get("folder_id", "root"),
                 max_results=args.get("max_results", 50),
             )
         elif tool_name == "get_drive_file_info":
-            return get_drive_file_info(file_id=args["file_id"])
+            return get_drive_file_info(aid, file_id=args["file_id"])
         elif tool_name == "read_drive_file_content":
             return read_drive_file_content(
-                file_id=args["file_id"],
+                aid, file_id=args["file_id"],
                 max_chars=args.get("max_chars", 50000),
             )
         elif tool_name == "create_drive_folder":
             return create_drive_folder(
-                name=args["name"],
+                aid, name=args["name"],
                 parent_folder_id=args.get("parent_folder_id", "root"),
             )
         elif tool_name == "create_drive_file":
             return create_drive_file(
-                name=args["name"],
+                aid, name=args["name"],
                 content=args.get("content", ""),
                 file_type=args.get("file_type", "document"),
                 folder_id=args.get("folder_id", "root"),
             )
         elif tool_name == "move_drive_file":
             return move_drive_file(
-                file_id=args["file_id"],
+                aid, file_id=args["file_id"],
                 new_parent_id=args["new_parent_id"],
             )
         elif tool_name == "rename_drive_file":
             return rename_drive_file(
-                file_id=args["file_id"],
+                aid, file_id=args["file_id"],
                 new_name=args["new_name"],
             )
         elif tool_name == "copy_drive_file":
             return copy_drive_file(
-                file_id=args["file_id"],
+                aid, file_id=args["file_id"],
                 new_name=args.get("new_name"),
                 folder_id=args.get("folder_id"),
             )

--- a/backend/core/providers/oauth.py
+++ b/backend/core/providers/oauth.py
@@ -148,6 +148,7 @@ def _build_auth_url(
     code_challenge: str | None,
     state: str,
     scopes: list[str] | None = None,
+    prompt: str | None = None,
 ) -> str:
     """Build the OAuth authorization URL, with optional PKCE parameters."""
     cfg = OAUTH_CONFIG[provider]
@@ -170,7 +171,7 @@ def _build_auth_url(
         params["code_challenge_method"] = "S256"
     if provider == "google":
         params["access_type"] = "offline"
-        params["prompt"] = "consent"  # ensure refresh_token on every connect
+        params["prompt"] = prompt or "consent"
     return f"{cfg['auth_url']}?{urlencode(params)}"
 
 
@@ -180,6 +181,7 @@ def start_oauth_flow(
     provider: str,
     scopes: list[str] | None = None,
     metadata: dict | None = None,
+    prompt: str | None = None,
 ) -> dict:
     """
     Start an OAuth flow.
@@ -219,7 +221,7 @@ def start_oauth_flow(
     else:
         state = flow_id
 
-    auth_url = _build_auth_url(provider, challenge, state=state, scopes=scopes)
+    auth_url = _build_auth_url(provider, challenge, state=state, scopes=scopes, prompt=prompt)
 
     _OAUTH_FLOWS[flow_id] = OAuthFlow(
         flow_id=flow_id,

--- a/backend/integrations/google/client.py
+++ b/backend/integrations/google/client.py
@@ -1,10 +1,10 @@
 """
-Chatty — Google API client factory with auto-refresh.
+Chatty — Google API client factory with auto-refresh (multi-account).
 
 All Gmail / Calendar / Drive operations route through here. The wrapper
 transparently refreshes the access token when it's near expiry or when
 an API call returns 401, and persists the refreshed tokens back to
-auth-profiles.json.
+google.json under the correct account entry.
 """
 
 from __future__ import annotations
@@ -18,9 +18,15 @@ from core.providers.oauth import refresh_google_token
 
 logger = logging.getLogger(__name__)
 
-# One global lock — we only have a single Google connection at any time,
-# so serializing refresh attempts across Gmail/Calendar/Drive callers is fine.
-_REFRESH_LOCK = threading.Lock()
+_ACCOUNT_LOCKS: dict[str, threading.Lock] = {}
+_LOCKS_LOCK = threading.Lock()
+
+
+def _get_account_lock(account_id: str) -> threading.Lock:
+    with _LOCKS_LOCK:
+        if account_id not in _ACCOUNT_LOCKS:
+            _ACCOUNT_LOCKS[account_id] = threading.Lock()
+        return _ACCOUNT_LOCKS[account_id]
 
 
 class GoogleAuthError(Exception):
@@ -29,39 +35,44 @@ class GoogleAuthError(Exception):
 
 # ── Token management ─────────────────────────────────────────────────────────
 
-def _load_integration_tokens() -> dict:
-    """Read tokens from data/integrations/google.json (NOT auth-profiles.json)."""
+def _load_integration_tokens(account_id: str) -> dict:
+    """Read tokens for a specific account from google.json."""
     try:
-        from integrations.registry import get_credentials
-        return get_credentials("google")
+        from integrations.registry import get_google_account
+        return get_google_account(account_id)
     except Exception:
         return {}
 
 
-def _save_refreshed_tokens(access: str, refresh: str, expires_in: int) -> None:
-    """Write refreshed tokens back to google.json."""
-    from integrations.registry import get_credentials, save_credentials
-    creds = get_credentials("google")
-    creds["access_token"] = access
-    creds["refresh_token"] = refresh
-    creds["token_expires_at"] = time.time() + expires_in
-    save_credentials("google", creds)
+def _save_refreshed_tokens(account_id: str, access: str, refresh: str, expires_in: int) -> None:
+    """Merge refreshed token fields into the account entry atomically."""
+    from integrations.registry import _GOOGLE_FILE_LOCK, _read_google_creds, _write_google_creds
+    with _GOOGLE_FILE_LOCK:
+        creds = _read_google_creds()
+        accounts = creds.get("accounts", {})
+        if account_id not in accounts:
+            return
+        accounts[account_id]["access_token"] = access
+        accounts[account_id]["refresh_token"] = refresh
+        accounts[account_id]["token_expires_at"] = time.time() + expires_in
+        _write_google_creds(creds)
 
 
-def _ensure_fresh_token(force: bool = False) -> str:
-    """Return a valid access token from google.json. Refreshes if expired.
+def _ensure_fresh_token(account_id: str, force: bool = False) -> str:
+    """Return a valid access token for the given account. Refreshes if expired.
 
     Raises GoogleAuthError if no tokens are stored or refresh fails.
     """
-    with _REFRESH_LOCK:
-        creds = _load_integration_tokens()
+    lock = _get_account_lock(account_id)
+    with lock:
+        creds = _load_integration_tokens(account_id)
         access = creds.get("access_token", "")
         refresh = creds.get("refresh_token", "")
         expires = creds.get("token_expires_at", 0)
 
         if not access and not refresh:
             raise GoogleAuthError(
-                "Google not connected. Connect at Settings → Integrations → Google."
+                "Google account not connected. Connect at Settings → Integrations → Google."
             )
 
         needs_refresh = force or not expires or time.time() >= (expires - 60)
@@ -76,8 +87,8 @@ def _ensure_fresh_token(force: bool = False) -> str:
         try:
             tokens = _run_sync(refresh_google_token(refresh))
         except Exception as e:
-            logger.error("Google token refresh failed: %s", e)
-            _mark_broken()
+            logger.error("Google token refresh failed for account %s: %s", account_id, e)
+            _mark_broken(account_id)
             raise GoogleAuthError(
                 "Google connection expired. Reconnect at Settings → Integrations → Google."
             ) from e
@@ -86,40 +97,32 @@ def _ensure_fresh_token(force: bool = False) -> str:
         new_expires = tokens.get("expires_in", 3600)
         new_refresh = tokens.get("refresh_token", refresh)
 
-        _save_refreshed_tokens(new_access, new_refresh, new_expires)
+        _save_refreshed_tokens(account_id, new_access, new_refresh, new_expires)
         return new_access
 
 
 def _run_sync(coro):
-    """Run an async coroutine from sync code.
-
-    If we're inside an async context (FastAPI request handler), we cannot
-    call asyncio.run directly — it would conflict with the running loop.
-    We run the coroutine in a background thread with its own loop. In a
-    purely-sync context, we just spin up a one-shot loop here.
-    """
+    """Run an async coroutine from sync code."""
     import concurrent.futures
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        # No running loop — safe to run directly
         return asyncio.run(coro)
 
-    # Inside an async context — offload to a thread
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
         return pool.submit(asyncio.run, coro).result()
 
 
-def _mark_broken() -> None:
-    """Set connection_status=broken in data/integrations/google.json."""
+def _mark_broken(account_id: str) -> None:
+    """Set connection_status=broken for a specific account."""
     try:
-        from integrations.registry import get_credentials, save_credentials
-        creds = get_credentials("google")
-        if creds:
-            creds["connection_status"] = "broken"
-            save_credentials("google", creds)
+        from integrations.registry import get_google_account, save_google_account
+        acct = get_google_account(account_id)
+        if acct:
+            acct["connection_status"] = "broken"
+            save_google_account(account_id, acct)
     except Exception as e:
-        logger.warning("Failed to mark Google connection broken: %s", e)
+        logger.warning("Failed to mark Google account %s broken: %s", account_id, e)
 
 
 # ── Service factories ────────────────────────────────────────────────────────
@@ -138,21 +141,21 @@ def _build_service(api_name: str, version: str, access_token: str):
     return build(api_name, version, credentials=credentials, cache_discovery=False)
 
 
-def get_gmail_service():
-    """Return an authenticated Gmail v1 service."""
-    access = _ensure_fresh_token()
+def get_gmail_service(account_id: str):
+    """Return an authenticated Gmail v1 service for the given account."""
+    access = _ensure_fresh_token(account_id)
     return _build_service("gmail", "v1", access)
 
 
-def get_calendar_service():
-    """Return an authenticated Calendar v3 service."""
-    access = _ensure_fresh_token()
+def get_calendar_service(account_id: str):
+    """Return an authenticated Calendar v3 service for the given account."""
+    access = _ensure_fresh_token(account_id)
     return _build_service("calendar", "v3", access)
 
 
-def get_drive_service():
-    """Return an authenticated Drive v3 service."""
-    access = _ensure_fresh_token()
+def get_drive_service(account_id: str):
+    """Return an authenticated Drive v3 service for the given account."""
+    access = _ensure_fresh_token(account_id)
     return _build_service("drive", "v3", access)
 
 
@@ -172,38 +175,31 @@ def _maybe_raise_scope_error(err):
     raise err
 
 
-def call_with_refresh(service_factory, operation, *args, **kwargs):
+def call_with_refresh(account_id: str, service_factory, operation, *args, **kwargs):
     """Run `operation(service, *args, **kwargs)` with one automatic 401 retry.
 
     On 401, force-refresh the token, rebuild the service, retry once.
-    Wraps Google library HttpError into GoogleAuthError with actionable text
-    when refresh itself fails.
-
-    Args:
-        service_factory: Callable that returns a fresh Google API service
-                         (e.g. get_gmail_service).
-        operation: Callable taking (service, *args, **kwargs) and performing the API call.
     """
     try:
         from googleapiclient.errors import HttpError
     except ImportError:
         HttpError = Exception  # type: ignore
 
-    service = service_factory()
+    service = service_factory(account_id)
     try:
         return operation(service, *args, **kwargs)
     except HttpError as e:
         status = getattr(getattr(e, "resp", None), "status", None)
         if status == 401:
-            logger.info("Google 401 — forcing token refresh and retrying once")
-            _ensure_fresh_token(force=True)
-            service = service_factory()
+            logger.info("Google 401 for account %s — forcing token refresh and retrying once", account_id)
+            _ensure_fresh_token(account_id, force=True)
+            service = service_factory(account_id)
             try:
                 return operation(service, *args, **kwargs)
             except HttpError as retry_err:
                 retry_status = getattr(getattr(retry_err, "resp", None), "status", None)
                 if retry_status == 401:
-                    _mark_broken()
+                    _mark_broken(account_id)
                     raise GoogleAuthError(
                         "Google connection expired. Reconnect at Settings → Integrations → Google."
                     ) from retry_err

--- a/backend/integrations/google/onboarding.py
+++ b/backend/integrations/google/onboarding.py
@@ -1,22 +1,27 @@
 """
-Chatty — Google integration setup flow.
+Chatty — Google integration setup flow (multi-account).
 
-Tokens for Gmail/Calendar/Drive are stored in data/integrations/google.json
-(NOT in auth-profiles.json). This keeps the integration credentials separate
-from the Gemini AI provider credentials, which live under google:default in
-auth-profiles.json. Connecting/disconnecting the integration never touches
-the AI provider slot.
+Tokens for each Google account are stored in data/integrations/google.json
+under the accounts dict, keyed by a short UUID. The Gemini AI provider
+credentials live separately in auth-profiles.json.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import time
+import uuid
 from pathlib import Path
 
 import httpx
 
-from integrations.registry import get_credentials, save_credentials
+from integrations.registry import (
+    get_google_account,
+    save_google_account,
+    delete_google_account,
+    list_google_accounts,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,16 +61,39 @@ async def setup_from_oauth(
     refresh_token: str,
     expires_in: int,
     scope_grants: dict,
+    account_id: str = "",
 ) -> dict:
-    """Persist tokens + grants to google.json. Returns {ok, email, ...}."""
+    """Persist tokens + grants to google.json accounts dict. Returns {ok, account_id, email, ...}."""
     email = await _resolve_email(access_token)
+    if not email:
+        return {
+            "ok": False,
+            "error": "Could not resolve Google account email. Please try again.",
+        }
+
+    if account_id:
+        existing = get_google_account(account_id)
+        if existing and existing.get("email") and existing["email"] != email:
+            logger.warning("Google reconnect email mismatch: stored=%s returned=%s", existing["email"], email)
+            return {
+                "ok": False,
+                "error": "Account email mismatch. Disconnect and add a new account instead.",
+            }
+
     timezone = "UTC"
     if scope_grants.get("calendar", "none") != "none":
         timezone = await _resolve_calendar_timezone(access_token)
 
-    existing = get_credentials("google")
-    existing.update({
-        "enabled": True,
+    if not account_id:
+        existing_accounts = list_google_accounts()
+        for aid, acct in existing_accounts.items():
+            if acct.get("email") and acct["email"] == email:
+                account_id = aid
+                break
+        if not account_id:
+            account_id = uuid.uuid4().hex[:8]
+
+    account_data = {
         "email": email,
         "access_token": access_token,
         "refresh_token": refresh_token,
@@ -73,25 +101,46 @@ async def setup_from_oauth(
         "scope_grants": scope_grants,
         "calendar_timezone": timezone,
         "connection_status": "ok",
-    })
-    save_credentials("google", existing)
+    }
 
-    logger.info("Google connected: email=%s scope_grants=%s", email, scope_grants)
+    save_google_account(account_id, account_data, create=True)
+
+    _clear_stale_assignments(account_id, scope_grants)
+
+    logger.info("Google account connected: id=%s email=%s scope_grants=%s", account_id, email, scope_grants)
     return {
         "ok": True,
+        "account_id": account_id,
         "email": email,
         "scope_grants": scope_grants,
         "timezone": timezone,
     }
 
 
-async def disconnect() -> dict:
-    """Revoke tokens with Google and clear google.json. Does NOT touch
-    auth-profiles.json — the Gemini AI provider is unaffected."""
-    creds = get_credentials("google")
-    refresh = creds.get("refresh_token", "")
-    access = creds.get("access_token", "")
+def _clear_stale_assignments(account_id: str, scope_grants: dict) -> None:
+    """Clear agent assignments for services that were downgraded to 'none'."""
+    try:
+        from agents.db import list_agents, update_agent
+        svc_map = {"gmail": "gmail", "calendar": "calendar", "drive": "drive"}
+        for agent in list_agents():
+            ga = agent.get("google_accounts", {})
+            if not isinstance(ga, dict):
+                continue
+            changed = False
+            for svc, scope_key in svc_map.items():
+                if ga.get(svc) == account_id and scope_grants.get(scope_key, "none") == "none":
+                    ga[svc] = ""
+                    changed = True
+            if changed:
+                update_agent(agent["id"], google_accounts=json.dumps(ga))
+    except Exception as e:
+        logger.warning("Failed to clear stale Google assignments: %s", e)
 
+
+async def _revoke_token(acct: dict) -> None:
+    """Revoke tokens for a single account."""
+    refresh = acct.get("refresh_token", "")
+    access = acct.get("access_token", "")
     token_to_revoke = refresh or access
     if token_to_revoke:
         try:
@@ -102,19 +151,68 @@ async def disconnect() -> dict:
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                 )
                 if resp.status_code == 200:
-                    logger.info("Google tokens revoked successfully")
+                    logger.info("Google tokens revoked for %s", acct.get("email", "?"))
                 else:
-                    logger.warning("Google token revoke returned %d", resp.status_code)
+                    logger.warning("Google token revoke returned %d for %s", resp.status_code, acct.get("email", "?"))
         except Exception as e:
-            logger.warning("Google token revoke failed: %s", e)
+            logger.warning("Google token revoke failed for %s: %s", acct.get("email", "?"), e)
 
-    preserved_app = creds.get("app")
-    creds_path = Path(__file__).resolve().parent.parent.parent / "data" / "integrations" / "google.json"
-    if creds_path.exists():
-        creds_path.unlink()
-        logger.info("Removed google.json")
 
-    if preserved_app:
-        save_credentials("google", {"app": preserved_app})
+def _clear_agent_references(account_id: str = "") -> None:
+    """Clear google_accounts on agents that reference a removed account."""
+    try:
+        from agents.db import list_agents, update_agent
+        for agent in list_agents():
+            ga = agent.get("google_accounts", {})
+            if not isinstance(ga, dict):
+                continue
+            changed = False
+            if account_id:
+                for svc, aid in list(ga.items()):
+                    if aid == account_id:
+                        ga[svc] = ""
+                        changed = True
+            else:
+                if any(v for v in ga.values()):
+                    ga = {"gmail": "", "calendar": "", "drive": ""}
+                    changed = True
+            if changed:
+                update_agent(agent["id"], google_accounts=json.dumps(ga))
+    except Exception as e:
+        logger.warning("Failed to clear agent Google references: %s", e)
 
-    return {"ok": True}
+
+async def disconnect(account_id: str = "") -> dict:
+    """Revoke tokens and remove account(s). Does NOT touch auth-profiles.json."""
+    from integrations.registry import get_credentials, _GOOGLE_FILE_LOCK, _read_google_creds, _write_google_creds
+
+    if account_id:
+        acct = get_google_account(account_id)
+        if acct:
+            await _revoke_token(acct)
+            delete_google_account(account_id)
+        _clear_agent_references(account_id)
+    else:
+        accounts = list_google_accounts()
+        for acct in accounts.values():
+            await _revoke_token(acct)
+
+        with _GOOGLE_FILE_LOCK:
+            creds = _read_google_creds()
+            preserved_app = creds.get("app")
+            preserved_tool_mode = creds.get("tool_mode")
+            creds_path = Path(__file__).resolve().parent.parent.parent / "data" / "integrations" / "google.json"
+            if creds_path.exists():
+                creds_path.unlink()
+                logger.info("Removed google.json")
+            if preserved_app or preserved_tool_mode:
+                new_creds = {}
+                if preserved_app:
+                    new_creds["app"] = preserved_app
+                if preserved_tool_mode:
+                    new_creds["tool_mode"] = preserved_tool_mode
+                _write_google_creds(new_creds)
+
+        _clear_agent_references()
+
+    return {"ok": True, "account_id": account_id}

--- a/backend/integrations/google/policy.py
+++ b/backend/integrations/google/policy.py
@@ -1,13 +1,8 @@
 """
-Chatty — Google capability resolution.
+Chatty — Google capability resolution (multi-account).
 
-When Google is connected globally, ALL agents automatically get the
-granted capabilities. No per-agent opt-in required — if the user
-connected Gmail with send access, every agent can send email.
-
-Per-agent flags (gmail_enabled, drive_enabled, etc.) act as opt-OUT
-overrides: set them to False to restrict a specific agent. By default
-they're treated as "use whatever the global connection grants."
+Each agent can have different Google accounts assigned per service
+(Gmail, Calendar, Drive). Capabilities are resolved per-account.
 """
 
 from __future__ import annotations
@@ -20,35 +15,36 @@ _CALENDAR_WRITE_LEVELS = {"full"}
 _DRIVE_READ_LEVELS = {"file", "readonly", "full"}
 _DRIVE_WRITE_LEVELS = {"file", "full"}
 
-
-def _load_grants() -> dict[str, str]:
-    """Load scope_grants from data/integrations/google.json."""
-    try:
-        from integrations.registry import get_credentials
-        creds = get_credentials("google")
-        if not creds or not creds.get("enabled"):
-            return {}
-        return creds.get("scope_grants", {}) or {}
-    except Exception:
-        return {}
+_ALL_DISABLED = {
+    "gmail_read_enabled": False,
+    "gmail_send_enabled": False,
+    "calendar_read_enabled": False,
+    "calendar_write_enabled": False,
+    "drive_read_enabled": False,
+    "drive_write_enabled": False,
+}
 
 
-def google_capabilities() -> dict[str, bool]:
-    """Return capability flags based on global Google connection grants.
+def google_capabilities(account_id: str = "") -> dict[str, bool]:
+    """Return capability flags for a specific Google account.
 
-    If Google is connected, agents get all granted capabilities automatically.
-    No per-agent toggle required — the global scope grants are the source of truth.
+    If account_id is empty or the account doesn't exist, returns all-disabled.
     """
-    grants = _load_grants()
-    if not grants:
-        return {
-            "gmail_read_enabled": False,
-            "gmail_send_enabled": False,
-            "calendar_read_enabled": False,
-            "calendar_write_enabled": False,
-            "drive_read_enabled": False,
-            "drive_write_enabled": False,
-        }
+    if not account_id:
+        return dict(_ALL_DISABLED)
+
+    try:
+        from integrations.registry import get_google_account
+        acct = get_google_account(account_id)
+        if not acct:
+            return dict(_ALL_DISABLED)
+        if acct.get("connection_status") == "broken":
+            return dict(_ALL_DISABLED)
+        grants = acct.get("scope_grants", {})
+        if not grants:
+            return dict(_ALL_DISABLED)
+    except Exception:
+        return dict(_ALL_DISABLED)
 
     gmail = grants.get("gmail", "none")
     calendar = grants.get("calendar", "none")

--- a/backend/integrations/google/tools.py
+++ b/backend/integrations/google/tools.py
@@ -1,9 +1,11 @@
 """
-Chatty — Google tool handlers (Gmail + Calendar + Drive).
+Chatty — Google tool handlers (Gmail + Calendar + Drive), multi-account.
 
 These are the functions that ToolRegistry._execute_gmail /
 _execute_calendar / _execute_drive dispatch to. Each wraps the underlying
 ops with call_with_refresh() for automatic token refresh on 401.
+
+Every tool function takes account_id as its first parameter.
 """
 
 from __future__ import annotations
@@ -22,10 +24,10 @@ from . import gmail_ops, calendar_ops, drive_ops
 logger = logging.getLogger(__name__)
 
 
-def _wrap(service_factory, op, **kwargs):
+def _wrap(account_id, service_factory, op, **kwargs):
     """Call an op with auto-refresh; surface GoogleAuthError + generic errors as dicts."""
     try:
-        return call_with_refresh(service_factory, op, **kwargs)
+        return call_with_refresh(account_id, service_factory, op, **kwargs)
     except GoogleAuthError as e:
         return {"error": str(e), "needs_reconnect": True}
     except Exception as e:
@@ -35,58 +37,57 @@ def _wrap(service_factory, op, **kwargs):
 
 # ── Gmail ────────────────────────────────────────────────────────────────────
 
-def search_emails(query: str, max_results: int = 10) -> dict:
-    result = _wrap(get_gmail_service, gmail_ops.list_messages_op, query=query, max_results=max_results)
+def search_emails(account_id: str, query: str, max_results: int = 10) -> dict:
+    result = _wrap(account_id, get_gmail_service, gmail_ops.list_messages_op, query=query, max_results=max_results)
     if isinstance(result, list):
         return {"messages": result, "count": len(result)}
     return result
 
 
-def get_email(message_id: str) -> dict:
-    return _wrap(get_gmail_service, gmail_ops.get_message_op, message_id=message_id)
+def get_email(account_id: str, message_id: str) -> dict:
+    return _wrap(account_id, get_gmail_service, gmail_ops.get_message_op, message_id=message_id)
 
 
-def get_email_thread(thread_id: str) -> dict:
-    return _wrap(get_gmail_service, gmail_ops.get_thread_op, thread_id=thread_id)
+def get_email_thread(account_id: str, thread_id: str) -> dict:
+    return _wrap(account_id, get_gmail_service, gmail_ops.get_thread_op, thread_id=thread_id)
 
 
-def send_email(to: str, subject: str, body: str, cc: str = "", bcc: str = "") -> dict:
-    return _wrap(get_gmail_service, gmail_ops.send_email_op,
+def send_email(account_id: str, to: str, subject: str, body: str, cc: str = "", bcc: str = "") -> dict:
+    return _wrap(account_id, get_gmail_service, gmail_ops.send_email_op,
                  to=to, subject=subject, body=body, cc=cc, bcc=bcc)
 
 
-def reply_to_email(message_id: str, body: str, reply_all: bool = False) -> dict:
-    return _wrap(get_gmail_service, gmail_ops.reply_to_email_op,
+def reply_to_email(account_id: str, message_id: str, body: str, reply_all: bool = False) -> dict:
+    return _wrap(account_id, get_gmail_service, gmail_ops.reply_to_email_op,
                  message_id=message_id, body=body, reply_all=reply_all)
 
 
-def create_draft(to: str, subject: str, body: str, cc: str = "", bcc: str = "") -> dict:
-    return _wrap(get_gmail_service, gmail_ops.create_draft_op,
+def create_draft(account_id: str, to: str, subject: str, body: str, cc: str = "", bcc: str = "") -> dict:
+    return _wrap(account_id, get_gmail_service, gmail_ops.create_draft_op,
                  to=to, subject=subject, body=body, cc=cc, bcc=bcc)
 
 
-def mark_email_as_read(message_id: str) -> dict:
-    return _wrap(get_gmail_service, gmail_ops.mark_as_read_op,
+def mark_email_as_read(account_id: str, message_id: str) -> dict:
+    return _wrap(account_id, get_gmail_service, gmail_ops.mark_as_read_op,
                  message_id=message_id)
 
 
 _MAX_BATCH_MARK_READ = 50
 
 
-def batch_mark_emails_as_read(message_ids: list[str]) -> dict:
+def batch_mark_emails_as_read(account_id: str, message_ids: list[str]) -> dict:
     if not message_ids:
         return {"error": "message_ids must be a non-empty list"}
     if len(message_ids) > _MAX_BATCH_MARK_READ:
         return {"error": f"Too many message IDs ({len(message_ids)}). Maximum is {_MAX_BATCH_MARK_READ}."}
-    return _wrap(get_gmail_service, gmail_ops.batch_mark_as_read_op,
+    return _wrap(account_id, get_gmail_service, gmail_ops.batch_mark_as_read_op,
                  message_ids=message_ids)
 
 
-def download_email_attachment(message_id: str, filename: str, cache_dir: str | None = None) -> dict:
+def download_email_attachment(account_id: str, message_id: str, filename: str, cache_dir: str | None = None) -> dict:
     """Download an email attachment, extract text, and cache for forwarding."""
     import base64 as b64
 
-    from integrations.google.client import get_gmail_service as _get_svc, call_with_refresh, GoogleAuthError
     from core.agents.tools.text_extraction import (
         classify_mimetype, is_text_extractable, extract_text,
         MAX_FILE_SIZE,
@@ -124,7 +125,7 @@ def download_email_attachment(message_id: str, filename: str, cache_dir: str | N
         ).execute()
 
     try:
-        msg = call_with_refresh(_get_svc, _fetch_message, message_id=message_id)
+        msg = call_with_refresh(account_id, get_gmail_service, _fetch_message, message_id=message_id)
     except GoogleAuthError as e:
         return {"error": str(e), "needs_reconnect": True}
     except Exception as e:
@@ -155,7 +156,7 @@ def download_email_attachment(message_id: str, filename: str, cache_dir: str | N
             return {"error": "Attachment has no downloadable content"}
     else:
         try:
-            raw = call_with_refresh(_get_svc, gmail_ops.get_attachment_content_op,
+            raw = call_with_refresh(account_id, get_gmail_service, gmail_ops.get_attachment_content_op,
                                     message_id=message_id, attachment_id=attachment_id)
         except Exception as e:
             return {"error": f"Failed to download attachment: {e}"}
@@ -245,6 +246,7 @@ def _resolve_attachment(
 
 
 def send_email_with_attachment(
+    account_id: str,
     to: str, subject: str, body: str,
     attachment_filename: str,
     attachment_base64: str = "",
@@ -265,12 +267,13 @@ def send_email_with_attachment(
         return {"ok": False, "error": f"Attachment too large (~{decoded_mb:.1f} MB). Gmail rejects messages over ~35 MB."}
 
     attachments = [{"filename": att_fn, "content_base64": att_b64, "mime_type": att_mt}]
-    return _wrap(get_gmail_service, gmail_ops.send_email_op,
+    return _wrap(account_id, get_gmail_service, gmail_ops.send_email_op,
                  to=to, subject=subject, body=body, cc=cc, bcc=bcc,
                  attachments=attachments)
 
 
 def reply_to_email_with_attachment(
+    account_id: str,
     message_id: str, body: str,
     attachment_filename: str,
     attachment_base64: str = "",
@@ -291,31 +294,32 @@ def reply_to_email_with_attachment(
         return {"ok": False, "error": f"Attachment too large (~{decoded_mb:.1f} MB). Gmail rejects messages over ~35 MB."}
 
     attachments = [{"filename": att_fn, "content_base64": att_b64, "mime_type": att_mt}]
-    return _wrap(get_gmail_service, gmail_ops.reply_to_email_op,
+    return _wrap(account_id, get_gmail_service, gmail_ops.reply_to_email_op,
                  message_id=message_id, body=body,
                  reply_all=reply_all, attachments=attachments)
 
 
 # ── Calendar ─────────────────────────────────────────────────────────────────
 
-def _user_timezone() -> str:
-    """Read the cached timezone from data/integrations/google.json."""
+def _user_timezone(account_id: str) -> str:
+    """Read the cached timezone from the specific account in google.json."""
     try:
-        from integrations.registry import get_credentials
-        creds = get_credentials("google")
-        return creds.get("calendar_timezone", "UTC") or "UTC"
+        from integrations.registry import get_google_account
+        acct = get_google_account(account_id)
+        return acct.get("calendar_timezone", "UTC") or "UTC"
     except Exception:
         return "UTC"
 
 
 def list_calendar_events(
+    account_id: str,
     time_min: str = "",
     time_max: str = "",
     calendar_id: str = "primary",
     max_results: int = 10,
 ) -> dict:
     result = _wrap(
-        get_calendar_service, calendar_ops.list_events_op,
+        account_id, get_calendar_service, calendar_ops.list_events_op,
         time_min=time_min, time_max=time_max,
         calendar_id=calendar_id, max_results=max_results,
     )
@@ -324,12 +328,13 @@ def list_calendar_events(
     return result
 
 
-def get_calendar_event(event_id: str, calendar_id: str = "primary") -> dict:
-    return _wrap(get_calendar_service, calendar_ops.get_event_op,
+def get_calendar_event(account_id: str, event_id: str, calendar_id: str = "primary") -> dict:
+    return _wrap(account_id, get_calendar_service, calendar_ops.get_event_op,
                  event_id=event_id, calendar_id=calendar_id)
 
 
 def search_calendar_events(
+    account_id: str,
     query: str,
     time_min: str = "",
     time_max: str = "",
@@ -337,7 +342,7 @@ def search_calendar_events(
     calendar_id: str = "primary",
 ) -> dict:
     result = _wrap(
-        get_calendar_service, calendar_ops.search_events_op,
+        account_id, get_calendar_service, calendar_ops.search_events_op,
         query=query, time_min=time_min, time_max=time_max,
         max_results=max_results, calendar_id=calendar_id,
     )
@@ -347,20 +352,22 @@ def search_calendar_events(
 
 
 def find_free_slot(
+    account_id: str,
     duration_minutes: int,
     between_start: str,
     between_end: str,
     calendar_ids: list[str] | None = None,
 ) -> dict:
     return _wrap(
-        get_calendar_service, calendar_ops.find_free_slot_op,
+        account_id, get_calendar_service, calendar_ops.find_free_slot_op,
         duration_minutes=duration_minutes,
         between_start=between_start, between_end=between_end,
-        calendar_ids=calendar_ids, timezone_str=_user_timezone(),
+        calendar_ids=calendar_ids, timezone_str=_user_timezone(account_id),
     )
 
 
 def create_calendar_event(
+    account_id: str,
     summary: str,
     start: str,
     end: str,
@@ -370,15 +377,16 @@ def create_calendar_event(
     calendar_id: str = "primary",
 ) -> dict:
     return _wrap(
-        get_calendar_service, calendar_ops.create_event_op,
+        account_id, get_calendar_service, calendar_ops.create_event_op,
         summary=summary, start=start, end=end,
         description=description, location=location,
         attendees=attendees, calendar_id=calendar_id,
-        timezone_str=_user_timezone(),
+        timezone_str=_user_timezone(account_id),
     )
 
 
 def update_calendar_event(
+    account_id: str,
     event_id: str,
     calendar_id: str = "primary",
     summary: str | None = None,
@@ -389,68 +397,69 @@ def update_calendar_event(
     attendees: list[str] | None = None,
 ) -> dict:
     return _wrap(
-        get_calendar_service, calendar_ops.update_event_op,
+        account_id, get_calendar_service, calendar_ops.update_event_op,
         event_id=event_id, calendar_id=calendar_id,
         summary=summary, start=start, end=end,
         description=description, location=location, attendees=attendees,
-        timezone_str=_user_timezone(),
+        timezone_str=_user_timezone(account_id),
     )
 
 
-def delete_calendar_event(event_id: str, calendar_id: str = "primary") -> dict:
-    return _wrap(get_calendar_service, calendar_ops.delete_event_op,
+def delete_calendar_event(account_id: str, event_id: str, calendar_id: str = "primary") -> dict:
+    return _wrap(account_id, get_calendar_service, calendar_ops.delete_event_op,
                  event_id=event_id, calendar_id=calendar_id)
 
 
 # ── Drive ────────────────────────────────────────────────────────────────────
 
-def search_drive_files(query: str, max_results: int = 20) -> dict:
-    result = _wrap(get_drive_service, drive_ops.search_files_op,
+def search_drive_files(account_id: str, query: str, max_results: int = 20) -> dict:
+    result = _wrap(account_id, get_drive_service, drive_ops.search_files_op,
                    query=query, max_results=max_results)
     if isinstance(result, list):
         return {"count": len(result), "query": query, "files": result}
     return result
 
 
-def list_drive_folder(folder_id: str = "root", max_results: int = 50) -> dict:
-    result = _wrap(get_drive_service, drive_ops.list_folder_op,
+def list_drive_folder(account_id: str, folder_id: str = "root", max_results: int = 50) -> dict:
+    result = _wrap(account_id, get_drive_service, drive_ops.list_folder_op,
                    folder_id=folder_id, max_results=max_results)
     if isinstance(result, list):
         return {"count": len(result), "folder_id": folder_id, "files": result}
     return result
 
 
-def get_drive_file_info(file_id: str) -> dict:
-    return _wrap(get_drive_service, drive_ops.get_file_info_op, file_id=file_id)
+def get_drive_file_info(account_id: str, file_id: str) -> dict:
+    return _wrap(account_id, get_drive_service, drive_ops.get_file_info_op, file_id=file_id)
 
 
-def read_drive_file_content(file_id: str, max_chars: int = 50000) -> dict:
-    return _wrap(get_drive_service, drive_ops.read_file_content_op,
+def read_drive_file_content(account_id: str, file_id: str, max_chars: int = 50000) -> dict:
+    return _wrap(account_id, get_drive_service, drive_ops.read_file_content_op,
                  file_id=file_id, max_chars=max_chars)
 
 
-def create_drive_folder(name: str, parent_folder_id: str = "root") -> dict:
-    return _wrap(get_drive_service, drive_ops.create_folder_op,
+def create_drive_folder(account_id: str, name: str, parent_folder_id: str = "root") -> dict:
+    return _wrap(account_id, get_drive_service, drive_ops.create_folder_op,
                  name=name, parent_folder_id=parent_folder_id)
 
 
 def create_drive_file(
+    account_id: str,
     name: str, content: str = "", file_type: str = "document", folder_id: str = "root",
 ) -> dict:
-    return _wrap(get_drive_service, drive_ops.create_file_op,
+    return _wrap(account_id, get_drive_service, drive_ops.create_file_op,
                  name=name, content=content, file_type=file_type, folder_id=folder_id)
 
 
-def move_drive_file(file_id: str, new_parent_id: str) -> dict:
-    return _wrap(get_drive_service, drive_ops.move_file_op,
+def move_drive_file(account_id: str, file_id: str, new_parent_id: str) -> dict:
+    return _wrap(account_id, get_drive_service, drive_ops.move_file_op,
                  file_id=file_id, new_parent_id=new_parent_id)
 
 
-def rename_drive_file(file_id: str, new_name: str) -> dict:
-    return _wrap(get_drive_service, drive_ops.rename_file_op,
+def rename_drive_file(account_id: str, file_id: str, new_name: str) -> dict:
+    return _wrap(account_id, get_drive_service, drive_ops.rename_file_op,
                  file_id=file_id, new_name=new_name)
 
 
-def copy_drive_file(file_id: str, new_name: str | None = None, folder_id: str | None = None) -> dict:
-    return _wrap(get_drive_service, drive_ops.copy_file_op,
+def copy_drive_file(account_id: str, file_id: str, new_name: str | None = None, folder_id: str | None = None) -> dict:
+    return _wrap(account_id, get_drive_service, drive_ops.copy_file_op,
                  file_id=file_id, new_name=new_name, folder_id=folder_id)

--- a/backend/integrations/paperclip/webhook.py
+++ b/backend/integrations/paperclip/webhook.py
@@ -99,7 +99,7 @@ async def handle_heartbeat(request: Request):
     Execution: run_sync() with Paperclip tool mode forced to "power".
     Response: synchronous JSON with result text.
     """
-    from integrations.registry import get_credentials, get_tool_mode, is_enabled as _is_enabled
+    from integrations.registry import get_credentials, get_tool_mode
 
     try:
         payload = await request.json()
@@ -164,7 +164,11 @@ async def handle_heartbeat(request: Request):
                 status_code=500,
             )
 
-        google_connected = _is_enabled("google")
+        ga = config.google_accounts
+        gmail_account_id = ga.get("gmail", "")
+        calendar_account_id = ga.get("calendar", "")
+        drive_account_id = ga.get("drive", "")
+        google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
         integration_tool_defs, integration_executors = _load_integration_tools()
 
         # Force Paperclip writes to "power" — no approval UI in headless mode
@@ -179,6 +183,9 @@ async def handle_heartbeat(request: Request):
             agent_slug=slug,
             reminder_handlers=reminder_handlers,
             scheduled_action_handlers=sa_handlers,
+            gmail_account_id=gmail_account_id,
+            calendar_account_id=calendar_account_id,
+            drive_account_id=drive_account_id,
         )
 
         # 6. Build task message

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -14,6 +14,7 @@ Available integrations:
 
 import json
 import logging
+import threading
 from pathlib import Path
 
 from core.encryption import decrypt_dict, encrypt_dict, needs_migration
@@ -97,6 +98,8 @@ def is_enabled(name: str) -> bool:
         return False
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+        if name == "google":
+            return bool(data.get("accounts", {}))
         return bool(data.get("enabled", False))
     except Exception:
         return False
@@ -162,30 +165,178 @@ def set_tool_mode(name: str, mode: str) -> None:
     save_credentials(name, creds)
 
 
+# ── Google multi-account helpers ─────────────────────────────────────────────
+
+_GOOGLE_FILE_LOCK = threading.RLock()
+
+
+def _read_google_creds() -> dict:
+    """Read google.json (caller must hold _GOOGLE_FILE_LOCK)."""
+    return get_credentials("google")
+
+
+def _write_google_creds(data: dict) -> None:
+    """Write google.json (caller must hold _GOOGLE_FILE_LOCK)."""
+    ensure_dir()
+    encrypted = encrypt_dict(data)
+    atomic_write_json(_creds_path("google"), encrypted)
+
+
+def get_google_account(account_id: str) -> dict:
+    """Load a specific Google account's credentials by account_id."""
+    creds = get_credentials("google")
+    return creds.get("accounts", {}).get(account_id, {})
+
+
+def save_google_account(account_id: str, data: dict, create: bool = False) -> None:
+    """Save/update a single Google account within google.json.
+
+    When create=False (default, used by token refresh), refuses to save if
+    the account doesn't exist — prevents disconnect-vs-refresh races.
+    When create=True (used by onboarding), allows creating new entries.
+    """
+    with _GOOGLE_FILE_LOCK:
+        creds = _read_google_creds()
+        if "accounts" not in creds:
+            creds["accounts"] = {}
+        if not create and account_id not in creds["accounts"]:
+            logger.warning("Refusing to save non-existent account %s (deleted?)", account_id)
+            return
+        creds["accounts"][account_id] = data
+        _write_google_creds(creds)
+
+
+def delete_google_account(account_id: str) -> dict | None:
+    """Remove a Google account. Returns the removed account data or None."""
+    with _GOOGLE_FILE_LOCK:
+        creds = _read_google_creds()
+        accounts = creds.get("accounts", {})
+        removed = accounts.pop(account_id, None)
+        if removed is not None:
+            creds["accounts"] = accounts
+            _write_google_creds(creds)
+    if removed is not None:
+        try:
+            from integrations.google.client import _LOCKS_LOCK, _ACCOUNT_LOCKS
+            with _LOCKS_LOCK:
+                _ACCOUNT_LOCKS.pop(account_id, None)
+        except Exception:
+            pass
+    return removed
+
+
+def list_google_accounts() -> dict[str, dict]:
+    """Return all Google accounts {id: data}."""
+    creds = get_credentials("google")
+    return creds.get("accounts", {})
+
+
+def save_google_app_credentials(app_data: dict) -> None:
+    """Save Google OAuth app credentials (locked)."""
+    with _GOOGLE_FILE_LOCK:
+        creds = _read_google_creds()
+        creds["app"] = app_data
+        _write_google_creds(creds)
+
+
+def migrate_google_json() -> None:
+    """Migrate old flat google.json to multi-account format."""
+    import uuid
+
+    creds = get_credentials("google")
+    if not creds:
+        return
+    if "accounts" in creds:
+        return
+    if not creds.get("access_token"):
+        return
+
+    account_id = uuid.uuid4().hex[:8]
+    scope_grants = creds.get("scope_grants", {})
+
+    account_data = {
+        "email": creds.pop("email", ""),
+        "access_token": creds.pop("access_token", ""),
+        "refresh_token": creds.pop("refresh_token", ""),
+        "token_expires_at": creds.pop("token_expires_at", 0),
+        "scope_grants": creds.pop("scope_grants", {}),
+        "calendar_timezone": creds.pop("calendar_timezone", "UTC"),
+        "connection_status": creds.pop("connection_status", "ok"),
+    }
+
+    creds.pop("enabled", None)
+
+    creds["accounts"] = {account_id: account_data}
+    save_credentials("google", creds)
+
+    try:
+        from agents.db import list_agents, update_agent
+        ga = {}
+        if scope_grants.get("gmail", "none") != "none":
+            ga["gmail"] = account_id
+        if scope_grants.get("calendar", "none") != "none":
+            ga["calendar"] = account_id
+        if scope_grants.get("drive", "none") != "none":
+            ga["drive"] = account_id
+
+        if ga:
+            import json as _json
+            ga_str = _json.dumps(ga)
+            for agent in list_agents():
+                update_agent(agent["id"], google_accounts=ga_str)
+
+        logger.info("Migrated google.json to multi-account format (account_id=%s)", account_id)
+    except Exception as e:
+        logger.warning("Google migration: credential format updated but agent assignment failed: %s", e)
+
+
 def list_integrations() -> list[dict]:
     """Return all integrations with their status."""
     result = []
     for key, meta in AVAILABLE_INTEGRATIONS.items():
         creds = get_credentials(key)
         always_on = meta.get("always_on", False)
-        # For OAuth integrations, "configured" means tokens exist (not just app creds)
-        if meta.get("auth_type") in ("oauth2", "oauth2_scoped"):
+
+        if key == "google":
+            accounts = creds.get("accounts", {})
+            is_configured = any(
+                a.get("access_token") or a.get("refresh_token")
+                for a in accounts.values()
+            )
+            is_enabled_val = bool(accounts)
+        elif meta.get("auth_type") in ("oauth2", "oauth2_scoped"):
             is_configured = bool(creds.get("access_token") or creds.get("refresh_token"))
+            is_enabled_val = bool(creds.get("enabled", False))
         else:
             is_configured = bool(creds)
+            is_enabled_val = bool(creds.get("enabled", False))
 
         entry = {
             "id": key,
             **meta,
-            "enabled": True if always_on else bool(creds.get("enabled", False)),
+            "enabled": True if always_on else is_enabled_val,
             "configured": True if always_on else is_configured,
             "hidden": False,
             "connection_status": creds.get("connection_status", "ok") if creds else "ok",
             "tool_mode": creds.get("tool_mode", "normal"),
         }
         if key == "google" and creds:
-            entry["email"] = creds.get("email", "")
-            entry["scope_grants"] = creds.get("scope_grants", {})
+            accounts = creds.get("accounts", {})
+            entry["google_accounts"] = [
+                {
+                    "id": acct_id,
+                    "email": acct.get("email", ""),
+                    "scope_grants": acct.get("scope_grants", {}),
+                    "connection_status": acct.get("connection_status", "ok"),
+                }
+                for acct_id, acct in accounts.items()
+            ]
+            if len(accounts) == 1:
+                only = next(iter(accounts.values()))
+                entry["email"] = only.get("email", "")
+                entry["scope_grants"] = only.get("scope_grants", {})
+            if any(a.get("connection_status") == "broken" for a in accounts.values()):
+                entry["connection_status"] = "broken"
         if meta.get("auth_type") in ("oauth2", "oauth2_scoped"):
             from .app_credentials import has_app_credentials
             entry["has_app_credentials"] = has_app_credentials(key)

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -260,6 +260,7 @@ async def setup_google(body: GoogleSetupRequest, user=Depends(get_current_user))
                 "drive_level": body.drive_level,
                 "include_ai": include_ai,
             },
+            prompt="consent select_account",
         )
     except ValueError as e:
         logger.warning("Google OAuth setup failed: %s", e)
@@ -270,23 +271,12 @@ class GoogleCompleteRequest(BaseModel):
     flow_id: str
 
 
-@router.post("/google/setup/complete")
-async def setup_google_complete(body: GoogleCompleteRequest, user=Depends(get_current_user)):
-    """Finalize Google setup after the OAuth callback stashes tokens."""
-    from core.providers.oauth import consume_flow
-    from .google.onboarding import setup_from_oauth
-
-    flow = consume_flow(body.flow_id)
-    if not flow:
-        raise HTTPException(status_code=404, detail="OAuth flow not found or expired")
-    if flow.status != "ok" or not flow.tokens:
-        logger.warning("Google OAuth flow failed: %s", flow.error)
-        raise HTTPException(status_code=400, detail="OAuth flow failed. Please try again.")
-
+def _google_complete_common(flow, require_refresh_token: bool = True):
+    """Shared validation for both new-account and reconnect complete endpoints."""
     tokens = flow.tokens
     if not tokens.get("access_token"):
         raise HTTPException(status_code=400, detail="Google did not return an access token")
-    if not tokens.get("refresh_token"):
+    if require_refresh_token and not tokens.get("refresh_token"):
         raise HTTPException(
             status_code=400,
             detail="Google did not return a refresh token. Try disconnecting at "
@@ -300,20 +290,162 @@ async def setup_google_complete(body: GoogleCompleteRequest, user=Depends(get_cu
         "drive": meta.get("drive_level", "none"),
     }
 
+    return tokens, scope_grants
+
+
+@router.post("/google/setup/complete")
+async def setup_google_complete(body: GoogleCompleteRequest, user=Depends(get_current_user)):
+    """Finalize Google setup — creates a new account entry."""
+    from core.providers.oauth import consume_flow
+    from .google.onboarding import setup_from_oauth
+
+    flow = consume_flow(body.flow_id)
+    if not flow:
+        raise HTTPException(status_code=404, detail="OAuth flow not found or expired")
+    if flow.status != "ok" or not flow.tokens:
+        logger.warning("Google OAuth flow failed: %s", flow.error)
+        raise HTTPException(status_code=400, detail="OAuth flow failed. Please try again.")
+
+    tokens, scope_grants = _google_complete_common(flow, require_refresh_token=True)
+
     result = await setup_from_oauth(
         access_token=tokens["access_token"],
         refresh_token=tokens["refresh_token"],
         expires_in=tokens.get("expires_in", 3600),
         scope_grants=scope_grants,
     )
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Setup failed"))
+    return result
+
+
+@router.get("/google/accounts")
+async def list_google_accounts_endpoint(user=Depends(get_current_user)):
+    """List all connected Google accounts (sanitized — no tokens)."""
+    from .registry import list_google_accounts as _list
+    accounts = _list()
+    return {
+        "accounts": [
+            {
+                "id": aid,
+                "email": a.get("email", ""),
+                "scope_grants": a.get("scope_grants", {}),
+                "connection_status": a.get("connection_status", "ok"),
+            }
+            for aid, a in accounts.items()
+        ]
+    }
+
+
+import re as _re
+_ACCOUNT_ID_RE = _re.compile(r"^[0-9a-f]{8}$")
+
+
+def _validate_account_id(account_id: str) -> None:
+    if not _ACCOUNT_ID_RE.match(account_id):
+        raise HTTPException(status_code=400, detail="Invalid account_id format")
+
+
+@router.post("/google/{account_id}/setup")
+async def setup_google_account(account_id: str, body: GoogleSetupRequest, user=Depends(get_current_user)):
+    """Start OAuth to reconnect/change scopes for an existing account."""
+    _validate_account_id(account_id)
+    from core.providers.oauth import start_oauth_flow
+    from core.config import build_google_scopes
+    from .registry import get_google_account
+
+    existing = get_google_account(account_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Google account not found")
+
+    if body.gmail_level == "none" and body.calendar_level == "none" and body.drive_level == "none":
+        raise HTTPException(status_code=400, detail="At least one scope must be enabled")
+
+    from core.providers.credentials import CredentialStore
+    store = CredentialStore()
+    include_ai = store.data.get("active_provider") == "google"
+
+    scopes = build_google_scopes(
+        gmail_level=body.gmail_level,
+        calendar_level=body.calendar_level,
+        drive_level=body.drive_level,
+        include_ai=include_ai,
+    )
+
+    try:
+        return start_oauth_flow(
+            "google",
+            scopes=scopes,
+            metadata={
+                "gmail_level": body.gmail_level,
+                "calendar_level": body.calendar_level,
+                "drive_level": body.drive_level,
+                "include_ai": include_ai,
+                "account_id": account_id,
+            },
+            prompt="consent",
+        )
+    except ValueError as e:
+        logger.warning("Google OAuth setup failed: %s", e)
+        raise HTTPException(status_code=400, detail="Google OAuth is not configured.")
+
+
+@router.post("/google/{account_id}/setup/complete")
+async def setup_google_account_complete(account_id: str, body: GoogleCompleteRequest, user=Depends(get_current_user)):
+    """Finalize reconnect for an existing account. Verifies email matches."""
+    _validate_account_id(account_id)
+    from core.providers.oauth import consume_flow
+    from .google.onboarding import setup_from_oauth
+    from .registry import get_google_account
+
+    flow = consume_flow(body.flow_id)
+    if not flow:
+        raise HTTPException(status_code=404, detail="OAuth flow not found or expired")
+    if flow.status != "ok" or not flow.tokens:
+        raise HTTPException(status_code=400, detail="OAuth flow failed. Please try again.")
+
+    flow_account_id = (flow.metadata or {}).get("account_id", "")
+    if flow_account_id != account_id:
+        raise HTTPException(status_code=400, detail="OAuth flow was started for a different account")
+
+    tokens, scope_grants = _google_complete_common(flow, require_refresh_token=False)
+
+    refresh_token = tokens.get("refresh_token", "")
+    if not refresh_token:
+        existing = get_google_account(account_id)
+        refresh_token = existing.get("refresh_token", "")
+    if not refresh_token:
+        raise HTTPException(
+            status_code=400,
+            detail="Google did not return a refresh token. Try disconnecting at "
+                   "https://myaccount.google.com/permissions then reconnect.",
+        )
+
+    result = await setup_from_oauth(
+        access_token=tokens["access_token"],
+        refresh_token=refresh_token,
+        expires_in=tokens.get("expires_in", 3600),
+        scope_grants=scope_grants,
+        account_id=account_id,
+    )
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Setup failed"))
     return result
 
 
 @router.post("/google/disconnect")
 async def disconnect_google(user=Depends(get_current_user)):
-    """Revoke Google OAuth + clear stored credentials."""
+    """Disconnect ALL Google accounts."""
     from .google.onboarding import disconnect
     return await disconnect()
+
+
+@router.post("/google/{account_id}/disconnect")
+async def disconnect_google_account(account_id: str, user=Depends(get_current_user)):
+    """Disconnect a specific Google account."""
+    _validate_account_id(account_id)
+    from .google.onboarding import disconnect
+    return await disconnect(account_id=account_id)
 
 
 @router.post("/qb_csv/setup")
@@ -413,7 +545,13 @@ async def save_app_creds(name: str, body: AppCredentialsRequest, user=Depends(ge
 
     # If connected and credentials changed, disconnect first
     did_disconnect = False
-    has_tokens = bool(creds.get("access_token") or creds.get("refresh_token"))
+    if name == "google":
+        has_tokens = any(
+            a.get("access_token") or a.get("refresh_token")
+            for a in creds.get("accounts", {}).values()
+        )
+    else:
+        has_tokens = bool(creds.get("access_token") or creds.get("refresh_token"))
     if has_tokens:
         old_app = creds.get("app") or {}
         changed = (
@@ -444,7 +582,13 @@ async def delete_app_creds(name: str, user=Depends(get_current_user)):
         raise HTTPException(status_code=400, detail="App credentials only apply to OAuth integrations")
     from .registry import get_credentials
     creds = get_credentials(name)
-    has_tokens = bool(creds.get("access_token") or creds.get("refresh_token"))
+    if name == "google":
+        has_tokens = any(
+            a.get("access_token") or a.get("refresh_token")
+            for a in creds.get("accounts", {}).values()
+        )
+    else:
+        has_tokens = bool(creds.get("access_token") or creds.get("refresh_token"))
     if has_tokens:
         if name == "quickbooks":
             await disconnect_quickbooks()

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -179,8 +179,11 @@ async def process_message(
     if not provider:
         return "No AI provider is configured. Please set up an AI provider in Settings."
 
-    from integrations.registry import is_enabled as _is_enabled
-    google_connected = _is_enabled("google")
+    ga = config.google_accounts
+    gmail_account_id = ga.get("gmail", "")
+    calendar_account_id = ga.get("calendar", "")
+    drive_account_id = ga.get("drive", "")
+    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
@@ -195,6 +198,9 @@ async def process_message(
         agent_slug=slug,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
+        gmail_account_id=gmail_account_id,
+        calendar_account_id=calendar_account_id,
+        drive_account_id=drive_account_id,
     )
 
     # 5. Get/create Telegram conversation for multi-turn context
@@ -264,8 +270,11 @@ async def process_group_message(
     if not provider:
         return "No AI provider is configured. Please set up an AI provider in Settings."
 
-    from integrations.registry import is_enabled as _is_enabled
-    google_connected = _is_enabled("google")
+    ga = config.google_accounts
+    gmail_account_id = ga.get("gmail", "")
+    calendar_account_id = ga.get("calendar", "")
+    drive_account_id = ga.get("drive", "")
+    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
@@ -280,6 +289,9 @@ async def process_group_message(
         agent_slug=slug,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
+        gmail_account_id=gmail_account_id,
+        calendar_account_id=calendar_account_id,
+        drive_account_id=drive_account_id,
     )
 
     group_sender_id = f"group:{chat_id}"

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -178,8 +178,11 @@ def _process_message_locked(
 
     # 8. Build tool registry
     store = CredentialStore()
-    from integrations.registry import is_enabled as _is_enabled
-    google_connected = _is_enabled("google")
+    ga = config.google_accounts
+    gmail_account_id = ga.get("gmail", "")
+    calendar_account_id = ga.get("calendar", "")
+    drive_account_id = ga.get("drive", "")
+    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
@@ -205,16 +208,26 @@ def _process_message_locked(
         agent_slug=agent_slug,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
+        gmail_account_id=gmail_account_id,
+        calendar_account_id=calendar_account_id,
+        drive_account_id=drive_account_id,
     )
 
     # 9. Build tool definitions
     dynamic_real_tools = load_all_real_tools(agent_slug)
     from integrations.google.policy import google_capabilities
-    google_caps = google_capabilities()
+    gmail_caps = google_capabilities(gmail_account_id)
+    cal_caps = google_capabilities(calendar_account_id)
+    drive_caps = google_capabilities(drive_account_id)
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs or None,
         dynamic_real_tools=dynamic_real_tools or None,
-        **google_caps,
+        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
+        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
+        calendar_read_enabled=cal_caps["calendar_read_enabled"],
+        calendar_write_enabled=cal_caps["calendar_write_enabled"],
+        drive_read_enabled=drive_caps["drive_read_enabled"],
+        drive_write_enabled=drive_caps["drive_write_enabled"],
     )
 
     # Apply integration permission ceilings — messaging channels have no approval UI,

--- a/backend/main.py
+++ b/backend/main.py
@@ -90,8 +90,9 @@ async def lifespan(app: FastAPI):
     from integrations.crm_lite.db import init_db as init_crm_db
     _safe_init("crm_lite", init_crm_db)
 
-    from integrations.registry import is_enabled as integration_enabled, ensure_crm_active
+    from integrations.registry import is_enabled as integration_enabled, ensure_crm_active, migrate_google_json
     ensure_crm_active()
+    migrate_google_json()
 
     if integration_enabled("qb_csv"):
         from integrations.qb_csv.db import init_db as init_qb_csv_db

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -15,6 +15,7 @@ export interface Agent {
   calendar_write_enabled?: boolean;
   drive_enabled?: boolean;
   drive_write_enabled?: boolean;
+  google_accounts?: { gmail?: string; calendar?: string; drive?: string };
   whatsapp_session_id?: string;
   telegram_enabled: boolean;
   telegram_bot_token?: string;
@@ -48,6 +49,13 @@ export interface GoogleScopeGrants {
   gmail: GmailScopeLevel;
   calendar: CalendarScopeLevel;
   drive: DriveScopeLevel;
+}
+
+export interface GoogleAccount {
+  id: string;
+  email: string;
+  scope_grants: GoogleScopeGrants;
+  connection_status: string;
 }
 
 export interface Conversation {
@@ -99,6 +107,7 @@ export interface Integration {
   tool_mode?: string;
   email?: string;
   scope_grants?: GoogleScopeGrants;
+  google_accounts?: GoogleAccount[];
   has_app_credentials?: boolean;
 }
 

--- a/frontend/src/dashboard/GoogleIntegrationCard.tsx
+++ b/frontend/src/dashboard/GoogleIntegrationCard.tsx
@@ -4,6 +4,8 @@ import { useOAuthFlow } from '../core/hooks/useOAuthFlow';
 import { AppCredentialsForm } from './AppCredentialsForm';
 import type {
   Integration,
+  Agent,
+  GoogleAccount,
   GmailScopeLevel,
   CalendarScopeLevel,
   DriveScopeLevel,
@@ -11,7 +13,7 @@ import type {
 
 interface Props {
   integration: Integration;
-  onChanged: () => void;  // parent re-fetches integrations list
+  onChanged: () => void;
 }
 
 const GMAIL_OPTIONS: { value: GmailScopeLevel; label: string; hint: string }[] = [
@@ -33,16 +35,46 @@ const DRIVE_OPTIONS: { value: DriveScopeLevel; label: string; hint: string }[] =
   { value: 'full',      label: 'Full access', hint: 'Read, write, and delete any Drive file. Most powerful; requires verification.' },
 ];
 
+function scopeSummary(grants: GoogleAccount['scope_grants']) {
+  return [
+    grants.gmail !== 'none' && `Gmail: ${grants.gmail === 'send' ? 'read+send' : grants.gmail}`,
+    grants.calendar !== 'none' && `Calendar: ${grants.calendar}`,
+    grants.drive !== 'none' && `Drive: ${grants.drive}`,
+  ].filter(Boolean).join(' \u00b7 ');
+}
+
 export function GoogleIntegrationCard({ integration, onChanged }: Props) {
   const [pickerOpen, setPickerOpen] = useState(false);
-  const [gmail, setGmail]       = useState<GmailScopeLevel>(integration.scope_grants?.gmail ?? 'none');
-  const [calendar, setCalendar] = useState<CalendarScopeLevel>(integration.scope_grants?.calendar ?? 'none');
-  const [drive, setDrive]       = useState<DriveScopeLevel>(integration.scope_grants?.drive ?? 'none');
-  const [disconnecting, setDisconnecting] = useState(false);
-  const [localError, setLocalError] = useState<string>('');
+  const [editingAccountId, setEditingAccountId] = useState('');
+  const [gmail, setGmail]       = useState<GmailScopeLevel>('none');
+  const [calendar, setCalendar] = useState<CalendarScopeLevel>('none');
+  const [drive, setDrive]       = useState<DriveScopeLevel>('none');
+  const [disconnecting, setDisconnecting] = useState('');
+  const [localError, setLocalError] = useState('');
   const [showCredForm, setShowCredForm] = useState(false);
   const [existingCreds, setExistingCreds] = useState<{ client_id?: string; redirect_uri?: string; source?: 'stored' | 'env' }>({});
+  const [assignmentsOpen, setAssignmentsOpen] = useState(false);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [savingAgent, setSavingAgent] = useState('');
   const hasAppCreds = integration.has_app_credentials !== false;
+  const accounts = integration.google_accounts || [];
+
+  const oauth = useOAuthFlow();
+
+  useEffect(() => {
+    if (oauth.state.status === 'success') {
+      setPickerOpen(false);
+      setEditingAccountId('');
+      onChanged();
+      oauth.reset();
+    }
+  }, [oauth.state.status]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (assignmentsOpen && agents.length === 0) {
+      api<{ agents: Agent[] }>('/api/agents').then(data => setAgents(data.agents)).catch(() => {});
+    }
+  }, [assignmentsOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function openCredForm() {
     setLocalError('');
@@ -55,21 +87,14 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
     setShowCredForm(true);
   }
 
-  useEffect(() => {
-    setGmail(integration.scope_grants?.gmail ?? 'none');
-    setCalendar(integration.scope_grants?.calendar ?? 'none');
-    setDrive(integration.scope_grants?.drive ?? 'none');
-  }, [integration.scope_grants?.gmail, integration.scope_grants?.calendar, integration.scope_grants?.drive]);
-
-  const oauth = useOAuthFlow();
-
-  useEffect(() => {
-    if (oauth.state.status === 'success') {
-      setPickerOpen(false);
-      onChanged();
-      oauth.reset();
-    }
-  }, [oauth.state.status]);  // eslint-disable-line react-hooks/exhaustive-deps
+  function openScopePicker(accountId: string = '', acct?: GoogleAccount) {
+    setEditingAccountId(accountId);
+    setGmail(acct?.scope_grants?.gmail ?? 'none');
+    setCalendar(acct?.scope_grants?.calendar ?? 'none');
+    setDrive(acct?.scope_grants?.drive ?? 'none');
+    setPickerOpen(true);
+    setLocalError('');
+  }
 
   const anyGranted = gmail !== 'none' || calendar !== 'none' || drive !== 'none';
 
@@ -79,112 +104,108 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
       setLocalError('Enable at least one of Gmail, Calendar, or Drive.');
       return;
     }
+    const base = editingAccountId
+      ? `/api/integrations/google/${editingAccountId}/setup`
+      : '/api/integrations/google/setup';
+    const complete = editingAccountId
+      ? `/api/integrations/google/${editingAccountId}/setup/complete`
+      : '/api/integrations/google/setup/complete';
     await oauth.start({
-      setupUrl: '/api/integrations/google/setup',
+      setupUrl: base,
       setupBody: { gmail_level: gmail, calendar_level: calendar, drive_level: drive },
-      completeUrl: '/api/integrations/google/setup/complete',
+      completeUrl: complete,
     });
   }
 
-  async function disconnect() {
-    setDisconnecting(true); setLocalError('');
+  async function disconnectAccount(accountId: string) {
+    setDisconnecting(accountId); setLocalError('');
     try {
-      await api('/api/integrations/google/disconnect', { method: 'POST' });
+      await api(`/api/integrations/google/${accountId}/disconnect`, { method: 'POST' });
       onChanged();
+      setAgents([]);
     } catch (err: unknown) {
       setLocalError(err instanceof Error ? err.message : 'Disconnect failed');
     } finally {
-      setDisconnecting(false);
+      setDisconnecting('');
     }
+  }
+
+  async function updateAgentAccount(agentId: string, service: 'gmail' | 'calendar' | 'drive', accountId: string) {
+    setSavingAgent(agentId);
+    const agent = agents.find(a => a.id === agentId);
+    const current = agent?.google_accounts || {};
+    const updated = { ...current, [service]: accountId };
+    try {
+      await api(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ google_accounts: updated }),
+      });
+      const data = await api<{ agents: Agent[] }>('/api/agents');
+      setAgents(data.agents);
+    } catch (err: unknown) {
+      setLocalError(err instanceof Error ? err.message : 'Failed to update agent');
+    } finally {
+      setSavingAgent('');
+    }
+  }
+
+  function accountsForService(service: 'gmail' | 'calendar' | 'drive') {
+    return accounts.filter(a => {
+      const g = a.scope_grants;
+      if (service === 'gmail') return g.gmail !== 'none';
+      if (service === 'calendar') return g.calendar !== 'none';
+      return g.drive !== 'none';
+    });
   }
 
   const isRunning = oauth.state.status === 'starting' ||
                     oauth.state.status === 'awaiting_user' ||
                     oauth.state.status === 'completing';
 
-  const isBroken = integration.configured && integration.connection_status === 'broken';
-  const isConnected = integration.configured && !isBroken;
-
-  // Grants label summary
-  const grants = integration.scope_grants;
-  const grantsSummary = grants ? [
-    grants.gmail !== 'none' && `Gmail: ${grants.gmail === 'send' ? 'read+send' : grants.gmail}`,
-    grants.calendar !== 'none' && `Calendar: ${grants.calendar}`,
-    grants.drive !== 'none' && `Drive: ${grants.drive}`,
-  ].filter(Boolean).join(' · ') : '';
-
   return (
     <div className="bg-gray-800 rounded-xl p-4 border border-gray-700">
+      {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <span className="text-2xl">{integration.icon}</span>
           <div>
             <p className="text-white font-medium">{integration.name}</p>
-            <p className="text-gray-400 text-xs mt-0.5">{integration.description}</p>
-            {isConnected && integration.email && (
-              <p className="text-gray-300 text-xs mt-1">
-                Connected as <span className="text-indigo-300">{integration.email}</span>
-                {grantsSummary && <span className="text-gray-500 ml-2">· {grantsSummary}</span>}
-              </p>
-            )}
+            <p className="text-gray-400 text-xs mt-0.5">
+              {accounts.length === 0
+                ? integration.description
+                : `${accounts.length} account${accounts.length > 1 ? 's' : ''} connected`}
+            </p>
           </div>
         </div>
-
         <div className="flex items-center gap-2">
-          {isBroken && (
-            <>
-              <span className="text-xs text-red-400 bg-red-900/20 px-2 py-1 rounded">Connection lost</span>
-              <button
-                onClick={() => hasAppCreds ? setPickerOpen(true) : openCredForm()}
-                disabled={isRunning}
-                className="text-xs px-3 py-1.5 rounded-lg bg-red-600 text-white hover:bg-red-500 transition disabled:opacity-50"
-              >
-                {hasAppCreds ? 'Reconnect' : 'Setup credentials'}
-              </button>
-            </>
-          )}
-
-          {!integration.configured && (
-            <button
-              onClick={() => {
-                setLocalError('');
-                if (hasAppCreds) setPickerOpen(true);
-                else openCredForm();
-              }}
-              disabled={isRunning}
-              className="text-xs px-3 py-1.5 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600 transition disabled:opacity-50"
-            >
-              {isRunning ? 'Connecting...' : hasAppCreds ? 'Connect' : 'Setup'}
+          {accounts.length === 0 && !hasAppCreds && (
+            <button onClick={openCredForm} disabled={isRunning}
+              className="text-xs px-3 py-1.5 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600 transition disabled:opacity-50">
+              Setup
             </button>
           )}
-
-          {isConnected && (
+          {accounts.length === 0 && hasAppCreds && (
+            <button onClick={() => openScopePicker()} disabled={isRunning}
+              className="text-xs px-3 py-1.5 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600 transition disabled:opacity-50">
+              {isRunning ? 'Connecting...' : 'Connect'}
+            </button>
+          )}
+          {accounts.length > 0 && (
             <>
-              <button
-                onClick={() => setPickerOpen(true)}
-                disabled={isRunning || disconnecting}
-                className="text-xs px-3 py-1.5 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600 transition disabled:opacity-50"
-              >
-                Change scopes
+              <button onClick={() => openScopePicker()} disabled={isRunning}
+                className="text-xs px-3 py-1.5 rounded-lg bg-brand text-white hover:opacity-90 transition disabled:opacity-50">
+                + Add Account
               </button>
-              <button
-                onClick={openCredForm}
-                className="text-xs px-2 py-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700 transition"
-              >
+              <button onClick={openCredForm}
+                className="text-xs px-2 py-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700 transition">
                 Edit credentials
-              </button>
-              <button
-                onClick={disconnect}
-                disabled={disconnecting || isRunning}
-                className="text-xs px-2 py-1.5 rounded-lg text-gray-500 hover:text-red-400 hover:bg-gray-700 transition disabled:opacity-50"
-              >
-                {disconnecting ? 'Disconnecting...' : 'Disconnect'}
               </button>
             </>
           )}
         </div>
       </div>
 
+      {/* Error / OAuth status */}
       {localError && <p className="mt-2 text-red-400 text-xs">{localError}</p>}
       {oauth.state.status === 'error' && oauth.state.error && (
         <p className="mt-2 text-red-400 text-xs">{oauth.state.error}</p>
@@ -198,6 +219,7 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
         </p>
       )}
 
+      {/* App credentials form */}
       {showCredForm && (
         <AppCredentialsForm
           integration="google"
@@ -209,46 +231,105 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
         />
       )}
 
+      {/* Connected accounts list */}
+      {accounts.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {accounts.map(acct => (
+            <div key={acct.id} className="flex items-center justify-between bg-gray-900/50 rounded-lg px-3 py-2">
+              <div>
+                <p className="text-white text-xs font-medium">
+                  {acct.email}
+                  {acct.connection_status === 'broken' && (
+                    <span className="ml-2 text-red-400 text-[10px] bg-red-900/20 px-1.5 py-0.5 rounded">Connection lost</span>
+                  )}
+                </p>
+                <p className="text-gray-500 text-[11px] mt-0.5">{scopeSummary(acct.scope_grants)}</p>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <button onClick={() => openScopePicker(acct.id, acct)} disabled={isRunning}
+                  className="text-[11px] px-2 py-1 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 transition disabled:opacity-50">
+                  {acct.connection_status === 'broken' ? 'Reconnect' : 'Change scopes'}
+                </button>
+                <button onClick={() => disconnectAccount(acct.id)} disabled={disconnecting === acct.id || isRunning}
+                  className="text-[11px] px-2 py-1 rounded text-gray-500 hover:text-red-400 hover:bg-gray-700 transition disabled:opacity-50">
+                  {disconnecting === acct.id ? '...' : 'Disconnect'}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Agent Assignments */}
+      {accounts.length > 0 && (
+        <div className="mt-3">
+          <button onClick={() => setAssignmentsOpen(!assignmentsOpen)}
+            className="text-xs text-gray-400 hover:text-gray-200 transition flex items-center gap-1">
+            <span className={`transition-transform ${assignmentsOpen ? 'rotate-90' : ''}`}>&#9654;</span>
+            Agent Assignments
+          </button>
+          {assignmentsOpen && (
+            <div className="mt-2 space-y-2">
+              {agents.length === 0 && <p className="text-gray-500 text-xs">No agents created yet.</p>}
+              {agents.map(agent => {
+                const ga = agent.google_accounts || {};
+                return (
+                  <div key={agent.id} className="bg-gray-900/30 rounded-lg px-3 py-2">
+                    <p className="text-white text-xs font-medium mb-1.5">{agent.agent_name}</p>
+                    <div className="grid grid-cols-3 gap-2">
+                      {(['gmail', 'calendar', 'drive'] as const).map(svc => {
+                        const available = accountsForService(svc);
+                        return (
+                          <div key={svc}>
+                            <label className="text-gray-500 text-[10px] uppercase tracking-wide block mb-0.5">
+                              {svc === 'gmail' ? 'Gmail' : svc === 'calendar' ? 'Calendar' : 'Drive'}
+                            </label>
+                            <select
+                              value={ga[svc] || ''}
+                              onChange={e => updateAgentAccount(agent.id, svc, e.target.value)}
+                              disabled={savingAgent === agent.id}
+                              className="w-full bg-gray-800 text-gray-300 text-[11px] rounded px-1.5 py-1 border border-gray-700 focus:border-indigo-500 outline-none disabled:opacity-50"
+                            >
+                              <option value="">None</option>
+                              {available.map(a => (
+                                <option key={a.id} value={a.id}>{a.email}</option>
+                              ))}
+                            </select>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Scope picker panel */}
       {pickerOpen && (
         <div className="mt-4 pt-4 border-t border-gray-700 space-y-4">
           <p className="text-gray-400 text-xs">
-            Pick the access levels you want to grant Chatty. You can change these later by reconnecting.
-            Chatty only requests the scopes you select on Google's consent screen.
+            {editingAccountId
+              ? 'Update the access levels for this account. You\'ll re-authorize on Google\'s consent screen.'
+              : 'Pick the access levels for the new Google account.'}
           </p>
-
-          <ScopeGroup
-            title="Gmail"
-            options={GMAIL_OPTIONS}
-            value={gmail}
-            onChange={(v) => setGmail(v as GmailScopeLevel)}
-          />
-          <ScopeGroup
-            title="Google Calendar"
-            options={CALENDAR_OPTIONS}
-            value={calendar}
-            onChange={(v) => setCalendar(v as CalendarScopeLevel)}
-          />
-          <ScopeGroup
-            title="Google Drive"
-            options={DRIVE_OPTIONS}
-            value={drive}
-            onChange={(v) => setDrive(v as DriveScopeLevel)}
-          />
+          <ScopeGroup title="Gmail" options={GMAIL_OPTIONS} value={gmail}
+            onChange={(v) => setGmail(v as GmailScopeLevel)} />
+          <ScopeGroup title="Google Calendar" options={CALENDAR_OPTIONS} value={calendar}
+            onChange={(v) => setCalendar(v as CalendarScopeLevel)} />
+          <ScopeGroup title="Google Drive" options={DRIVE_OPTIONS} value={drive}
+            onChange={(v) => setDrive(v as DriveScopeLevel)} />
 
           <div className="flex gap-2 pt-2">
-            <button
-              onClick={() => setPickerOpen(false)}
-              disabled={isRunning}
-              className="flex-1 py-2 text-sm rounded-lg border border-gray-600 text-gray-400 hover:bg-gray-700 transition disabled:opacity-50"
-            >
+            <button onClick={() => { setPickerOpen(false); setEditingAccountId(''); }} disabled={isRunning}
+              className="flex-1 py-2 text-sm rounded-lg border border-gray-600 text-gray-400 hover:bg-gray-700 transition disabled:opacity-50">
               Cancel
             </button>
-            <button
-              onClick={connect}
-              disabled={isRunning || !anyGranted}
-              className="flex-1 py-2 text-sm rounded-lg bg-brand text-white font-medium disabled:opacity-50"
-            >
-              {isRunning ? 'Connecting...' : (isConnected ? 'Reconnect with these scopes' : 'Connect Google')}
+            <button onClick={connect} disabled={isRunning || !anyGranted}
+              className="flex-1 py-2 text-sm rounded-lg bg-brand text-white font-medium disabled:opacity-50">
+              {isRunning ? 'Connecting...' : editingAccountId ? 'Reconnect' : 'Connect Google Account'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **Multiple Google accounts**: Connect unlimited Google accounts (personal, workspace, etc.) from Settings > Integrations. Each account gets its own OAuth tokens, scope grants, and connection status tracked independently in `google.json`.
- **Per-agent, per-service assignment**: Assign different Google accounts to each agent for Gmail, Calendar, and Drive independently via dropdown selectors — both in the Google integration card and individual agent settings. Scope-filtered dropdowns prevent invalid assignments.
- **Backward-compatible migration**: Existing single-account `google.json` is automatically migrated to multi-account format on first startup, with the account auto-assigned to all agents. No manual intervention required.

## Changes

### Backend (17 files)
- `google.json` schema: flat → `{accounts: {id: {email, tokens, scope_grants, ...}}}` with `app` and `tool_mode` preserved at top level
- New `google_accounts` TEXT column on agents table storing `{"gmail": "acc_id", "calendar": "acc_id", "drive": "acc_id"}`
- Account-aware client layer: all service factories, tool functions, and `google_capabilities()` take `account_id`
- Per-account token refresh locks + file-level RLock for concurrent safety
- 6 new/modified API endpoints for account CRUD
- Validation: account_id format (`^[0-9a-f]{8}$`), scope checking, email verification on reconnect, duplicate email dedup, stale assignment cleanup on scope downgrade
- All 8 ToolRegistry construction sites updated (router, ai_service, telegram, whatsapp, paperclip, router_factory)

### Frontend (2 files)
- `GoogleIntegrationCard`: multi-account list with per-account change scopes/disconnect, "+" to add, collapsible Agent Assignments grid
- New `GoogleAccount` type, extended `Agent` and `Integration` types

## Test plan

- [ ] Start app with existing single-account google.json → verify auto-migration + all agents assigned
- [ ] Add a second Google account via "+" button → verify both appear in card
- [ ] Assign Gmail from account A and Calendar from account B to an agent → verify correct account used per service in chat
- [ ] Disconnect one account → verify agent references cleared, other account unaffected
- [ ] Verify scope-filtered dropdowns (account without Drive scope doesn't appear in Drive dropdown)
- [ ] Reconnect an existing account with wrong Google identity → verify email mismatch rejection
- [ ] Change BYO OAuth app credentials with connected accounts → verify warning about existing connections
- [ ] Test via Telegram/WhatsApp messaging path → verify correct account used