### PR TITLE
Add unified activity logging, export, and agent log tool

### DIFF
--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -950,5 +950,5 @@ async def get_agent_activity(
 ):
     agent = _get_agent_or_404(agent_id)
     from core.agents.scheduled_actions.history import get_history
-    records = get_history(agent=agent["slug"], limit=limit)
+    records = get_history(agent=agent["slug"], limit=limit, event_type="scheduled_action")
     return {"activities": records}

--- a/backend/core/agents/activity_log.py
+++ b/backend/core/agents/activity_log.py
@@ -1,0 +1,72 @@
+"""Chatty — Unified activity log for chat events.
+
+Logs completed chat turns into the execution_history table alongside
+scheduled action records. Provides a single activity stream across
+web chat, Telegram, WhatsApp, and Paperclip.
+"""
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from core.agents.reminders import db
+
+logger = logging.getLogger(__name__)
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _normalize_tool_calls(tool_calls: list[dict]) -> list[dict]:
+    """Normalize tool call shapes: rename elapsed_ms → duration_ms."""
+    normalized = []
+    for tc in tool_calls:
+        entry = dict(tc)
+        if "elapsed_ms" in entry and "duration_ms" not in entry:
+            entry["duration_ms"] = entry.pop("elapsed_ms")
+        normalized.append(entry)
+    return normalized
+
+
+def log_chat_event(
+    agent: str,
+    *,
+    conversation_id: str = "",
+    source: str = "chat",
+    status: str = "ok",
+    result_summary: str = "",
+    tool_calls: list | None = None,
+    model_used: str = "",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    duration_ms: int = 0,
+) -> str:
+    """Record a completed chat turn in the unified activity log."""
+    event_id = str(uuid.uuid4())
+    now = _now_utc()
+
+    if tool_calls:
+        tool_calls = _normalize_tool_calls(tool_calls)
+    tool_calls_json = json.dumps(tool_calls)[:10240] if tool_calls else None
+
+    conn = db.get_db()
+    with db.write_lock():
+        conn.execute(
+            """INSERT INTO execution_history
+               (id, action_id, agent, action_type, event_type, source,
+                conversation_id, started_at, completed_at, status,
+                result_summary, tool_calls, model_used,
+                input_tokens, output_tokens, duration_ms)
+               VALUES (?, ?, ?, 'chat', 'chat', ?,
+                       ?, ?, ?, ?,
+                       ?, ?, ?,
+                       ?, ?, ?)""",
+            (event_id, event_id, agent, source,
+             conversation_id, now, now, status,
+             result_summary[:500], tool_calls_json, model_used,
+             input_tokens, output_tokens, duration_ms),
+        )
+        conn.commit()
+    return event_id

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -508,6 +508,45 @@ def _build_kind_map(tool_defs: list[dict]) -> dict[str, str]:
     return {t["name"]: t.get("kind", "context") for t in tool_defs}
 
 
+# ── Activity log helper ───────────────────────────────────────────────────────
+
+def _log_chat_completion(
+    agent_slug: str,
+    conversation_id: str | None,
+    source: str,
+    status: str,
+    accumulated_text: str,
+    all_tool_calls: list,
+    model_used: str,
+    total_input_tokens: int,
+    total_output_tokens: int,
+    chat_start_time: float,
+) -> None:
+    try:
+        from core.agents.activity_log import log_chat_event
+        tool_error_count = sum(
+            1 for tc in (all_tool_calls or [])
+            if isinstance(tc.get("result"), str) and '"error"' in tc["result"]
+        )
+        summary = accumulated_text[:500]
+        if tool_error_count and status == "ok":
+            summary = f"[{tool_error_count} tool error(s)] {summary}"
+        log_chat_event(
+            agent=agent_slug,
+            conversation_id=conversation_id or "",
+            source=source,
+            status=status,
+            result_summary=summary,
+            tool_calls=all_tool_calls or None,
+            model_used=model_used,
+            input_tokens=total_input_tokens,
+            output_tokens=total_output_tokens,
+            duration_ms=int((time.time() - chat_start_time) * 1000),
+        )
+    except Exception:
+        logger.warning("Activity log write failed", exc_info=True)
+
+
 # ── Main chat coroutine ────────────────────────────────────────────────────────
 
 async def chat(
@@ -549,6 +588,11 @@ async def chat(
         approved_tool: Previously confirmed tool execution result to reconstruct
         integration_tool_modes: Per-integration permission ceilings (e.g. {"odoo": "read-only"})
     """
+    chat_start_time = time.time()
+    total_input_tokens = 0
+    total_output_tokens = 0
+    model_used = getattr(provider, "model", "") or ""
+
     # Validate tool_mode
     if tool_mode not in ("read-only", "normal", "power"):
         tool_mode = "normal"
@@ -794,9 +838,11 @@ async def chat(
                 tool_calls_this_turn = event.get("tool_calls", [])
                 stop_reason = event.get("stop_reason", "stop")
 
-                # Emit usage event
+                # Emit usage event and track totals
                 usage = event.get("usage", {})
                 if usage:
+                    total_input_tokens += usage.get("input_tokens", 0)
+                    total_output_tokens += usage.get("output_tokens", 0)
                     yield _sse({
                         "type": "usage",
                         "input_tokens": usage.get("input_tokens", 0),
@@ -829,15 +875,24 @@ async def chat(
 
                 # If no tool calls, we're done
                 if stop_reason != "tool_use" or not tool_calls_this_turn:
+                    _log_chat_completion(config.slug, conversation_id, "chat", "ok",
+                                        accumulated_text, all_tool_calls, model_used,
+                                        total_input_tokens, total_output_tokens, chat_start_time)
                     yield _sse({"type": "done"})
                     return
 
             elif etype == "error":
+                _log_chat_completion(config.slug, conversation_id, "chat", "error",
+                                    event.get("error", "Unknown error"), all_tool_calls, model_used,
+                                    total_input_tokens, total_output_tokens, chat_start_time)
                 yield _sse({"type": "error", "error": event.get("error", "Unknown error")})
                 return
 
         # ── Execute tool calls ────────────────────────────────────────
         if not tool_calls_this_turn:
+            _log_chat_completion(config.slug, conversation_id, "chat", "ok",
+                                accumulated_text, all_tool_calls, model_used,
+                                total_input_tokens, total_output_tokens, chat_start_time)
             yield _sse({"type": "done"})
             return
 
@@ -873,6 +928,9 @@ async def chat(
                         yield _sse({"type": "text", "text": event["text"]})
                     elif etype == "_turn_complete":
                         break
+                _log_chat_completion(config.slug, conversation_id, "chat", "ok",
+                                    accumulated_text, all_tool_calls, model_used,
+                                    total_input_tokens, total_output_tokens, chat_start_time)
                 yield _sse({"type": "done"})
                 return
 
@@ -951,10 +1009,16 @@ async def chat(
                     yield _sse({"type": "text", "text": event["text"]})
                 elif etype == "_turn_complete":
                     break
+            _log_chat_completion(config.slug, conversation_id, "chat", "ok",
+                                accumulated_text, all_tool_calls, model_used,
+                                total_input_tokens, total_output_tokens, chat_start_time)
             yield _sse({"type": "done"})
             return
 
     # Exceeded max iterations
+    _log_chat_completion(config.slug, conversation_id, "chat", "error",
+                        "Tool loop exceeded maximum iterations", all_tool_calls, model_used,
+                        total_input_tokens, total_output_tokens, chat_start_time)
     yield _sse({"type": "error", "error": "Tool loop exceeded maximum iterations"})
 
 
@@ -970,6 +1034,7 @@ async def run_sync(
     conversation_id: str | None = None,
     integration_tool_defs: list[dict] | None = None,
     integration_tool_modes: dict[str, str] | None = None,
+    source: str = "chat",
 ) -> str:
     """Run an agent synchronously, returning the final text response.
 
@@ -980,6 +1045,9 @@ async def run_sync(
     Works with any AIProvider (Anthropic, OpenAI, Google Gemini).
     Supports full multi-turn tool execution loop.
     """
+    chat_start_time = time.time()
+    model_used = getattr(provider, "model", "") or ""
+
     # Build tool definitions (same as streaming path)
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
@@ -1063,6 +1131,8 @@ async def run_sync(
     current_messages = list(messages)
     accumulated_text = ""
     all_tool_calls: list[dict] = []
+    total_input_tokens = 0
+    total_output_tokens = 0
     max_iterations = 20
 
     for iteration in range(max_iterations):
@@ -1081,9 +1151,15 @@ async def run_sync(
             elif etype == "_turn_complete":
                 tool_calls_this_turn = event.get("tool_calls", [])
                 stop_reason = event.get("stop_reason", "stop")
+                usage = event.get("usage", {})
+                total_input_tokens += usage.get("input_tokens", 0)
+                total_output_tokens += usage.get("output_tokens", 0)
 
             elif etype == "error":
                 logger.error("run_sync: provider error: %s", event.get("error"))
+                _log_chat_completion(config.slug, conversation_id, source, "error",
+                                    event.get("error", "Provider error"), all_tool_calls, model_used,
+                                    total_input_tokens, total_output_tokens, chat_start_time)
                 return accumulated_text or "I encountered an error. Please try again."
 
         # Save assistant turn to history (with tool calls)
@@ -1102,6 +1178,9 @@ async def run_sync(
 
         # If no tool calls, we're done
         if stop_reason != "tool_use" or not tool_calls_this_turn:
+            _log_chat_completion(config.slug, conversation_id, source, "ok",
+                                accumulated_text, all_tool_calls, model_used,
+                                total_input_tokens, total_output_tokens, chat_start_time)
             break
 
         # Execute tool calls (power mode — no confirmation flow for messaging)
@@ -1139,5 +1218,9 @@ async def run_sync(
 
         # Append tool results for next turn
         current_messages = provider.add_tool_results(current_messages, tool_calls_this_turn, results)
+    else:
+        _log_chat_completion(config.slug, conversation_id, source, "error",
+                            "Tool loop exceeded maximum iterations", all_tool_calls, model_used,
+                            total_input_tokens, total_output_tokens, chat_start_time)
 
     return accumulated_text or "I had trouble generating a response. Please try again."

--- a/backend/core/agents/background_runner.py
+++ b/backend/core/agents/background_runner.py
@@ -172,29 +172,69 @@ def run_background_turn(
     model_override: str | None = None,
     provider_override: str | None = None,
     on_iteration: Callable[[int], bool] | None = None,
+    source: str | None = None,
 ) -> BackgroundResult:
     """Synchronous wrapper for running a background AI turn.
 
     Creates a new event loop if needed (e.g., from APScheduler thread).
+    When ``source`` is provided (e.g. "whatsapp"), logs a chat event
+    after execution. Scheduled actions pass source=None since they
+    already log via history.py.
     """
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
+    t0 = time.time()
 
-    if loop and loop.is_running():
-        import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(
-                asyncio.run,
+    try:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(
+                    asyncio.run,
+                    _run_turn(system_prompt, user_message, tool_defs, registry,
+                              max_iterations, model_override, provider_override,
+                              on_iteration)
+                )
+                result = future.result(timeout=300)
+        else:
+            result = asyncio.run(
                 _run_turn(system_prompt, user_message, tool_defs, registry,
                           max_iterations, model_override, provider_override,
                           on_iteration)
             )
-            return future.result(timeout=300)
-    else:
-        return asyncio.run(
-            _run_turn(system_prompt, user_message, tool_defs, registry,
-                      max_iterations, model_override, provider_override,
-                      on_iteration)
-        )
+    except Exception as exc:
+        if source:
+            try:
+                from core.agents.activity_log import log_chat_event
+                log_chat_event(
+                    agent=getattr(registry, "agent_slug", "unknown"),
+                    source=source,
+                    status="error",
+                    result_summary=str(exc)[:500],
+                    duration_ms=int((time.time() - t0) * 1000),
+                )
+            except Exception:
+                logger.warning("Activity log write failed", exc_info=True)
+        raise
+
+    if source:
+        try:
+            from core.agents.activity_log import log_chat_event
+            log_chat_event(
+                agent=getattr(registry, "agent_slug", "unknown"),
+                source=source,
+                status="error" if result.error else "ok",
+                result_summary=result.text[:500],
+                tool_calls=result.tool_log or None,
+                model_used=result.model_used,
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+                duration_ms=int((time.time() - t0) * 1000),
+            )
+        except Exception:
+            logger.warning("Activity log write failed", exc_info=True)
+
+    return result

--- a/backend/core/agents/reminders/db.py
+++ b/backend/core/agents/reminders/db.py
@@ -168,6 +168,17 @@ def _setup_connection() -> None:
     _connection.execute("CREATE INDEX IF NOT EXISTS idx_sa_lease ON scheduled_actions(lease_id, leased_until)")
     _connection.commit()
 
+    # Migration: add unified activity log columns to execution_history
+    eh_cols = {r[1] for r in _connection.execute("PRAGMA table_info(execution_history)").fetchall()}
+    if "event_type" not in eh_cols:
+        _connection.execute("ALTER TABLE execution_history ADD COLUMN event_type TEXT DEFAULT 'scheduled_action'")
+    if "source" not in eh_cols:
+        _connection.execute("ALTER TABLE execution_history ADD COLUMN source TEXT DEFAULT 'system'")
+    if "conversation_id" not in eh_cols:
+        _connection.execute("ALTER TABLE execution_history ADD COLUMN conversation_id TEXT")
+    _connection.execute("CREATE INDEX IF NOT EXISTS idx_eh_event_type ON execution_history(event_type, started_at DESC)")
+    _connection.commit()
+
     logger.info("Reminders DB initialized at %s", DB_PATH)
 
 

--- a/backend/core/agents/scheduled_actions/history.py
+++ b/backend/core/agents/scheduled_actions/history.py
@@ -72,6 +72,8 @@ def get_history(
     limit: int = 50,
     offset: int = 0,
     status_filter: str | None = None,
+    event_type: str | None = None,
+    since: str | None = None,
 ) -> list[dict]:
     conn = db.get_db()
     query = "SELECT * FROM execution_history WHERE 1=1"
@@ -83,6 +85,15 @@ def get_history(
     if action_id:
         query += " AND action_id = ?"
         params.append(action_id)
+    if event_type:
+        if event_type == "scheduled_action":
+            query += " AND (event_type = 'scheduled_action' OR event_type IS NULL)"
+        else:
+            query += " AND event_type = ?"
+            params.append(event_type)
+    if since:
+        query += " AND started_at >= ?"
+        params.append(since)
     if status_filter:
         if status_filter == "action_taken":
             query += " AND status NOT IN ('ok', 'skipped', 'running', 'lease_lost')"
@@ -145,15 +156,20 @@ def get_recent_errors(agent: str, action_id: str | None = None, limit: int = 3) 
 
 def cleanup_old(retention_days: int = 7) -> int:
     conn = db.get_db()
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).strftime(
-        "%Y-%m-%dT%H:%M:%S"
-    )
+    now = datetime.now(timezone.utc)
+    sa_cutoff = (now - timedelta(days=retention_days)).strftime("%Y-%m-%dT%H:%M:%S")
+    chat_cutoff = (now - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%S")
     with db.write_lock():
-        cursor = conn.execute(
-            "DELETE FROM execution_history WHERE started_at < ?", (cutoff,)
+        c1 = conn.execute(
+            "DELETE FROM execution_history WHERE (event_type = 'scheduled_action' OR event_type IS NULL) AND started_at < ?",
+            (sa_cutoff,),
+        )
+        c2 = conn.execute(
+            "DELETE FROM execution_history WHERE event_type = 'chat' AND started_at < ?",
+            (chat_cutoff,),
         )
         conn.commit()
-        deleted = cursor.rowcount
+        deleted = c1.rowcount + c2.rowcount
     if deleted:
         logger.info("Cleaned up %d old execution history records", deleted)
     return deleted

--- a/backend/core/agents/scheduled_actions/router.py
+++ b/backend/core/agents/scheduled_actions/router.py
@@ -30,6 +30,7 @@ class UpdateActionRequest(BaseModel):
 # -- Static routes (must come before /{agent_slug} to avoid capture) ------
 
 _VALID_LOG_STATUSES = {"ok", "error", "action_taken", "skipped", "running", "lease_lost"}
+_VALID_EVENT_TYPES = {"scheduled_action", "chat"}
 
 
 @router.get("/logs")
@@ -37,13 +38,102 @@ async def get_system_logs(
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
     status: str | None = None,
+    event_type: str | None = None,
+    agent: str | None = None,
     user=Depends(get_current_user),
 ):
     if status and status not in _VALID_LOG_STATUSES:
         raise HTTPException(status_code=400, detail=f"Invalid status filter: {status}")
+    if event_type and event_type not in _VALID_EVENT_TYPES:
+        raise HTTPException(status_code=400, detail=f"Invalid event_type: {event_type}")
     from . import history
-    records = history.get_history(limit=limit, offset=offset, status_filter=status)
+    records = history.get_history(
+        agent=agent, limit=limit, offset=offset,
+        status_filter=status, event_type=event_type,
+    )
     return {"logs": records}
+
+
+@router.get("/logs/export")
+async def export_logs(
+    format: str = Query("json"),
+    agent: str | None = None,
+    event_type: str | None = None,
+    status: str | None = None,
+    days: int = Query(7, ge=1, le=90),
+    user=Depends(get_current_user),
+):
+    """Export activity logs as JSON, CSV, or plain text."""
+    import csv
+    import io
+    from datetime import datetime, timedelta, timezone
+    from starlette.responses import Response
+
+    if format not in ("json", "csv", "text"):
+        raise HTTPException(status_code=400, detail="format must be json, csv, or text")
+    if event_type and event_type not in _VALID_EVENT_TYPES:
+        raise HTTPException(status_code=400, detail=f"Invalid event_type: {event_type}")
+    if status and status not in _VALID_LOG_STATUSES:
+        raise HTTPException(status_code=400, detail=f"Invalid status: {status}")
+
+    from . import history
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%S")
+    records = history.get_history(
+        agent=agent, limit=10000, event_type=event_type, since=since,
+        status_filter=status,
+    )
+
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    if format == "json":
+        import json as _json
+        content = _json.dumps(records, indent=2, default=str)
+        return Response(
+            content=content,
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="chatty-logs-{date_str}.json"'},
+        )
+
+    if format == "csv":
+
+        def _sanitize_csv_cell(val: str) -> str:
+            if val and val[0] in ("=", "+", "-", "@"):
+                return "'" + val
+            return val
+
+        buf = io.StringIO()
+        fieldnames = [
+            "started_at", "agent", "event_type", "action_type", "source",
+            "status", "result_summary", "model_used",
+            "input_tokens", "output_tokens", "duration_ms", "tool_call_count",
+        ]
+        writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for rec in records:
+            row = {k: _sanitize_csv_cell("" if rec.get(k) is None else str(rec.get(k))) for k in fieldnames}
+            tc = rec.get("tool_calls")
+            row["tool_call_count"] = str(len(tc) if isinstance(tc, list) else 0)
+            writer.writerow(row)
+        return Response(
+            content=buf.getvalue(),
+            media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="chatty-logs-{date_str}.csv"'},
+        )
+
+    # Plain text
+    lines = []
+    for rec in records:
+        ts = rec.get("started_at", "")
+        ag = rec.get("agent", "")
+        et = rec.get("event_type", rec.get("action_type", ""))
+        st = rec.get("status", "")
+        summary = rec.get("result_summary", "") or ""
+        lines.append(f"[{ts}] {ag} | {et} | {st} | {summary}")
+    return Response(
+        content="\n".join(lines),
+        media_type="text/plain",
+        headers={"Content-Disposition": f'attachment; filename="chatty-logs-{date_str}.txt"'},
+    )
 
 
 @router.get("/dashboard")

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1354,6 +1354,40 @@ def build_context_memory_map(tool_defs: list[dict]) -> dict[str, bool]:
     return {t["name"]: t.get("context_memory", False) for t in tool_defs}
 
 
+# ── Activity log tools ────────────────────────────────────────────────────────
+
+ACTIVITY_LOG_TOOLS = [
+    {
+        "name": "read_activity_log",
+        "description": (
+            "Read your recent activity log — chat history summaries, scheduled action "
+            "results, tool calls, and errors. Use this to recall what you've done "
+            "recently or check for errors."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "event_type": {
+                    "type": "string",
+                    "description": "Filter: 'chat', 'scheduled_action', or omit for all",
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Filter: 'ok', 'error', 'action_taken', or omit for all",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Number of recent entries (default 20, max 50)",
+                },
+            },
+            "required": [],
+        },
+        "kind": "activity_log",
+        "writes": False,
+    },
+]
+
+
 def get_tool_definitions(
     gmail_enabled: bool = False,
     calendar_enabled: bool = False,
@@ -1429,6 +1463,7 @@ def get_tool_definitions(
     if integration_tools:
         tools.extend(integration_tools)
     tools.extend(SETUP_TOOLS)
+    tools.extend(ACTIVITY_LOG_TOOLS)
     # Append agent-created real tools (loaded from filesystem)
     if dynamic_real_tools:
         tools.extend(dynamic_real_tools)

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -134,6 +134,8 @@ class ToolRegistry:
                 return self._execute_setup(tool_name, tool_args)
             elif kind == "import":
                 return self._execute_import(tool_name, tool_args)
+            elif kind == "activity_log":
+                return self._execute_activity_log(tool_name, tool_args)
             else:
                 return {"error": f"Unknown tool kind: {kind}"}
         except Exception as e:
@@ -480,6 +482,36 @@ class ToolRegistry:
         session = getattr(self, "_import_session", None)
         ctx_manager = ContextManager(Path(self.context_dir), gcs_prefix=self.gcs_prefix)
         return execute_import_tool(tool_name, args, session, ctx_manager)
+
+    def _execute_activity_log(self, tool_name: str, args: dict) -> dict:
+        from core.agents.scheduled_actions.history import get_history
+        try:
+            limit = max(1, min(int(args.get("limit", 20) or 20), 50))
+        except (TypeError, ValueError):
+            limit = 20
+        event_type = args.get("event_type")
+        if event_type and event_type not in ("scheduled_action", "chat"):
+            return {"error": f"Invalid event_type: {event_type}"}
+        status = args.get("status")
+        if status and status not in ("ok", "error", "action_taken", "skipped"):
+            return {"error": f"Invalid status: {status}"}
+        records = get_history(
+            agent=self.agent_slug,
+            limit=limit,
+            status_filter=status,
+            event_type=event_type,
+        )
+        for r in records:
+            r.pop("result_full", None)
+            r.pop("notification_sent", None)
+            if r.get("result_summary"):
+                r["result_summary"] = r["result_summary"][:200]
+            if isinstance(r.get("tool_calls"), list):
+                r["tool_calls"] = [
+                    {"tool": tc.get("tool", ""), "result": str(tc.get("result", ""))[:200]}
+                    for tc in r["tool_calls"]
+                ]
+        return {"entries": records, "count": len(records)}
 
     def _mark_setup_complete(self, integration_name: str) -> None:
         """Auto-update _pending-setup.md to check off a completed integration."""

--- a/backend/integrations/paperclip/webhook.py
+++ b/backend/integrations/paperclip/webhook.py
@@ -206,6 +206,7 @@ async def handle_heartbeat(request: Request):
             messages=messages,
             integration_tool_defs=integration_tool_defs or None,
             integration_tool_modes=integration_tool_modes,
+            source="paperclip",
         )
 
         logger.info("Paperclip heartbeat complete: agent=%s len=%d", slug, len(result_text or ""))

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -234,6 +234,7 @@ async def process_message(
         conversation_id=chatty_conv_id,
         integration_tool_defs=integration_tool_defs or None,
         integration_tool_modes=integration_tool_modes,
+        source="telegram",
     )
 
     return response or "I had trouble generating a response. Please try again."
@@ -320,6 +321,7 @@ async def process_group_message(
         conversation_id=chatty_conv_id,
         integration_tool_defs=integration_tool_defs or None,
         integration_tool_modes=integration_tool_modes,
+        source="telegram-group",
     )
 
     return response or "I had trouble generating a response. Please try again."

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -240,6 +240,7 @@ def _process_message_locked(
         registry=registry,
         max_iterations=5,
         model_override=config.model_override or None,
+        source="whatsapp",
     )
 
     response_text = result.text

--- a/frontend/src/dashboard/LogsTab.tsx
+++ b/frontend/src/dashboard/LogsTab.tsx
@@ -1,10 +1,14 @@
 import { useState, useEffect, useRef } from 'react';
 import { api } from '../core/api/client';
+import type { Agent } from '../core/types';
 
 interface LogRecord {
   id: string;
   agent: string;
   action_type: string;
+  event_type: string | null;
+  source: string | null;
+  conversation_id: string | null;
   started_at: string;
   completed_at: string | null;
   status: string;
@@ -18,6 +22,7 @@ interface LogRecord {
 }
 
 type StatusFilter = 'all' | 'ok' | 'error' | 'action_taken';
+type EventTypeFilter = 'all' | 'scheduled_action' | 'chat';
 
 const STATUS_COLORS: Record<string, string> = {
   ok: '#8EA589',
@@ -26,6 +31,11 @@ const STATUS_COLORS: Record<string, string> = {
   lease_lost: '#D97757',
   skipped: '#6B7280',
   running: '#60A5FA',
+};
+
+const EVENT_TYPE_COLORS: Record<string, string> = {
+  scheduled_action: '#D4A85A',
+  chat: '#60A5FA',
 };
 
 function formatTime(iso: string): string {
@@ -45,17 +55,29 @@ function formatTokens(n: number): string {
 export function LogsTab() {
   const [logs, setLogs] = useState<LogRecord[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState<StatusFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [eventTypeFilter, setEventTypeFilter] = useState<EventTypeFilter>('all');
+  const [agentFilter, setAgentFilter] = useState<string>('all');
+  const [agents, setAgents] = useState<Agent[]>([]);
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [expanded, setExpanded] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
   const intervalRef = useRef<number | null>(null);
 
-  async function fetchLogs(statusFilter: StatusFilter) {
+  useEffect(() => {
+    api<{ agents: Agent[] }>('/api/agents').then(d => setAgents(d.agents)).catch(() => {});
+  }, []);
+
+  async function fetchLogs() {
     try {
       setError(null);
-      const params = statusFilter !== 'all' ? `?status=${statusFilter}` : '';
-      const result = await api<{ logs: LogRecord[] }>(`/api/scheduled-actions/logs${params}`);
+      const params = new URLSearchParams();
+      if (statusFilter !== 'all') params.set('status', statusFilter);
+      if (eventTypeFilter !== 'all') params.set('event_type', eventTypeFilter);
+      if (agentFilter !== 'all') params.set('agent', agentFilter);
+      const qs = params.toString();
+      const result = await api<{ logs: LogRecord[] }>(`/api/scheduled-actions/logs${qs ? `?${qs}` : ''}`);
       setLogs(result.logs);
     } catch {
       setError('Failed to load logs.');
@@ -66,35 +88,69 @@ export function LogsTab() {
 
   useEffect(() => {
     setLoading(true);
-    fetchLogs(filter);
-  }, [filter]);
+    fetchLogs();
+  }, [statusFilter, eventTypeFilter, agentFilter]);
 
   useEffect(() => {
     if (autoRefresh) {
-      intervalRef.current = window.setInterval(() => fetchLogs(filter), 30000);
+      intervalRef.current = window.setInterval(() => fetchLogs(), 30000);
     }
     return () => {
       if (intervalRef.current) window.clearInterval(intervalRef.current);
     };
-  }, [autoRefresh, filter]);
+  }, [autoRefresh, statusFilter, eventTypeFilter, agentFilter]);
 
-  const filters: { id: StatusFilter; label: string }[] = [
+  async function handleExport(format: string) {
+    setExporting(true);
+    try {
+      const token = sessionStorage.getItem('chatty_token');
+      const params = new URLSearchParams({ format, days: '30' });
+      if (agentFilter !== 'all') params.set('agent', agentFilter);
+      if (eventTypeFilter !== 'all') params.set('event_type', eventTypeFilter);
+      if (statusFilter !== 'all') params.set('status', statusFilter);
+      const res = await fetch(`/api/scheduled-actions/logs/export?${params}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error('Export failed');
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const ext = format === 'json' ? 'json' : format === 'csv' ? 'csv' : 'txt';
+      a.download = `chatty-logs-${new Date().toISOString().slice(0, 10)}.${ext}`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError('Export failed.');
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  const statusFilters: { id: StatusFilter; label: string }[] = [
     { id: 'all', label: 'All' },
     { id: 'ok', label: 'OK' },
     { id: 'action_taken', label: 'Activity' },
     { id: 'error', label: 'Errors' },
   ];
 
+  const eventTypeFilters: { id: EventTypeFilter; label: string }[] = [
+    { id: 'all', label: 'All Types' },
+    { id: 'scheduled_action', label: 'Scheduled' },
+    { id: 'chat', label: 'Chat' },
+  ];
+
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
+      {/* Filters row */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
         <div className="flex gap-1">
-          {filters.map(f => (
+          {statusFilters.map(f => (
             <button
               key={f.id}
-              onClick={() => setFilter(f.id)}
+              onClick={() => setStatusFilter(f.id)}
               className={`px-3 py-1.5 text-xs rounded-md transition-colors ${
-                filter === f.id
+                statusFilter === f.id
                   ? 'bg-ch-accent/20 text-ch-accent font-medium'
                   : 'text-ch-ink-dim hover:text-ch-ink hover:bg-ch-bg-raised/50'
               }`}
@@ -114,6 +170,53 @@ export function LogsTab() {
         </label>
       </div>
 
+      {/* Event type + agent + export row */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex gap-1">
+          {eventTypeFilters.map(f => (
+            <button
+              key={f.id}
+              onClick={() => setEventTypeFilter(f.id)}
+              className={`px-3 py-1.5 text-xs rounded-md transition-colors ${
+                eventTypeFilter === f.id
+                  ? 'bg-ch-accent/20 text-ch-accent font-medium'
+                  : 'text-ch-ink-dim hover:text-ch-ink hover:bg-ch-bg-raised/50'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+          {agents.length > 1 && (
+            <select
+              value={agentFilter}
+              onChange={e => setAgentFilter(e.target.value)}
+              className="ml-2 px-2 py-1 text-xs rounded-md bg-ch-bg-raised/50 text-ch-ink-dim border border-ch-line-strong/50 outline-none"
+            >
+              <option value="all">All agents</option>
+              {agents.map(a => (
+                <option key={a.id} value={a.slug}>{a.agent_name}</option>
+              ))}
+            </select>
+          )}
+        </div>
+        <div className="flex gap-1">
+          <button
+            onClick={() => handleExport('json')}
+            disabled={exporting}
+            className="px-3 py-1.5 text-xs rounded-md text-ch-ink-dim hover:text-ch-ink hover:bg-ch-bg-raised/50 transition-colors disabled:opacity-50"
+          >
+            {exporting ? 'Exporting...' : 'Export JSON'}
+          </button>
+          <button
+            onClick={() => handleExport('csv')}
+            disabled={exporting}
+            className="px-3 py-1.5 text-xs rounded-md text-ch-ink-dim hover:text-ch-ink hover:bg-ch-bg-raised/50 transition-colors disabled:opacity-50"
+          >
+            CSV
+          </button>
+        </div>
+      </div>
+
       {loading ? (
         <div className="flex items-center gap-2 text-sm text-ch-ink-dim py-8 justify-center">
           <div className="animate-spin w-4 h-4 border-2 border-ch-accent border-t-transparent rounded-full" />
@@ -125,90 +228,95 @@ export function LogsTab() {
         </div>
       ) : logs.length === 0 ? (
         <div className="text-center py-12">
-          <p className="text-sm text-ch-ink-dim">No scheduled action logs yet.</p>
+          <p className="text-sm text-ch-ink-dim">No log entries yet.</p>
         </div>
       ) : (
         <div className="space-y-1">
-          {logs.map(rec => (
-            <div key={rec.id} className="border border-ch-line-strong/50 rounded bg-ch-bg-elev">
-              <button
-                onClick={() => setExpanded(expanded === rec.id ? null : rec.id)}
-                className="w-full px-3 py-2 flex items-center gap-3 text-left hover:bg-ch-bg-raised/30 transition-colors rounded text-xs"
-              >
-                <div
-                  className="w-2 h-2 rounded-full shrink-0"
-                  style={{ backgroundColor: STATUS_COLORS[rec.status] || '#6B7280' }}
-                />
-                <span className="text-ch-ink-dim w-[130px] shrink-0 font-mono">
-                  {formatTime(rec.started_at)}
-                </span>
-                <span className="text-ch-ink font-medium w-[100px] shrink-0 truncate">
-                  {rec.agent}
-                </span>
-                <span className="text-ch-ink-dim w-[70px] shrink-0">
-                  {rec.action_type}
-                </span>
-                <span
-                  className="w-[80px] shrink-0 font-medium"
-                  style={{ color: STATUS_COLORS[rec.status] || '#6B7280' }}
+          {logs.map(rec => {
+            const eventType = rec.event_type || 'scheduled_action';
+            const dotColor = EVENT_TYPE_COLORS[eventType] || STATUS_COLORS[rec.status] || '#6B7280';
+
+            return (
+              <div key={rec.id} className="border border-ch-line-strong/50 rounded bg-ch-bg-elev">
+                <button
+                  onClick={() => setExpanded(expanded === rec.id ? null : rec.id)}
+                  className="w-full px-3 py-2 flex items-center gap-3 text-left hover:bg-ch-bg-raised/30 transition-colors rounded text-xs"
                 >
-                  {rec.status}
-                </span>
-                <span className="text-ch-ink-dim flex-1 truncate">
-                  {rec.result_summary || ''}
-                </span>
-                <span className="text-ch-ink-dim shrink-0">
-                  {rec.duration_ms ? `${(rec.duration_ms / 1000).toFixed(1)}s` : ''}
-                </span>
-                <span className="text-ch-ink-dim shrink-0 w-[50px] text-right">
-                  {rec.input_tokens + rec.output_tokens > 0
-                    ? formatTokens(rec.input_tokens + rec.output_tokens)
-                    : ''}
-                </span>
-                <svg
-                  className={`w-3 h-3 text-ch-ink-dim shrink-0 transition-transform ${expanded === rec.id ? 'rotate-180' : ''}`}
-                  fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                </svg>
-              </button>
+                  <div
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ backgroundColor: dotColor }}
+                  />
+                  <span className="text-ch-ink-dim w-[130px] shrink-0 font-mono">
+                    {formatTime(rec.started_at)}
+                  </span>
+                  <span className="text-ch-ink font-medium w-[100px] shrink-0 truncate">
+                    {rec.agent}
+                  </span>
+                  <span className="text-ch-ink-dim w-[70px] shrink-0">
+                    {eventType === 'chat' ? (rec.source || 'chat') : rec.action_type}
+                  </span>
+                  <span
+                    className="w-[80px] shrink-0 font-medium"
+                    style={{ color: STATUS_COLORS[rec.status] || '#6B7280' }}
+                  >
+                    {rec.status}
+                  </span>
+                  <span className="text-ch-ink-dim flex-1 truncate">
+                    {rec.result_summary || ''}
+                  </span>
+                  <span className="text-ch-ink-dim shrink-0">
+                    {rec.duration_ms ? `${(rec.duration_ms / 1000).toFixed(1)}s` : ''}
+                  </span>
+                  <span className="text-ch-ink-dim shrink-0 w-[50px] text-right">
+                    {rec.input_tokens + rec.output_tokens > 0
+                      ? formatTokens(rec.input_tokens + rec.output_tokens)
+                      : ''}
+                  </span>
+                  <svg
+                    className={`w-3 h-3 text-ch-ink-dim shrink-0 transition-transform ${expanded === rec.id ? 'rotate-180' : ''}`}
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
 
-              {expanded === rec.id && (
-                <div className="px-3 pb-3 border-t border-ch-line-strong/30 mt-0">
-                  <div className="flex flex-wrap gap-3 mt-2 text-xs text-ch-ink-dim">
-                    {rec.model_used && <span>Model: {rec.model_used}</span>}
-                    <span>In: {formatTokens(rec.input_tokens)} / Out: {formatTokens(rec.output_tokens)}</span>
-                    {rec.completed_at && <span>Completed: {formatTime(rec.completed_at)}</span>}
-                  </div>
-
-                  {rec.result_full && (
-                    <pre className="mt-2 text-xs text-ch-ink-mute bg-ch-bg-raised/50 px-3 py-2 rounded max-h-48 overflow-auto whitespace-pre-wrap font-mono">
-                      {rec.result_full}
-                    </pre>
-                  )}
-
-                  {Array.isArray(rec.tool_calls) && rec.tool_calls.length > 0 && (
-                    <div className="mt-2 space-y-1">
-                      <div className="text-xs text-ch-ink-dim font-medium">Tool Calls ({rec.tool_calls.length})</div>
-                      {rec.tool_calls.map((tc, i) => (
-                        <div key={i} className="text-xs bg-ch-bg-raised/50 px-3 py-1.5 rounded font-mono">
-                          <div className="flex items-center justify-between">
-                            <span className="text-ch-ink">{tc.tool}</span>
-                            <span className="text-ch-ink-dim">{tc.duration_ms}ms</span>
-                          </div>
-                          {tc.result && (
-                            <div className="text-ch-ink-dim mt-0.5 max-h-12 overflow-auto whitespace-pre-wrap">
-                              {tc.result}
-                            </div>
-                          )}
-                        </div>
-                      ))}
+                {expanded === rec.id && (
+                  <div className="px-3 pb-3 border-t border-ch-line-strong/30 mt-0">
+                    <div className="flex flex-wrap gap-3 mt-2 text-xs text-ch-ink-dim">
+                      {rec.model_used && <span>Model: {rec.model_used}</span>}
+                      <span>In: {formatTokens(rec.input_tokens)} / Out: {formatTokens(rec.output_tokens)}</span>
+                      {rec.completed_at && <span>Completed: {formatTime(rec.completed_at)}</span>}
+                      {rec.source && <span>Source: {rec.source}</span>}
+                      {rec.event_type && <span>Type: {rec.event_type}</span>}
                     </div>
-                  )}
-                </div>
-              )}
-            </div>
-          ))}
+
+                    {rec.result_full && (
+                      <pre className="mt-2 text-xs text-ch-ink-mute bg-ch-bg-raised/50 px-3 py-2 rounded max-h-48 overflow-auto whitespace-pre-wrap font-mono">
+                        {rec.result_full}
+                      </pre>
+                    )}
+
+                    {Array.isArray(rec.tool_calls) && rec.tool_calls.length > 0 && (
+                      <div className="mt-2 space-y-1">
+                        <div className="text-xs text-ch-ink-dim font-medium">Tool Calls ({rec.tool_calls.length})</div>
+                        {rec.tool_calls.map((tc, i) => (
+                          <div key={i} className="text-xs bg-ch-bg-raised/50 px-3 py-1.5 rounded font-mono">
+                            <div className="flex items-center justify-between">
+                              <span className="text-ch-ink">{tc.tool}</span>
+                              <span className="text-ch-ink-dim">{tc.duration_ms}ms</span>
+                            </div>
+                            {tc.result && (
+                              <div className="text-ch-ink-dim mt-0.5 max-h-12 overflow-auto whitespace-pre-wrap">{tc.result}</div>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Extends the Settings → Logs tab into a comprehensive activity log that captures all chat turns across web, Telegram, WhatsApp, and Paperclip channels alongside the existing scheduled action logs
- Adds JSON/CSV/text export with date range, agent, event type, and status filters for troubleshooting and bug reporting
- Adds `read_activity_log` agent tool so agents can review their own recent activity, errors, and tool call history

## Changes

**Schema**: 3 new columns on `execution_history` (`event_type`, `source`, `conversation_id`) with backward-compatible defaults and migration

**Backend logging**: Instrumented `ai_service.chat()`, `run_sync()`, and `background_runner.run_background_turn()` with centralized `_log_chat_completion()` helper that tracks tokens, detects tool errors, and handles all exit paths including exceptions

**Export**: New `GET /api/scheduled-actions/logs/export` endpoint supporting JSON, CSV (with formula injection protection), and plain text formats with date range filtering and 10K record cap

**Agent tool**: `read_activity_log` with privacy trimming (drops args, trims results) and input validation

**Frontend**: Event type filter pills, agent dropdown, Export JSON/CSV buttons in LogsTab. Per-agent Activity tab unchanged (pinned to `event_type='scheduled_action'`)

**Retention**: 7 days for scheduled actions, 30 days for chat events

## Test plan

- [ ] Chat with an agent via web → verify chat event appears in Settings → Logs
- [ ] Send a Telegram message → verify it logs with source='telegram'
- [ ] Test All Types / Scheduled / Chat filter pills
- [ ] Test agent filter dropdown
- [ ] Test Export JSON and CSV buttons
- [ ] Ask an agent "what have you been doing?" → verify it uses read_activity_log tool
- [ ] Verify per-agent Activity tab still shows only heartbeat/cron
- [ ] Verify existing scheduled action logs display correctly (backward compat)