### PR TITLE
Replace Activity tab with visual Heartbeat mission control

### DIFF
--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -7,7 +7,7 @@ import { useScrollDirection } from './hooks/useScrollDirection';
 import { AgentChatPanel } from './components/AgentChatPanel';
 import { AgentContextEditor } from './components/AgentContextEditor';
 import ReportsPanel from './reports/ReportsPanel';
-import AgentActivityPanel from './components/AgentActivityPanel';
+import HeartbeatPanel from './components/HeartbeatPanel';
 import { ConversationSidebar } from './components/ConversationSidebar';
 import { AvatarPicker } from './components/AvatarPicker';
 import { AgentMark } from '../shared/AgentMark';
@@ -34,13 +34,20 @@ interface AgentRow {
   telegram_max_bot_turns: number;
 }
 
-type Tab = 'chat' | 'knowledge' | 'reports' | 'activity';
+type Tab = 'chat' | 'knowledge' | 'reports' | 'heartbeat';
+
+function parseTab(raw: string | null): Tab | null {
+  if (!raw) return null;
+  if (raw === 'activity') return 'heartbeat';
+  if (['chat', 'knowledge', 'reports', 'heartbeat'].includes(raw)) return raw as Tab;
+  return null;
+}
 
 const TABS: { key: Tab; label: string }[] = [
   { key: 'chat', label: 'Chat' },
   { key: 'knowledge', label: 'Knowledge' },
   { key: 'reports', label: 'Reports' },
-  { key: 'activity', label: 'Activity' },
+  { key: 'heartbeat', label: 'Heartbeat' },
 ];
 
 const TOOL_MODES: { key: ToolMode; label: string }[] = [
@@ -55,10 +62,7 @@ export function AgentPage() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [agent, setAgent] = useState<AgentRow | null>(null);
-  const [activeTab, setActiveTab] = useState<Tab>(() => {
-    const tab = searchParams.get('tab');
-    return (tab && ['chat', 'knowledge', 'reports', 'activity'].includes(tab)) ? tab as Tab : 'chat';
-  });
+  const [activeTab, setActiveTab] = useState<Tab>(() => parseTab(searchParams.get('tab')) || 'chat');
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);
   const [showSidebar, setShowSidebar] = useState(false);
   const [openaiAvailable, setOpenaiAvailable] = useState(false);
@@ -209,9 +213,9 @@ export function AgentPage() {
 
   // Handle tab from URL search params
   useEffect(() => {
-    const tab = searchParams.get('tab');
-    if (tab && ['chat', 'knowledge', 'reports', 'activity'].includes(tab)) {
-      queueMicrotask(() => setActiveTab(tab as Tab));
+    const parsed = parseTab(searchParams.get('tab'));
+    if (parsed) {
+      queueMicrotask(() => setActiveTab(parsed));
       searchParams.delete('tab');
       setSearchParams(searchParams, { replace: true });
     }
@@ -584,9 +588,9 @@ export function AgentPage() {
           <AgentContextEditor agentId={agentId!} />
         ) : activeTab === 'reports' ? (
           <ReportsPanel apiPrefix={apiPrefix} />
-        ) : activeTab === 'activity' ? (
+        ) : activeTab === 'heartbeat' ? (
           <div style={{ flex: 1, overflow: 'auto' }}>
-            <AgentActivityPanel apiPrefix={apiPrefix} />
+            <HeartbeatPanel agentSlug={agent.slug} apiPrefix={apiPrefix} />
           </div>
         ) : null}
       </div>

--- a/frontend/src/agent/components/HeartbeatPanel.tsx
+++ b/frontend/src/agent/components/HeartbeatPanel.tsx
@@ -1,0 +1,58 @@
+import { useHeartbeat } from '../hooks/useHeartbeat';
+import { HeartbeatStatusBar } from './heartbeat/HeartbeatStatusBar';
+import { HeartbeatChecklist } from './heartbeat/HeartbeatChecklist';
+import { HeartbeatHistory } from './heartbeat/HeartbeatHistory';
+import { HeartbeatConfig } from './heartbeat/HeartbeatConfig';
+import { FONT_SANS, INK_DIM, LINE_STRONG } from '../../shared/styles';
+
+interface Props {
+  agentSlug: string;
+  apiPrefix: string;
+}
+
+export default function HeartbeatPanel({ agentSlug, apiPrefix }: Props) {
+  const hb = useHeartbeat(agentSlug, apiPrefix);
+
+  if (hb.loading) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, padding: '48px 0' }}>
+        <div className="animate-spin w-5 h-5 border-2 border-ch-accent border-t-transparent rounded-full" />
+        <span style={{ fontFamily: FONT_SANS, fontSize: 13, color: INK_DIM }}>Loading heartbeat...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: 720, margin: '0 auto', width: '100%' }}>
+      <HeartbeatStatusBar
+        action={hb.action}
+        countdown={hb.countdown}
+        running={hb.running}
+        actionError={hb.actionError}
+        onRunNow={hb.runNow}
+        onToggleEnabled={hb.toggleEnabled}
+      />
+
+      <div style={{ borderBottom: `1px solid ${LINE_STRONG}` }}>
+        <HeartbeatChecklist
+          parsedLines={hb.parsedLines}
+          canEditCards={hb.canEditCards}
+          rawMarkdown={hb.rawMarkdown}
+          onSave={hb.saveChecklist}
+          onSaveRaw={hb.saveRawChecklist}
+        />
+      </div>
+
+      <div style={{ borderBottom: `1px solid ${LINE_STRONG}` }}>
+        <HeartbeatHistory history={hb.history} />
+      </div>
+
+      {hb.action && (
+        <HeartbeatConfig
+          action={hb.action}
+          onUpdateConfig={hb.updateConfig}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/agent/components/heartbeat/HeartbeatChecklist.tsx
+++ b/frontend/src/agent/components/heartbeat/HeartbeatChecklist.tsx
@@ -1,0 +1,267 @@
+import { useState, useRef, useEffect } from 'react';
+import type { ParsedLine } from '../../hooks/useHeartbeat';
+import { FONT_SANS, FONT_MONO, INK, INK_DIM, INK_MUTE, BG_ELEV, BG_RAISED, LINE_STRONG, ACCENT, ACCENT_INK, SAGE } from '../../../shared/styles';
+
+interface Props {
+  parsedLines: ParsedLine[];
+  canEditCards: boolean;
+  rawMarkdown: string;
+  onSave: (lines: ParsedLine[]) => Promise<void>;
+  onSaveRaw: (raw: string) => Promise<void>;
+}
+
+export function HeartbeatChecklist({ parsedLines, canEditCards, rawMarkdown, onSave, onSaveRaw }: Props) {
+  const [localLines, setLocalLines] = useState<ParsedLine[]>(parsedLines);
+  const [rawText, setRawText] = useState(rawMarkdown);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState('');
+  const [addingNew, setAddingNew] = useState(false);
+  const [newText, setNewText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [rawDirty, setRawDirty] = useState(false);
+  const newInputRef = useRef<HTMLInputElement>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { setLocalLines(parsedLines); setDirty(false); }, [parsedLines]);
+  useEffect(() => { setRawText(rawMarkdown); setRawDirty(false); }, [rawMarkdown]);
+  useEffect(() => { if (addingNew) newInputRef.current?.focus(); }, [addingNew]);
+  useEffect(() => { if (editingId) editInputRef.current?.focus(); }, [editingId]);
+
+  const items = localLines.filter(l => l.type === 'list-item');
+
+  function startEdit(item: ParsedLine) {
+    setEditingId(item.id!);
+    setEditText(item.text || '');
+  }
+
+  function commitEdit() {
+    if (!editingId) return;
+    const updated = localLines.map(l =>
+      l.id === editingId ? { ...l, text: editText.trim() || l.text } : l,
+    );
+    setLocalLines(updated);
+    setEditingId(null);
+    setDirty(true);
+  }
+
+  function deleteItem(id: string) {
+    setLocalLines(prev => prev.filter(l => l.id !== id));
+    setDirty(true);
+  }
+
+  function addItem() {
+    if (!newText.trim()) { setAddingNew(false); return; }
+    const line: ParsedLine = {
+      type: 'list-item', raw: `- ${newText.trim()}`,
+      prefix: '- ', text: newText.trim(), id: crypto.randomUUID(),
+    };
+    setLocalLines(prev => [...prev, line]);
+    setNewText('');
+    setAddingNew(false);
+    setDirty(true);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await onSave(localLines);
+      setDirty(false);
+    } finally { setSaving(false); }
+  }
+
+  async function handleSaveRaw() {
+    setSaving(true);
+    try {
+      await onSaveRaw(rawText);
+      setRawDirty(false);
+    } finally { setSaving(false); }
+  }
+
+  // Raw markdown editor fallback
+  if (!canEditCards && rawMarkdown) {
+    return (
+      <div style={{ padding: '16px 24px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+          <span style={{ fontFamily: FONT_MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: INK_DIM }}>
+            CHECKLIST
+          </span>
+          {rawDirty && (
+            <button onClick={handleSaveRaw} disabled={saving} style={{
+              fontFamily: FONT_SANS, fontSize: 12, fontWeight: 500,
+              padding: '4px 12px', borderRadius: 4, cursor: 'pointer',
+              background: ACCENT, color: ACCENT_INK, border: 'none',
+              opacity: saving ? 0.5 : 1,
+            }}>
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          )}
+        </div>
+        <textarea
+          value={rawText}
+          onChange={e => { setRawText(e.target.value); setRawDirty(true); }}
+          style={{
+            width: '100%', minHeight: 200, boxSizing: 'border-box',
+            fontFamily: FONT_SANS, fontSize: 13, lineHeight: 1.6,
+            background: BG_RAISED, border: `1px solid ${LINE_STRONG}`,
+            color: INK, borderRadius: 6, padding: 12, resize: 'vertical', outline: 'none',
+          }}
+        />
+      </div>
+    );
+  }
+
+  // Card editor
+  return (
+    <div style={{ padding: '16px 24px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+        <span style={{ fontFamily: FONT_MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: INK_DIM }}>
+          CHECKLIST
+        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {dirty && (
+            <button onClick={handleSave} disabled={saving} style={{
+              fontFamily: FONT_SANS, fontSize: 12, fontWeight: 500,
+              padding: '4px 12px', borderRadius: 4, cursor: 'pointer',
+              background: ACCENT, color: ACCENT_INK, border: 'none',
+              opacity: saving ? 0.5 : 1,
+            }}>
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          )}
+          {!addingNew && (
+            <button onClick={() => setAddingNew(true)} style={{
+              fontFamily: FONT_SANS, fontSize: 12, color: INK_MUTE,
+              background: 'none', border: `1px solid ${LINE_STRONG}`,
+              borderRadius: 4, padding: '4px 12px', cursor: 'pointer',
+            }}>
+              + Add Item
+            </button>
+          )}
+        </div>
+      </div>
+
+      {items.length === 0 && !addingNew ? (
+        <div style={{ textAlign: 'center', padding: '32px 0' }}>
+          <p style={{ fontFamily: FONT_SANS, fontSize: 13, color: INK_DIM }}>No checklist items yet.</p>
+          <button
+            onClick={() => setAddingNew(true)}
+            style={{
+              marginTop: 8, fontFamily: FONT_SANS, fontSize: 13, color: ACCENT,
+              background: 'none', border: 'none', cursor: 'pointer',
+            }}
+          >Add your first task</button>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {items.map(item => (
+            <div
+              key={item.id}
+              className="group"
+              style={{
+                background: BG_ELEV, border: `1px solid ${LINE_STRONG}`,
+                borderRadius: 6, padding: '10px 14px',
+                display: 'flex', alignItems: 'center', gap: 10,
+              }}
+            >
+              {/* Checkbox dot */}
+              <div
+                onClick={() => {
+                  if (item.checked === undefined) return;
+                  const updated = localLines.map(l =>
+                    l.id === item.id ? { ...l, checked: !l.checked } : l,
+                  );
+                  setLocalLines(updated);
+                  setDirty(true);
+                }}
+                style={{
+                  width: 16, height: 16, borderRadius: 3, flexShrink: 0,
+                  border: `1.5px solid ${item.checked ? SAGE : LINE_STRONG}`,
+                  background: item.checked ? SAGE : 'transparent',
+                  cursor: item.checked !== undefined ? 'pointer' : 'default',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}
+              >
+                {item.checked && (
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                    <path d="M2 5l2.5 2.5L8 3" stroke="#fff" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                )}
+              </div>
+
+              {/* Text or edit input */}
+              {editingId === item.id ? (
+                <input
+                  ref={editInputRef}
+                  value={editText}
+                  onChange={e => setEditText(e.target.value)}
+                  onBlur={commitEdit}
+                  onKeyDown={e => { if (e.key === 'Enter') commitEdit(); if (e.key === 'Escape') setEditingId(null); }}
+                  style={{
+                    flex: 1, fontFamily: FONT_SANS, fontSize: 13, color: INK,
+                    background: BG_RAISED, border: `1px solid ${LINE_STRONG}`,
+                    borderRadius: 4, padding: '4px 8px', outline: 'none',
+                  }}
+                />
+              ) : (
+                <span
+                  onDoubleClick={() => startEdit(item)}
+                  style={{
+                    flex: 1, fontFamily: FONT_SANS, fontSize: 13, color: INK,
+                    textDecoration: item.checked ? 'line-through' : 'none',
+                    opacity: item.checked ? 0.5 : 1,
+                  }}
+                >{item.text}</span>
+              )}
+
+              {/* Edit / delete actions */}
+              <div className="opacity-0 group-hover:opacity-100 transition-opacity" style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+                <button
+                  onClick={() => startEdit(item)}
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: INK_DIM, padding: 2 }}
+                  title="Edit"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17 3a2.85 2.85 0 114 4L7.5 20.5 2 22l1.5-5.5L17 3z" />
+                  </svg>
+                </button>
+                <button
+                  onClick={() => deleteItem(item.id!)}
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: INK_DIM, padding: 2 }}
+                  title="Delete"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add new item input */}
+      {addingNew && (
+        <div style={{ marginTop: 6, display: 'flex', gap: 8 }}>
+          <input
+            ref={newInputRef}
+            value={newText}
+            onChange={e => setNewText(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') addItem(); if (e.key === 'Escape') { setAddingNew(false); setNewText(''); } }}
+            placeholder="Describe a task for the agent to check..."
+            style={{
+              flex: 1, fontFamily: FONT_SANS, fontSize: 13, color: INK,
+              background: BG_RAISED, border: `1px solid ${LINE_STRONG}`,
+              borderRadius: 4, padding: '8px 12px', outline: 'none',
+            }}
+          />
+          <button onClick={addItem} style={{
+            fontFamily: FONT_SANS, fontSize: 12, fontWeight: 500,
+            padding: '6px 14px', borderRadius: 4, cursor: 'pointer',
+            background: ACCENT, color: ACCENT_INK, border: 'none',
+          }}>Add</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/agent/components/heartbeat/HeartbeatConfig.tsx
+++ b/frontend/src/agent/components/heartbeat/HeartbeatConfig.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect } from 'react';
+import type { ScheduledAction } from '../../hooks/useHeartbeat';
+import { FONT_SANS, FONT_MONO, INK, INK_DIM, ACCENT, ACCENT_INK, BG_RAISED, LINE_STRONG, SAGE } from '../../../shared/styles';
+import { labelStyle, inputStyle } from '../../../shared/styles';
+
+interface Props {
+  action: ScheduledAction;
+  onUpdateConfig: (fields: Record<string, unknown>) => Promise<void>;
+}
+
+export function HeartbeatConfig({ action, onUpdateConfig }: Props) {
+  const [interval, setInterval_] = useState(action.interval_minutes || 30);
+  const [triage, setTriage] = useState(action.triage_enabled);
+  const [alwaysOn, setAlwaysOn] = useState(action.always_on);
+  const [hoursStart, setHoursStart] = useState(action.active_hours_start || '06:00');
+  const [hoursEnd, setHoursEnd] = useState(action.active_hours_end || '20:00');
+  const [modelOverride, setModelOverride] = useState(action.model_override || '');
+  const [maxIterations, setMaxIterations] = useState(action.max_tool_iterations || 10);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    setInterval_(action.interval_minutes || 30);
+    setTriage(action.triage_enabled);
+    setAlwaysOn(action.always_on);
+    setHoursStart(action.active_hours_start || '06:00');
+    setHoursEnd(action.active_hours_end || '20:00');
+    setModelOverride(action.model_override || '');
+    setMaxIterations(action.max_tool_iterations || 10);
+    setDirty(false);
+  }, [action]);
+
+  function markDirty() { setDirty(true); }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const fields: Record<string, unknown> = {
+        interval_minutes: interval,
+        triage_enabled: triage,
+        always_on: alwaysOn,
+        active_hours_start: hoursStart,
+        active_hours_end: hoursEnd,
+        max_tool_iterations: maxIterations,
+      };
+      fields.model_override = modelOverride.trim() || '';
+      await onUpdateConfig(fields);
+      setDirty(false);
+    } catch {
+      // Backend rejected values — keep dirty so user can correct
+    } finally { setSaving(false); }
+  }
+
+  function Toggle({ on, onChange, label: lbl }: { on: boolean; onChange: (v: boolean) => void; label: string }) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 0' }}>
+        <span style={{ fontFamily: FONT_SANS, fontSize: 13, color: INK }}>{lbl}</span>
+        <button
+          onClick={() => { onChange(!on); markDirty(); }}
+          style={{
+            width: 36, height: 20, borderRadius: 10, border: 'none', cursor: 'pointer',
+            background: on ? SAGE : BG_RAISED, position: 'relative', transition: 'background 0.2s',
+          }}
+        >
+          <div style={{
+            width: 14, height: 14, borderRadius: '50%', background: '#fff',
+            position: 'absolute', top: 3, left: on ? 19 : 3, transition: 'left 0.2s',
+          }} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '16px 24px' }}>
+      <span style={{ ...labelStyle, marginBottom: 16, display: 'block' }}>CONFIGURATION</span>
+
+      {/* Essential fields */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div>
+          <label style={labelStyle}>Interval (minutes)</label>
+          <input
+            type="number" min={5} max={1440} value={interval}
+            onChange={e => { setInterval_(Math.max(5, Math.min(1440, Number(e.target.value) || 5))); markDirty(); }}
+            style={{ ...inputStyle, width: 120 }}
+          />
+        </div>
+
+        <Toggle on={triage} onChange={setTriage} label="Triage (quick check before full run)" />
+      </div>
+
+      {/* Advanced disclosure */}
+      <button
+        onClick={() => setShowAdvanced(!showAdvanced)}
+        style={{
+          marginTop: 16, fontFamily: FONT_MONO, fontSize: 10, letterSpacing: '0.12em',
+          textTransform: 'uppercase', color: INK_DIM,
+          background: 'none', border: 'none', cursor: 'pointer',
+          display: 'flex', alignItems: 'center', gap: 6,
+        }}
+      >
+        <svg
+          width="10" height="10" viewBox="0 0 10 10" fill="none"
+          stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"
+          style={{ transition: 'transform 0.2s', transform: showAdvanced ? 'rotate(90deg)' : 'none' }}
+        >
+          <path d="M3 1l4 4-4 4" />
+        </svg>
+        Advanced
+      </button>
+
+      {showAdvanced && (
+        <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 12, paddingLeft: 16, borderLeft: `1px solid ${LINE_STRONG}` }}>
+          <Toggle on={alwaysOn} onChange={setAlwaysOn} label="Always On (ignore active hours)" />
+
+          {!alwaysOn && (
+            <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+              <div>
+                <label style={labelStyle}>Active Start</label>
+                <input
+                  type="time" value={hoursStart}
+                  onChange={e => { setHoursStart(e.target.value); markDirty(); }}
+                  style={{ ...inputStyle, width: 120 }}
+                />
+              </div>
+              <div>
+                <label style={labelStyle}>Active End</label>
+                <input
+                  type="time" value={hoursEnd}
+                  onChange={e => { setHoursEnd(e.target.value); markDirty(); }}
+                  style={{ ...inputStyle, width: 120 }}
+                />
+              </div>
+              <span style={{ fontFamily: FONT_SANS, fontSize: 11, color: INK_DIM, marginTop: 16 }}>
+                {action.active_hours_tz}
+              </span>
+            </div>
+          )}
+
+          <div>
+            <label style={labelStyle}>Model Override</label>
+            <input
+              value={modelOverride}
+              onChange={e => { setModelOverride(e.target.value); markDirty(); }}
+              placeholder="Default"
+              style={{ ...inputStyle, width: 200 }}
+            />
+          </div>
+
+          <div>
+            <label style={labelStyle}>Max Tool Iterations</label>
+            <input
+              type="number" min={1} max={10} value={maxIterations}
+              onChange={e => { setMaxIterations(Math.max(1, Math.min(10, Number(e.target.value) || 1))); markDirty(); }}
+              style={{ ...inputStyle, width: 80 }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Save button */}
+      {dirty && (
+        <button
+          onClick={handleSave} disabled={saving}
+          style={{
+            marginTop: 16, fontFamily: FONT_SANS, fontSize: 12, fontWeight: 500,
+            padding: '6px 16px', borderRadius: 4, cursor: 'pointer',
+            background: ACCENT, color: ACCENT_INK, border: 'none',
+            opacity: saving ? 0.5 : 1,
+          }}
+        >
+          {saving ? 'Saving...' : 'Save Changes'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/agent/components/heartbeat/HeartbeatHistory.tsx
+++ b/frontend/src/agent/components/heartbeat/HeartbeatHistory.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import type { ActivityRecord } from '../../hooks/useHeartbeat';
+import { FONT_SANS, FONT_MONO, INK, INK_DIM, INK_MUTE, BG_ELEV, LINE_STRONG, SAGE, GOLD, CORAL } from '../../../shared/styles';
+
+const statusColors: Record<string, string> = {
+  ok: SAGE,
+  action_taken: GOLD,
+  error: CORAL,
+  skipped: INK_DIM,
+};
+
+function timeAgo(iso: string): string {
+  const d = new Date(iso + 'Z');
+  const diff = Date.now() - d.getTime();
+  if (diff < 60000) return 'Just now';
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  return `${Math.floor(diff / 86400000)}d ago`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return String(n);
+}
+
+interface Props {
+  history: ActivityRecord[];
+}
+
+export function HeartbeatHistory({ history }: Props) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  return (
+    <div style={{ padding: '16px 24px' }}>
+      <span style={{ fontFamily: FONT_MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: INK_DIM, display: 'block', marginBottom: 12 }}>
+        RECENT RUNS
+      </span>
+
+      {history.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: '24px 0' }}>
+          <p style={{ fontFamily: FONT_SANS, fontSize: 13, color: INK_DIM }}>No heartbeat runs yet.</p>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {history.map(rec => {
+            const isExpanded = expanded === rec.id;
+            const color = statusColors[rec.status] || INK_DIM;
+
+            return (
+              <div key={rec.id} style={{ background: BG_ELEV, border: `1px solid ${LINE_STRONG}`, borderRadius: 6 }}>
+                <button
+                  onClick={() => setExpanded(isExpanded ? null : rec.id)}
+                  style={{
+                    width: '100%', padding: '10px 14px', border: 'none', background: 'none',
+                    display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer', textAlign: 'left',
+                  }}
+                >
+                  <div style={{ width: 6, height: 6, borderRadius: '50%', background: color, flexShrink: 0 }} />
+
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <span style={{ fontFamily: FONT_SANS, fontSize: 12, fontWeight: 500, color: INK, textTransform: 'capitalize' }}>
+                        {rec.status.replace('_', ' ')}
+                      </span>
+                      <span style={{ fontFamily: FONT_SANS, fontSize: 12, color: INK_DIM }}>{timeAgo(rec.started_at)}</span>
+                    </div>
+                    {rec.result_summary && (
+                      <p style={{
+                        fontFamily: FONT_SANS, fontSize: 12, color: INK_MUTE, marginTop: 2,
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      }}>{rec.result_summary}</p>
+                    )}
+                  </div>
+
+                  <div style={{ fontFamily: FONT_SANS, fontSize: 11, color: INK_DIM, flexShrink: 0, textAlign: 'right', whiteSpace: 'nowrap' }}>
+                    {rec.duration_ms ? `${(rec.duration_ms / 1000).toFixed(1)}s` : ''}
+                    {Array.isArray(rec.tool_calls) && rec.tool_calls.filter(tc => tc && typeof tc === 'object' && tc.tool).length > 0
+                      ? ` · ${rec.tool_calls.filter(tc => tc && typeof tc === 'object' && tc.tool).length} tools`
+                      : ''}
+                  </div>
+
+                  <svg
+                    width="14" height="14" viewBox="0 0 24 24" fill="none"
+                    stroke={INK_DIM} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                    style={{ flexShrink: 0, transition: 'transform 0.2s', transform: isExpanded ? 'rotate(180deg)' : 'none' }}
+                  >
+                    <path d="M6 9l6 6 6-6" />
+                  </svg>
+                </button>
+
+                {isExpanded && (
+                  <div style={{ padding: '0 14px 14px', borderTop: `1px solid ${LINE_STRONG}` }}>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, marginTop: 10, fontFamily: FONT_SANS, fontSize: 11, color: INK_DIM }}>
+                      {rec.model_used && <span>Model: {rec.model_used.split('-').slice(-2).join('-')}</span>}
+                      <span>Tokens: {formatTokens(rec.input_tokens + rec.output_tokens)}</span>
+                      <span>{new Date(rec.started_at + 'Z').toLocaleString()}</span>
+                    </div>
+
+                    {rec.result_full && (
+                      <div style={{
+                        marginTop: 10, fontFamily: FONT_SANS, fontSize: 12, color: INK_MUTE,
+                        background: 'rgba(34,40,48,0.35)', padding: '8px 12px', borderRadius: 4,
+                        maxHeight: 160, overflow: 'auto', whiteSpace: 'pre-wrap', lineHeight: 1.5,
+                      }}>
+                        {rec.result_full}
+                      </div>
+                    )}
+
+                    {Array.isArray(rec.tool_calls) && rec.tool_calls.length > 0 && (
+                      <div style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        {rec.tool_calls.filter(tc => tc && typeof tc === 'object' && tc.tool).map((tc, i) => (
+                          <div key={i} style={{
+                            fontFamily: FONT_SANS, fontSize: 12,
+                            background: 'rgba(34,40,48,0.35)', padding: '6px 12px', borderRadius: 4,
+                          }}>
+                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                              <span style={{ fontWeight: 500, color: INK }}>{tc.tool}</span>
+                              {tc.duration_ms != null && <span style={{ color: INK_DIM, fontSize: 11 }}>{tc.duration_ms}ms</span>}
+                            </div>
+                            {tc.result && (
+                              <div style={{ color: INK_DIM, marginTop: 4, maxHeight: 64, overflow: 'auto', whiteSpace: 'pre-wrap' }}>
+                                {tc.result}
+                              </div>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/agent/components/heartbeat/HeartbeatStatusBar.tsx
+++ b/frontend/src/agent/components/heartbeat/HeartbeatStatusBar.tsx
@@ -1,0 +1,160 @@
+import type { ScheduledAction } from '../../hooks/useHeartbeat';
+import { FONT_MONO, FONT_SANS, INK_DIM, INK_MUTE, ACCENT, ACCENT_INK, BG_RAISED, LINE_STRONG, SAGE, GOLD, CORAL } from '../../../shared/styles';
+
+const statusColors: Record<string, string> = {
+  ok: SAGE,
+  action_taken: GOLD,
+  error: CORAL,
+  skipped: INK_DIM,
+};
+
+const statusLabels: Record<string, string> = {
+  ok: 'All clear',
+  action_taken: 'Action taken',
+  error: 'Error',
+  skipped: 'Skipped',
+};
+
+interface Props {
+  action: ScheduledAction | null;
+  countdown: string;
+  running: boolean;
+  actionError: boolean;
+  onRunNow: () => void;
+  onToggleEnabled: () => void;
+}
+
+export function HeartbeatStatusBar({ action, countdown, running, actionError, onRunNow, onToggleEnabled }: Props) {
+  if (!action) {
+    return (
+      <div style={{
+        padding: '20px 24px', borderBottom: `1px solid ${LINE_STRONG}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+      }}>
+        {actionError ? (
+          <span style={{ fontFamily: FONT_SANS, fontSize: 13, color: CORAL }}>
+            Could not load heartbeat configuration. Check that the backend is running.
+          </span>
+        ) : (
+          <>
+            <div className="animate-spin w-4 h-4 border-2 border-ch-accent border-t-transparent rounded-full" />
+            <span style={{ fontFamily: FONT_SANS, fontSize: 13, color: INK_DIM }}>Initializing heartbeat...</span>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  const disabled = !action.enabled;
+  const lastStatus = action.last_status || 'ok';
+  const color = statusColors[lastStatus] || INK_DIM;
+  const label = statusLabels[lastStatus] || lastStatus;
+
+  const interval = action.interval_minutes
+    ? action.interval_minutes >= 60
+      ? `Every ${action.interval_minutes / 60}h`
+      : `Every ${action.interval_minutes}m`
+    : action.cron_expression || 'Custom';
+
+  return (
+    <div style={{ borderBottom: `1px solid ${LINE_STRONG}` }}>
+      {/* Disabled banner */}
+      {disabled && (
+        <div style={{
+          padding: '8px 24px', background: 'rgba(217,119,87,0.06)',
+          borderBottom: `1px solid rgba(217,119,87,0.15)`,
+          display: 'flex', alignItems: 'center', gap: 8,
+        }}>
+          <span style={{ fontFamily: FONT_MONO, fontSize: 10, fontWeight: 600, letterSpacing: '0.16em', textTransform: 'uppercase', color: CORAL }}>
+            PAUSED
+          </span>
+          <span style={{ fontSize: 12, color: INK_MUTE }}>
+            {action.consecutive_errors >= 5
+              ? 'Heartbeat paused due to repeated errors.'
+              : 'Heartbeat is disabled.'}
+          </span>
+          <button
+            onClick={onToggleEnabled}
+            style={{
+              marginLeft: 'auto', fontSize: 11, fontWeight: 500,
+              color: CORAL, background: 'none', border: 'none', cursor: 'pointer',
+            }}
+          >Re-enable</button>
+        </div>
+      )}
+
+      <div style={{ padding: '16px 24px' }}>
+        {/* Countdown hero */}
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 12 }}>
+          <span style={{ fontFamily: FONT_MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: INK_DIM }}>
+            NEXT RUN
+          </span>
+          <span style={{
+            fontFamily: FONT_MONO, fontSize: 28, fontWeight: 300,
+            letterSpacing: '0.05em', color: disabled ? INK_DIM : ACCENT,
+            lineHeight: 1,
+          }}>
+            {running && (
+              <span className="inline-block animate-spin w-5 h-5 border-2 border-ch-accent border-t-transparent rounded-full mr-2 align-middle" />
+            )}
+            {countdown}
+          </span>
+        </div>
+
+        {/* Meta row */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+          <span style={{ fontFamily: FONT_MONO, fontSize: 11, letterSpacing: '0.08em', color: INK_MUTE }}>
+            {interval}
+          </span>
+
+          {action.last_run && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <div style={{ width: 6, height: 6, borderRadius: '50%', background: color }} />
+              <span style={{ fontFamily: FONT_SANS, fontSize: 12, color: INK_MUTE }}>{label}</span>
+            </div>
+          )}
+
+          {action.total_runs > 0 && (
+            <span style={{ fontFamily: FONT_SANS, fontSize: 12, color: INK_DIM }}>
+              {action.total_runs} total runs
+            </span>
+          )}
+
+          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 10 }}>
+            <button
+              onClick={onRunNow}
+              disabled={running || disabled}
+              style={{
+                fontFamily: FONT_SANS, fontSize: 12, fontWeight: 500,
+                padding: '6px 14px', borderRadius: 4, cursor: running || disabled ? 'default' : 'pointer',
+                background: running || disabled ? BG_RAISED : ACCENT,
+                color: running || disabled ? INK_DIM : ACCENT_INK,
+                border: 'none', opacity: running || disabled ? 0.5 : 1,
+              }}
+            >
+              {running ? 'Running...' : 'Run Now'}
+            </button>
+
+            {/* Enable/disable toggle */}
+            <button
+              onClick={onToggleEnabled}
+              style={{
+                width: 36, height: 20, borderRadius: 10, border: 'none', cursor: 'pointer',
+                background: action.enabled ? SAGE : BG_RAISED,
+                position: 'relative', transition: 'background 0.2s',
+              }}
+              title={action.enabled ? 'Disable heartbeat' : 'Enable heartbeat'}
+            >
+              <div style={{
+                width: 14, height: 14, borderRadius: '50%',
+                background: '#fff', position: 'absolute', top: 3,
+                left: action.enabled ? 19 : 3,
+                transition: 'left 0.2s',
+              }} />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/agent/hooks/useHeartbeat.ts
+++ b/frontend/src/agent/hooks/useHeartbeat.ts
@@ -1,0 +1,320 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { api } from '../../core/api/client';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ScheduledAction {
+  id: string;
+  agent: string;
+  action_type: string;
+  schedule_type: string;
+  name: string;
+  description: string;
+  interval_minutes: number | null;
+  cron_expression: string | null;
+  active_hours_start: string;
+  active_hours_end: string;
+  active_hours_tz: string;
+  model_override: string | null;
+  max_tool_iterations: number;
+  triage_enabled: boolean;
+  enabled: boolean;
+  always_on: boolean;
+  notify_on_action: boolean;
+  next_run: string | null;
+  last_run: string | null;
+  last_status: string | null;
+  last_result: string | null;
+  last_duration_ms: number | null;
+  total_runs: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  consecutive_errors: number;
+}
+
+export interface ActivityRecord {
+  id: string;
+  agent: string;
+  action_type: string;
+  started_at: string;
+  status: string;
+  result_summary: string | null;
+  result_full: string | null;
+  tool_calls: { tool: string; args: Record<string, unknown>; result: string; duration_ms: number }[] | null;
+  model_used: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  duration_ms: number;
+}
+
+export interface ParsedLine {
+  type: 'heading' | 'blank' | 'passthrough' | 'list-item';
+  raw: string;
+  prefix?: string;
+  text?: string;
+  checked?: boolean;
+  id?: string;
+}
+
+// ── Parsing ──────────────────────────────────────────────────────────────────
+
+export function parseHeartbeat(markdown: string): { lines: ParsedLine[]; canEditCards: boolean } {
+  if (!markdown.trim()) return { lines: [], canEditCards: true };
+
+  const lines: ParsedLine[] = [];
+  let hasIndented = false;
+
+  for (const line of markdown.split('\n')) {
+    const trimmed = line.trim();
+
+    if (!trimmed) { lines.push({ type: 'blank', raw: line }); continue; }
+    if (trimmed.startsWith('#')) { lines.push({ type: 'heading', raw: line }); continue; }
+
+    const indent = line.length - line.trimStart().length;
+    if (indent > 0 && /^[-*]/.test(trimmed)) {
+      hasIndented = true;
+      lines.push({ type: 'passthrough', raw: line });
+      continue;
+    }
+
+    const checkboxMatch = trimmed.match(/^([-*]\s*\[[ xX]\]\s*)(.+)$/);
+    if (checkboxMatch) {
+      lines.push({
+        type: 'list-item', raw: line,
+        prefix: checkboxMatch[1],
+        checked: /\[[xX]\]/.test(checkboxMatch[1]),
+        text: checkboxMatch[2],
+        id: crypto.randomUUID(),
+      });
+      continue;
+    }
+
+    const listMatch = trimmed.match(/^([-*]\s+)(.+)$/);
+    if (listMatch) {
+      lines.push({
+        type: 'list-item', raw: line,
+        prefix: listMatch[1],
+        text: listMatch[2],
+        id: crypto.randomUUID(),
+      });
+      continue;
+    }
+
+    lines.push({ type: 'passthrough', raw: line });
+  }
+
+  return { lines, canEditCards: !hasIndented };
+}
+
+export function serializeHeartbeat(lines: ParsedLine[]): string {
+  return lines.map(line => {
+    if (line.type === 'list-item') {
+      const bullet = line.prefix?.startsWith('*') ? '*' : '-';
+      if (line.checked !== undefined) {
+        return `${bullet} ${line.checked ? '[x]' : '[ ]'} ${line.text}`;
+      }
+      return `${bullet} ${line.text}`;
+    }
+    return line.raw;
+  }).join('\n');
+}
+
+// ── Boolean normalization (SQLite returns 0|1) ──────────────────────────────
+
+function normalizeAction(raw: Record<string, unknown>): ScheduledAction {
+  return {
+    ...raw,
+    enabled: Boolean(raw.enabled),
+    always_on: Boolean(raw.always_on),
+    triage_enabled: Boolean(raw.triage_enabled),
+    notify_on_action: Boolean(raw.notify_on_action),
+  } as ScheduledAction;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+interface UseHeartbeatResult {
+  action: ScheduledAction | null;
+  parsedLines: ParsedLine[];
+  canEditCards: boolean;
+  rawMarkdown: string;
+  history: ActivityRecord[];
+  loading: boolean;
+  running: boolean;
+  actionError: boolean;
+  countdown: string;
+  runNow: () => Promise<void>;
+  toggleEnabled: () => Promise<void>;
+  updateConfig: (fields: Record<string, unknown>) => Promise<void>;
+  saveChecklist: (lines: ParsedLine[]) => Promise<void>;
+  saveRawChecklist: (raw: string) => Promise<void>;
+  refetchAll: () => Promise<void>;
+}
+
+export function useHeartbeat(agentSlug: string, apiPrefix: string): UseHeartbeatResult {
+  const [action, setAction] = useState<ScheduledAction | null>(null);
+  const [parsedLines, setParsedLines] = useState<ParsedLine[]>([]);
+  const [canEditCards, setCanEditCards] = useState(true);
+  const [rawMarkdown, setRawMarkdown] = useState('');
+  const [history, setHistory] = useState<ActivityRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [countdown, setCountdown] = useState('');
+  const [actionError, setActionError] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
+  const mountedRef = useRef(true);
+
+  const fetchAction = useCallback(async () => {
+    try {
+      const data = await api<{ actions: Record<string, unknown>[] }>(`/api/scheduled-actions/${agentSlug}`);
+      const hb = data.actions.find((a) => a.action_type === 'heartbeat');
+      if (hb && mountedRef.current) {
+        setAction(normalizeAction(hb));
+        setActionError(false);
+      }
+    } catch {
+      if (mountedRef.current) setActionError(true);
+    }
+  }, [agentSlug]);
+
+  const fetchChecklist = useCallback(async () => {
+    try {
+      const data = await api<{ content: string }>(`${apiPrefix}/context/HEARTBEAT.md`);
+      if (!mountedRef.current) return;
+      setRawMarkdown(data.content);
+      const parsed = parseHeartbeat(data.content);
+      setParsedLines(parsed.lines);
+      setCanEditCards(parsed.canEditCards);
+    } catch (e) {
+      if (mountedRef.current && e instanceof Error && e.message.includes('404')) {
+        setRawMarkdown('');
+        setParsedLines([]);
+        setCanEditCards(true);
+      }
+    }
+  }, [apiPrefix]);
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      const data = await api<{ activities: ActivityRecord[] }>(`${apiPrefix}/activity?limit=30`);
+      if (!mountedRef.current) return;
+      setHistory(data.activities.filter(r => r.action_type === 'heartbeat').slice(0, 10));
+    } catch { /* supplementary */ }
+  }, [apiPrefix]);
+
+  const refetchAll = useCallback(async () => {
+    await Promise.all([fetchAction(), fetchChecklist(), fetchHistory()]);
+  }, [fetchAction, fetchChecklist, fetchHistory]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    (async () => {
+      await Promise.all([fetchAction(), fetchChecklist(), fetchHistory()]);
+      if (mountedRef.current) setLoading(false);
+    })();
+    return () => { mountedRef.current = false; };
+  }, [fetchAction, fetchChecklist, fetchHistory]);
+
+  // Retry if no action found (sweeper may not have created it yet), max 3 retries
+  useEffect(() => {
+    if (loading || action || retryCount >= 3) {
+      if (!loading && !action && retryCount >= 3 && !actionError) {
+        setActionError(true);
+      }
+      return;
+    }
+    const timer = setTimeout(async () => {
+      await fetchAction();
+      if (mountedRef.current) setRetryCount(c => c + 1);
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [loading, action, retryCount, actionError, fetchAction]);
+
+  // Countdown timer
+  useEffect(() => {
+    if (!action?.next_run || !action.enabled || running) {
+      setCountdown(running ? 'Running...' : action && !action.enabled ? 'Paused' : '--:--');
+      return;
+    }
+
+    function tick() {
+      const next = new Date(action!.next_run + 'Z').getTime();
+      const diff = next - Date.now();
+      if (diff <= 0) { setCountdown('Due now'); return; }
+      const h = Math.floor(diff / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      setCountdown(h > 0 ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}` : `${m}:${String(s).padStart(2, '0')}`);
+    }
+
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [action?.next_run, action?.enabled, running]);
+
+  const runNow = useCallback(async () => {
+    if (!action) return;
+    setRunning(true);
+    try {
+      await api(`/api/scheduled-actions/${action.id}/run-now`, { method: 'POST' });
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('409')) {
+        alert('Heartbeat is already running.');
+      }
+    } finally {
+      setRunning(false);
+      await Promise.all([fetchAction(), fetchHistory()]);
+    }
+  }, [action, fetchAction, fetchHistory]);
+
+  const toggleEnabled = useCallback(async () => {
+    if (!action) return;
+    const next = !action.enabled;
+    setAction(prev => prev ? { ...prev, enabled: next } : prev);
+    try {
+      await api(`/api/scheduled-actions/${action.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ enabled: next }),
+      });
+      await fetchAction();
+    } catch {
+      setAction(prev => prev ? { ...prev, enabled: !next } : prev);
+    }
+  }, [action, fetchAction]);
+
+  const updateConfig = useCallback(async (fields: Record<string, unknown>) => {
+    if (!action) return;
+    await api(`/api/scheduled-actions/${action.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(fields),
+    });
+    await fetchAction();
+  }, [action, fetchAction]);
+
+  const saveChecklist = useCallback(async (lines: ParsedLine[]) => {
+    const content = serializeHeartbeat(lines);
+    await api(`${apiPrefix}/context/HEARTBEAT.md`, {
+      method: 'PUT',
+      body: JSON.stringify({ content }),
+    });
+    setRawMarkdown(content);
+    setParsedLines(lines);
+  }, [apiPrefix]);
+
+  const saveRawChecklist = useCallback(async (raw: string) => {
+    await api(`${apiPrefix}/context/HEARTBEAT.md`, {
+      method: 'PUT',
+      body: JSON.stringify({ content: raw }),
+    });
+    setRawMarkdown(raw);
+    const parsed = parseHeartbeat(raw);
+    setParsedLines(parsed.lines);
+    setCanEditCards(parsed.canEditCards);
+  }, [apiPrefix]);
+
+  return {
+    action, parsedLines, canEditCards, rawMarkdown, history,
+    loading, running, actionError, countdown,
+    runNow, toggleEnabled, updateConfig, saveChecklist, saveRawChecklist, refetchAll,
+  };
+}


### PR DESCRIPTION
## Summary

- Replaces the flat Activity log with a rich **Heartbeat** tab that gives users a mission-control view of their agent's scheduled heartbeat system
- **Status bar**: live countdown to next run, schedule interval display, last-run status dot, "Run Now" button (synchronous), enable/disable toggle with error pause banner
- **Checklist editor**: non-destructive HEARTBEAT.md parser that renders flat list items as editable cards (add/edit/delete/checkbox toggle) with an explicit Save button; falls back to raw textarea for nested/indented markdown
- **Execution history**: last 10 heartbeat runs as expandable accordion with tool call details, token counts, and model info; filters out non-heartbeat records client-side
- **Configuration panel**: essential settings (interval, triage toggle) always visible; advanced settings (always-on, active hours, model override, max iterations) behind disclosure; dirty tracking with Save Changes button
- Legacy `?tab=activity` URL params automatically map to the new `heartbeat` tab
- No backend changes required — uses existing scheduled-actions, context, and activity APIs

## Test plan

- [ ] Navigate to an agent → Heartbeat tab renders with countdown, checklist, history, and config
- [ ] Add/edit/delete checklist items → Save → verify HEARTBEAT.md updated via Knowledge tab
- [ ] Click "Run Now" → spinner appears, execution completes, history refreshes, countdown resets
- [ ] Change interval → Save Changes → verify next_run updates
- [ ] Toggle enable/disable → verify heartbeat pauses/resumes
- [ ] Test with `?tab=activity` URL → redirects to heartbeat tab
- [ ] Test empty state (agent with no HEARTBEAT.md) → shows "Add your first task"
- [ ] Test mobile viewport → responsive stacking
- [ ] `tsc -p tsconfig.app.json --noEmit` passes
- [ ] `vite build` succeeds