### PR TITLE
Fix Heartbeat tab failing to load for pre-existing agents

### DIFF
--- a/backend/core/agents/scheduled_actions/service.py
+++ b/backend/core/agents/scheduled_actions/service.py
@@ -597,8 +597,8 @@ def ensure_default_actions(agent_slug: str) -> None:
                 update_action(action["id"], always_on=True)
         return
 
-    # Check for legacy "cron" actions that haven't been migrated yet
-    legacy = list_actions(agent=agent_slug, action_type="cron")
+    # Check for legacy "cron" heartbeat actions that haven't been migrated yet
+    legacy = [a for a in list_actions(agent=agent_slug, action_type="cron") if a.get("name") == "Heartbeat"]
     if legacy:
         for action in legacy:
             if not action.get("always_on"):
@@ -665,11 +665,12 @@ def _run_one_time_migrations() -> None:
             (now,),
         ).rowcount
 
-        # Reclassify legacy "cron" heartbeat actions so the Heartbeat UI can find them
+        # Reclassify legacy "cron" heartbeat actions so the Heartbeat UI can find them.
+        # Only targets system-created heartbeats (name='Heartbeat'), not agent-created cron jobs.
         reclassified = conn.execute(
             """UPDATE scheduled_actions SET
                action_type = 'heartbeat', updated_at = ?
-               WHERE action_type = 'cron'""",
+               WHERE action_type = 'cron' AND name = 'Heartbeat'""",
             (now,),
         ).rowcount
 

--- a/backend/core/agents/scheduled_actions/service.py
+++ b/backend/core/agents/scheduled_actions/service.py
@@ -597,6 +597,11 @@ def ensure_default_actions(agent_slug: str) -> None:
                 update_action(action["id"], always_on=True)
         return
 
+    # Check for legacy "cron" actions that haven't been migrated yet
+    legacy = list_actions(agent=agent_slug, action_type="cron")
+    if legacy:
+        return
+
     create_action(
         agent=agent_slug,
         schedule_type="interval",
@@ -657,12 +662,21 @@ def _run_one_time_migrations() -> None:
             (now,),
         ).rowcount
 
-        if re_enabled or bumped:
+        # Reclassify legacy "cron" heartbeat actions so the Heartbeat UI can find them
+        reclassified = conn.execute(
+            """UPDATE scheduled_actions SET
+               action_type = 'heartbeat', updated_at = ?
+               WHERE action_type = 'cron'""",
+            (now,),
+        ).rowcount
+
+        if re_enabled or bumped or reclassified:
             conn.commit()
             logger.info(
                 "One-time migration: re-enabled %d actions (old threshold), "
-                "bumped max_tool_iterations on %d actions",
-                re_enabled, bumped,
+                "bumped max_tool_iterations on %d actions, "
+                "reclassified %d cron→heartbeat",
+                re_enabled, bumped, reclassified,
             )
 
 

--- a/backend/core/agents/scheduled_actions/service.py
+++ b/backend/core/agents/scheduled_actions/service.py
@@ -600,6 +600,9 @@ def ensure_default_actions(agent_slug: str) -> None:
     # Check for legacy "cron" actions that haven't been migrated yet
     legacy = list_actions(agent=agent_slug, action_type="cron")
     if legacy:
+        for action in legacy:
+            if not action.get("always_on"):
+                update_action(action["id"], always_on=True)
         return
 
     create_action(

--- a/frontend/src/agent/hooks/useHeartbeat.ts
+++ b/frontend/src/agent/hooks/useHeartbeat.ts
@@ -198,7 +198,7 @@ export function useHeartbeat(agentSlug: string, apiPrefix: string): UseHeartbeat
     try {
       const data = await api<{ activities: ActivityRecord[] }>(`${apiPrefix}/activity?limit=30`);
       if (!mountedRef.current) return;
-      setHistory(data.activities.filter(r => r.action_type === 'heartbeat').slice(0, 10));
+      setHistory(data.activities.filter(r => r.action_type === 'heartbeat' || r.action_type === 'cron').slice(0, 10));
     } catch { /* supplementary */ }
   }, [apiPrefix]);
 


### PR DESCRIPTION
## Summary

- Pre-existing agents had `action_type="cron"` in the database, but the new Heartbeat UI filters for `action_type="heartbeat"` — causing "Could not load heartbeat configuration" error
- Added a one-time migration to reclassify `cron` → `heartbeat` in the `scheduled_actions` table, runs automatically via the sweeper within 5 minutes of deploy
- Guarded `ensure_default_actions` against creating duplicate actions for agents with legacy "cron" records
- Updated frontend history filter to accept both "heartbeat" and "cron" action types so old execution logs display immediately

## Test plan

- [ ] Deploy and verify the Heartbeat tab loads for Tom (and any other pre-existing agent)
- [ ] Confirm the status bar shows countdown, Run Now button, and enable/disable toggle
- [ ] Confirm Recent Runs section shows historical heartbeat activity
- [ ] Check server logs for the migration message: `reclassified N cron→heartbeat`