### PR TITLE
Fix heartbeat time bug and add integration tools to reminder execution

### DIFF
--- a/backend/agents/tool_loader.py
+++ b/backend/agents/tool_loader.py
@@ -6,6 +6,8 @@ actions processor can build a full tool set with integration parity.
 
 import importlib
 import logging
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from core.agents.reminders.tools import (
     create_reminder_handler,
@@ -20,6 +22,17 @@ from core.agents.scheduled_actions.tools import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def format_current_time(tz_name: str = "America/Chicago") -> tuple[str, str]:
+    """Return (date_str, time_str) for system prompt injection."""
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = ZoneInfo("America/Chicago")
+    now = datetime.now(tz)
+    return now.strftime("%A, %B %d, %Y"), now.strftime("%I:%M %p %Z")
+
 
 INTEGRATION_MODULES = {
     "crm_lite": ("integrations.crm_lite.tools", "CRM_LITE_TOOL_DEFS"),

--- a/backend/core/agents/background_runner.py
+++ b/backend/core/agents/background_runner.py
@@ -30,7 +30,7 @@ class BackgroundResult:
 
 
 async def _run_turn(
-    system_prompt: str,
+    system_prompt: "str | tuple[str, str]",
     user_message: str,
     tool_defs: list[dict],
     registry: ToolRegistry,
@@ -164,7 +164,7 @@ async def _run_turn(
 
 
 def run_background_turn(
-    system_prompt: str,
+    system_prompt: "str | tuple[str, str]",
     user_message: str,
     tool_defs: list[dict],
     registry: ToolRegistry,

--- a/backend/core/agents/reminders/heartbeat.py
+++ b/backend/core/agents/reminders/heartbeat.py
@@ -8,8 +8,6 @@ import logging
 
 from . import service
 from core.agents.background_runner import run_background_turn
-from core.agents.tool_registry import ToolRegistry
-from core.agents.tool_definitions import get_tool_definitions
 
 logger = logging.getLogger(__name__)
 
@@ -65,23 +63,70 @@ def _process_self_reminder(reminder: dict) -> None:
     context = ctx_manager.load_all_context()
     context_snippet = context[:30000] if context else "(no context files)"
 
+    from agents.tool_loader import format_current_time
+    date_str, time_str = format_current_time()
+
     system_prompt = (
-        f"You are {agent['agent_name']}, a helpful AI assistant.\n\n"
-        f"# Reminder Triggered\n\n"
-        f"A reminder you set has fired. Take appropriate action.\n\n"
-        f"- **Message:** {reminder['message']}\n"
-        f"- **Context:** {reminder.get('context') or 'None'}\n"
-        f"- **Originally set at:** {reminder['created_at']}\n\n"
-        f"# Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
-        f"Take any appropriate action using your tools. Be concise."
+        (
+            f"You are {agent['agent_name']}, a helpful AI assistant.\n\n"
+            f"# Reminder Triggered\n\n"
+            f"A reminder you set has fired. Take appropriate action.\n\n"
+            f"- **Message:** {reminder['message']}\n"
+            f"- **Context:** {reminder.get('context') or 'None'}\n"
+            f"- **Originally set at:** {reminder['created_at']}\n\n"
+            f"# Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
+        ),
+        (
+            f"# Current Date & Time\n\n"
+            f"- Date: {date_str}\n"
+            f"- Time: {time_str}\n\n"
+            f"Take any appropriate action using your tools. Be concise."
+        ),
     )
 
     user_message = f"Your reminder just fired: {reminder['message']}"
 
-    tool_defs = get_tool_definitions(web_enabled=True)
+    from agents.tool_loader import load_integration_tools, build_agent_handlers, INTEGRATION_MODULES
+    from agents.engine import build_agent_config
+    from integrations.registry import is_enabled as _is_enabled, get_tool_mode
+    from integrations.google.policy import google_capabilities
+    from core.agents.tool_registry import ToolRegistry
+    from core.agents.tool_definitions import get_tool_definitions
+    from core.agents.tools.real_tools import load_all_real_tools
+    from pathlib import Path
+
+    config = build_agent_config(agent)
+    google_connected = _is_enabled("google")
+    integration_tool_defs, integration_executors = load_integration_tools()
+    google_caps = google_capabilities()
+    reminder_handlers, sa_handlers = build_agent_handlers(agent["slug"])
+
+    real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
+    dynamic_real_tools = load_all_real_tools(real_tools_dir)
+
+    tool_defs = get_tool_definitions(
+        integration_tools=integration_tool_defs,
+        dynamic_real_tools=dynamic_real_tools or None,
+        web_enabled=True,
+        **google_caps,
+    )
+
+    integration_modes = {name: get_tool_mode(name) for name in INTEGRATION_MODULES}
+    tool_defs = [
+        t for t in tool_defs
+        if not (t.get("integration") and t.get("writes")
+                and integration_modes.get(t["integration"]) == "read-only")
+    ]
+
     registry = ToolRegistry(
-        context_dir=str(DATA_DIR / agent["slug"] / "context"),
+        context_dir=config.context_dir,
+        gcs_prefix=config.gcs_prefix,
+        google_connected=google_connected,
+        integration_executors=integration_executors,
         agent_slug=agent["slug"],
+        agent_name=config.agent_name,
+        reminder_handlers=reminder_handlers,
+        scheduled_action_handlers=sa_handlers,
     )
 
     try:

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -329,12 +329,8 @@ def _process_heartbeat(action: dict) -> None:
     model_override = action.get("model_override") or agent.get("model_override") or None
 
     tz_name = action.get("active_hours_tz") or "America/Chicago"
-    try:
-        tz = ZoneInfo(tz_name)
-    except Exception:
-        tz = ZoneInfo("America/Chicago")
-    now_local = datetime.now(tz)
-    now_str = now_local.strftime(f"%Y-%m-%d %I:%M %p {now_local.strftime('%Z')}")
+    from agents.tool_loader import format_current_time
+    date_str, time_str = format_current_time(tz_name)
 
     context = ctx_manager.load_all_context()
     context_snippet = context[:30000] if context else "(no context files)"
@@ -349,7 +345,7 @@ def _process_heartbeat(action: dict) -> None:
             triage_result = run_background_turn(
                 system_prompt=(
                     f"You are {agent['agent_name']}.\n\n"
-                    f"# Quick Heartbeat Triage\n\n"
+                    f"# Quick Heartbeat Triage — {date_str}, {time_str}\n\n"
                     f"Quickly check the following items using your tools. "
                     f"Respond with ONLY one of:\n"
                     f"- NEEDS_ACTION: <brief reason>\n"
@@ -425,17 +421,24 @@ def _process_heartbeat(action: dict) -> None:
         error_context = _build_error_context(action, agent_slug)
 
         system_prompt = (
-            f"You are {agent['agent_name']}.\n\n"
-            f"# Heartbeat Check — {now_str}\n\n"
-            f"You are performing a periodic heartbeat check. Review your checklist "
-            f"and check each item against current data using your tools.\n\n"
-            f"## Your Checklist\n\n{checklist}\n\n"
-            f"## Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
-            f"## Rules\n\n"
-            f"- If everything is normal and no action is needed, respond with exactly: HEARTBEAT_OK\n"
-            f"- If something needs attention, take action and respond with: ACTION_TAKEN: <brief description>\n"
-            f"- Be concise. This is an automated check, not a conversation.\n"
-            f"{error_context}"
+            (
+                f"You are {agent['agent_name']}.\n\n"
+                f"# Heartbeat Check\n\n"
+                f"You are performing a periodic heartbeat check. Review your checklist "
+                f"and check each item against current data using your tools.\n\n"
+                f"## Your Checklist\n\n{checklist}\n\n"
+                f"## Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
+            ),
+            (
+                f"# Current Date & Time\n\n"
+                f"- Date: {date_str}\n"
+                f"- Time: {time_str}\n\n"
+                f"## Rules\n\n"
+                f"- If everything is normal and no action is needed, respond with exactly: HEARTBEAT_OK\n"
+                f"- If something needs attention, take action and respond with: ACTION_TAKEN: <brief description>\n"
+                f"- Be concise. This is an automated check, not a conversation.\n"
+                f"{error_context}"
+            ),
         )
 
         result = run_background_turn(
@@ -530,12 +533,23 @@ def _process_cron(action: dict) -> None:
     provider_override = agent.get("provider_override") or None
     model_override = action.get("model_override") or agent.get("model_override") or None
 
+    tz_name = action.get("active_hours_tz") or "America/Chicago"
+    from agents.tool_loader import format_current_time
+    date_str, time_str = format_current_time(tz_name)
+
     system_prompt = (
-        f"You are {agent['agent_name']}.\n\n"
-        f"# Scheduled Action: {action.get('name', 'Unnamed')}\n\n"
-        f"{prompt}\n\n"
-        f"# Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
-        f"Take appropriate action using your tools. Be concise."
+        (
+            f"You are {agent['agent_name']}.\n\n"
+            f"# Scheduled Action: {action.get('name', 'Unnamed')}\n\n"
+            f"{prompt}\n\n"
+            f"# Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
+        ),
+        (
+            f"# Current Date & Time\n\n"
+            f"- Date: {date_str}\n"
+            f"- Time: {time_str}\n\n"
+            f"Take appropriate action using your tools. Be concise."
+        ),
     )
 
     tool_defs, registry = _build_tools(agent_slug, agent)


### PR DESCRIPTION
## Summary

- **Time bug**: Agent hallucinated wrong dates (June 2025, July 2026, etc.) because the timestamp was buried in a heading before 30,000 chars of context files. Moved time to a dedicated `# Current Date & Time` section AFTER context (matching the interactive chat pattern where time is the last thing before the user message). Also added time to cron and triage prompts where it was completely missing.
- **Reminder tools**: Reminders created a bare ToolRegistry without Gmail, Calendar, Drive, CRM, or any integration tools. Wired up the same `_build_tools` pattern already used by heartbeat/cron (from PR #81's `tool_loader.py`).
- **Prompt caching**: Updated `background_runner.py` to accept `(static, volatile)` tuple system prompts, enabling Anthropic prompt caching on background turns.

## Test plan

- [ ] Start dev server and wait for heartbeat tick — activity log should show correct current date/time
- [ ] Agent should NOT say "Let me check the current time" or guess at dates
- [ ] Create a test reminder ("remind me in 2 min to check email") — verify integration tools work when it fires
- [ ] Verify `search_emails` returns real data in reminder execution (not "Google not connected" error)
- [ ] If a cron job is configured, verify it shows correct time
- [ ] Check server logs for import errors