### PR TITLE
Fix Telegram to support multiple agents per user

### DIFF
--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -211,14 +211,12 @@ def _safe_process_telegram(
             return
 
         # ── Private chat path ────────────────────────────────────────
-        # Check if sender has a mapping
-        mapping = state.get_mapping_by_sender("telegram", user_id)
+        agent_id = agent["id"]
+        mapping = state.get_mapping_by_sender("telegram", user_id, agent_id)
         if not mapping:
-            # Try auto-registration
-            if lifecycle.try_auto_register(agent["id"], user_id, sender_name):
+            if lifecycle.try_auto_register(agent_id, user_id, sender_name):
                 logger.info("Auto-registered Telegram user %s for agent %s", user_id, agent["agent_name"])
                 _mark_telegram_configured(agent["slug"])
-                mapping = state.get_mapping_by_sender("telegram", user_id)
             else:
                 send_message(
                     chat_id,
@@ -228,7 +226,6 @@ def _safe_process_telegram(
                 return
 
         # Busy check — save message to history but skip AI if already processing
-        mapped_agent_id = mapping["agent_id"] if mapping else agent["id"]
         busy_key = (agent_slug, chat_id)
         busy_started = time.monotonic()
         with _busy_lock:
@@ -245,7 +242,7 @@ def _safe_process_telegram(
             loop = asyncio.new_event_loop()
             try:
                 loop.run_until_complete(service.save_message_only(
-                    agent_id=mapped_agent_id,
+                    agent_id=agent_id,
                     agent_slug=agent_slug,
                     sender_id=user_id,
                     content=prefix + message,
@@ -261,7 +258,7 @@ def _safe_process_telegram(
             loop = asyncio.new_event_loop()
             try:
                 response = loop.run_until_complete(
-                    service.process_message(user_id, sender_name, message)
+                    service.process_message(user_id, sender_name, message, agent_id)
                 )
             finally:
                 loop.close()

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -134,6 +134,7 @@ async def process_message(
     sender_id: str,
     sender_name: str,
     message_text: str,
+    agent_id: str,
 ) -> str:
     """Route an inbound Telegram message to the appropriate agent and return the response.
 
@@ -141,32 +142,25 @@ async def process_message(
         sender_id: Telegram user ID (string)
         sender_name: Display name from Telegram
         message_text: The message content
+        agent_id: The agent ID (resolved by the webhook handler from the URL slug)
 
     Returns:
         The agent's response text.
     """
-    # 1. Look up sender → agent_id
-    mapping = state.get_mapping_by_sender("telegram", sender_id)
-    if not mapping:
+    if not state.get_mapping_by_sender("telegram", sender_id, agent_id):
         return (
             "I don't recognize your account yet. "
             "Please ask the admin to reset the registration window."
         )
 
-    agent_id = mapping["agent_id"]
-
-    # 2. Load agent
     agent = agent_db.get_agent(agent_id)
     if not agent:
         return "This agent is no longer available."
 
-    # 3. Check Telegram is enabled
     if not agent.get("telegram_enabled"):
         return "Telegram messaging is currently disabled for this agent."
 
     slug = agent["slug"]
-
-    # 4. Build the agent pipeline (mirrors agents/router.py::_stream_chat)
     config = build_agent_config(agent)
     ctx_manager = get_context_manager(slug)
     chat_service = get_chat_service(slug)

--- a/backend/integrations/telegram/state.py
+++ b/backend/integrations/telegram/state.py
@@ -30,6 +30,47 @@ def _get_db() -> sqlite3.Connection:
     return _connection
 
 
+def _migrate_user_mappings_v2(conn: sqlite3.Connection) -> None:
+    """Migrate user_mappings from UNIQUE(platform, platform_user_id) to
+    UNIQUE(platform, platform_user_id, agent_id) so one Telegram user
+    can be mapped to multiple agents simultaneously."""
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='user_mappings'"
+    ).fetchone()
+    if not row:
+        return
+    create_sql = row[0] or ""
+    if "platform_user_id, agent_id)" in create_sql:
+        return
+
+    logger.info("Migrating user_mappings to support multi-agent per user...")
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("""
+            CREATE TABLE user_mappings_v2 (
+                id TEXT PRIMARY KEY,
+                platform TEXT NOT NULL,
+                platform_user_id TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                sender_name TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                UNIQUE(platform, platform_user_id, agent_id)
+            )
+        """)
+        conn.execute("""
+            INSERT OR IGNORE INTO user_mappings_v2
+            SELECT id, platform, platform_user_id, agent_id, sender_name, created_at
+            FROM user_mappings
+        """)
+        conn.execute("DROP TABLE user_mappings")
+        conn.execute("ALTER TABLE user_mappings_v2 RENAME TO user_mappings")
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    logger.info("user_mappings migration complete")
+
+
 def _setup_connection() -> None:
     """Open connection, set PRAGMAs, create schema."""
     global _connection
@@ -39,6 +80,8 @@ def _setup_connection() -> None:
     _connection.execute("PRAGMA foreign_keys=ON")
     _connection.execute("PRAGMA busy_timeout=5000")
 
+    _migrate_user_mappings_v2(_connection)
+
     _connection.executescript("""
         CREATE TABLE IF NOT EXISTS user_mappings (
             id TEXT PRIMARY KEY,
@@ -47,7 +90,7 @@ def _setup_connection() -> None:
             agent_id TEXT NOT NULL,
             sender_name TEXT NOT NULL DEFAULT '',
             created_at TEXT NOT NULL,
-            UNIQUE(platform, platform_user_id)
+            UNIQUE(platform, platform_user_id, agent_id)
         );
 
         CREATE TABLE IF NOT EXISTS telegram_registration_windows (
@@ -102,12 +145,12 @@ def get_user_mappings() -> list[dict]:
     return [dict(r) for r in rows]
 
 
-def get_mapping_by_sender(platform: str, platform_user_id: str) -> dict | None:
+def get_mapping_by_sender(platform: str, platform_user_id: str, agent_id: str) -> dict | None:
     conn = _get_db()
     row = conn.execute(
         "SELECT id, platform, platform_user_id, agent_id, sender_name "
-        "FROM user_mappings WHERE platform = ? AND platform_user_id = ?",
-        (platform, platform_user_id),
+        "FROM user_mappings WHERE platform = ? AND platform_user_id = ? AND agent_id = ?",
+        (platform, platform_user_id, agent_id),
     ).fetchone()
     return dict(row) if row else None
 
@@ -123,15 +166,14 @@ def create_mapping(
             """INSERT INTO user_mappings
                (id, platform, platform_user_id, agent_id, sender_name, created_at)
                VALUES (?, ?, ?, ?, ?, ?)
-               ON CONFLICT(platform, platform_user_id)
-               DO UPDATE SET agent_id = excluded.agent_id,
-                             sender_name = excluded.sender_name""",
+               ON CONFLICT(platform, platform_user_id, agent_id)
+               DO UPDATE SET sender_name = excluded.sender_name""",
             (mapping_id, platform, platform_user_id, agent_id, sender_name, now),
         )
         conn.commit()
         row = conn.execute(
-            "SELECT id FROM user_mappings WHERE platform = ? AND platform_user_id = ?",
-            (platform, platform_user_id),
+            "SELECT id FROM user_mappings WHERE platform = ? AND platform_user_id = ? AND agent_id = ?",
+            (platform, platform_user_id, agent_id),
         ).fetchone()
         actual_id = row["id"] if row else mapping_id
     return {


### PR DESCRIPTION
## Summary

- Changed `user_mappings` UNIQUE constraint from `(platform, platform_user_id)` to `(platform, platform_user_id, agent_id)` so one Telegram user can be linked to multiple agents simultaneously
- Threaded `agent_id` from the webhook handler through the private chat routing path, matching how group chat already works
- Added automatic schema migration with transaction safety for existing databases

## Test plan

- [ ] Set up two agents with two different Telegram bot tokens
- [ ] Link the same Telegram account to both agents via registration windows
- [ ] Message Bot A → verify Agent A responds with its personality
- [ ] Message Bot B → verify Agent B responds with its personality
- [ ] Verify `GET /api/telegram/mappings` shows both mappings
- [ ] Disconnect one bot and verify the other still works
- [ ] Fresh install: verify new database gets correct schema without migration