### PR TITLE
Multi-account-per-service Google Workspace selection for agents

### DIFF
--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -134,10 +134,15 @@ def _normalize_agent(row: dict) -> dict:
     d = dict(row)
     raw = d.get("google_accounts", "{}")
     try:
-        d["google_accounts"] = json.loads(raw) if isinstance(raw, str) else (raw or {})
+        parsed = json.loads(raw) if isinstance(raw, str) else (raw or {})
     except (json.JSONDecodeError, TypeError):
         logger.warning("Malformed google_accounts for agent %s, treating as empty", d.get("id"))
-        d["google_accounts"] = {}
+        parsed = {}
+    for svc in ("gmail", "calendar", "drive"):
+        val = parsed.get(svc)
+        if isinstance(val, str):
+            parsed[svc] = [val] if val else []
+    d["google_accounts"] = parsed
     return d
 
 

--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -142,6 +142,10 @@ def _normalize_agent(row: dict) -> dict:
         val = parsed.get(svc)
         if isinstance(val, str):
             parsed[svc] = [val] if val else []
+        elif not isinstance(val, list):
+            parsed[svc] = []
+        else:
+            parsed[svc] = [v for v in val if isinstance(v, str) and v]
     d["google_accounts"] = parsed
     return d
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -237,18 +237,23 @@ async def update_agent(agent_id: str, body: UpdateAgentRequest, user=Depends(get
         _ALLOWED_GA_KEYS = {"gmail", "calendar", "drive"}
         if not isinstance(ga, dict) or not set(ga.keys()).issubset(_ALLOWED_GA_KEYS):
             raise HTTPException(status_code=400, detail="google_accounts keys must be a subset of {gmail, calendar, drive}")
-        if not all(isinstance(v, str) for v in ga.values()):
-            raise HTTPException(status_code=400, detail="google_accounts values must be strings")
+        for svc, ids in ga.items():
+            if not isinstance(ids, list) or not all(isinstance(i, str) and i for i in ids):
+                raise HTTPException(status_code=400, detail=f"google_accounts[{svc}] must be a list of non-empty strings")
+            if len(ids) != len(set(ids)):
+                raise HTTPException(status_code=400, detail=f"google_accounts[{svc}] contains duplicate account IDs")
         from integrations.registry import list_google_accounts
         existing = list_google_accounts()
-        for svc, acct_id in ga.items():
-            if not acct_id:
-                continue
-            if acct_id not in existing:
-                raise HTTPException(status_code=400, detail=f"Invalid Google account assignment for {svc}")
-            grants = existing[acct_id].get("scope_grants", {})
-            if grants.get(svc, "none") == "none":
-                raise HTTPException(status_code=400, detail=f"Invalid Google account assignment for {svc}")
+        for svc, acct_ids in ga.items():
+            for acct_id in acct_ids:
+                if acct_id not in existing:
+                    raise HTTPException(status_code=400, detail=f"Invalid Google account assignment for {svc}")
+                acct = existing[acct_id]
+                if acct.get("connection_status") == "broken":
+                    raise HTTPException(status_code=400, detail=f"Google account {acct.get('email', acct_id)} has a broken connection")
+                grants = acct.get("scope_grants", {})
+                if grants.get(svc, "none") == "none":
+                    raise HTTPException(status_code=400, detail=f"Google account {acct.get('email', acct_id)} does not have {svc} access")
         updates["google_accounts"] = _json.dumps(ga)
 
     for field in (
@@ -462,10 +467,17 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
         raise HTTPException(status_code=400, detail="No AI provider configured")
 
     ga = config.google_accounts
-    gmail_account_id = ga.get("gmail", "")
-    calendar_account_id = ga.get("calendar", "")
-    drive_account_id = ga.get("drive", "")
-    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    from integrations.registry import list_google_accounts as _list_ga
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
 
     integration_tool_defs, integration_executors = load_integration_tools()
 
@@ -481,9 +493,10 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
         context_dir=config.context_dir,
         gcs_prefix=config.gcs_prefix,
         google_connected=google_connected,
-        gmail_account_id=gmail_account_id,
-        calendar_account_id=calendar_account_id,
-        drive_account_id=drive_account_id,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
         integration_executors=integration_executors,
         agent_slug=agent["slug"],
         agent_name=config.agent_name,
@@ -890,10 +903,17 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
 
     store = CredentialStore()
     ga = config.google_accounts
-    gmail_account_id = ga.get("gmail", "")
-    calendar_account_id = ga.get("calendar", "")
-    drive_account_id = ga.get("drive", "")
-    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    from integrations.registry import list_google_accounts as _list_ga
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
 
     integration_tool_defs, integration_executors = load_integration_tools()
     reminder_handlers, sa_handlers = build_agent_handlers(agent["slug"])
@@ -902,9 +922,10 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
         context_dir=config.context_dir,
         gcs_prefix=config.gcs_prefix,
         google_connected=google_connected,
-        gmail_account_id=gmail_account_id,
-        calendar_account_id=calendar_account_id,
-        drive_account_id=drive_account_id,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
         integration_executors=integration_executors,
         agent_slug=agent["slug"],
         reminder_handlers=reminder_handlers,
@@ -912,10 +933,10 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
     )
 
     from core.agents.tool_definitions import get_tool_definitions, build_writes_map
-    from integrations.google.policy import google_capabilities
-    gmail_caps = google_capabilities(gmail_account_id)
-    cal_caps = google_capabilities(calendar_account_id)
-    drive_caps = google_capabilities(drive_account_id)
+    from integrations.google.policy import google_capabilities_union
+    gmail_caps = google_capabilities_union(gmail_ids)
+    cal_caps = google_capabilities_union(calendar_ids)
+    drive_caps = google_capabilities_union(drive_ids)
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
         gmail_read_enabled=gmail_caps["gmail_read_enabled"],

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -235,8 +235,11 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
     return (
         "## Google Accounts\n\n"
         "You have multiple Google accounts available. Use the `account` parameter "
-        "in Gmail/Calendar/Drive tools to specify which account to use. "
-        "If omitted, the first listed account is used by default.\n\n"
+        "in Gmail/Calendar/Drive tools to specify which account to use.\n"
+        "- For read operations: the first listed account is used by default.\n"
+        "- For write operations (send email, create event, etc.): the first account "
+        "with write access is used by default.\n"
+        "Always specify `account` when context makes the intended account clear.\n\n"
         + "\n\n".join(sections)
     )
 

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -215,6 +215,32 @@ When you've naturally covered the key topics:
 4. Just keep chatting normally. The transition should be invisible."""
 
 
+def _google_accounts_context(account_info_map: dict[str, dict], google_accounts: dict) -> str:
+    """Build system prompt section listing available Google accounts per service."""
+    sections = []
+    for service in ("gmail", "calendar", "drive"):
+        ids = google_accounts.get(service, [])
+        if len(ids) <= 1:
+            continue
+        entries = []
+        for i, aid in enumerate(ids):
+            info = account_info_map.get(aid, {})
+            email = info.get("email", aid)
+            suffix = " (default)" if i == 0 else ""
+            entries.append(f"  - {email}{suffix}")
+        label = service.title() if service != "gmail" else "Gmail"
+        sections.append(f"**{label}** accounts:\n" + "\n".join(entries))
+    if not sections:
+        return ""
+    return (
+        "## Google Accounts\n\n"
+        "You have multiple Google accounts available. Use the `account` parameter "
+        "in Gmail/Calendar/Drive tools to specify which account to use. "
+        "If omitted, the first listed account is used by default.\n\n"
+        + "\n\n".join(sections)
+    )
+
+
 def _build_system_prompt(
     config: AgentConfig,
     ctx_manager: ContextManager,
@@ -222,6 +248,7 @@ def _build_system_prompt(
     training_type: str | None = None,
     plan_mode: bool = False,
     first_user_message: str = "",
+    account_info_map: dict[str, dict] | None = None,
 ) -> tuple[str, str]:
     """Assemble the full system prompt.
 
@@ -322,6 +349,11 @@ def _build_system_prompt(
 
     if plan_mode:
         parts.append(_plan_mode_instructions())
+
+    if account_info_map:
+        ga_ctx = _google_accounts_context(account_info_map, config.google_accounts)
+        if ga_ctx:
+            parts.append(ga_ctx)
 
     static_text = "\n".join(parts)
 
@@ -645,10 +677,14 @@ async def chat(
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
 
-    from integrations.google.policy import google_capabilities
-    gmail_caps = google_capabilities(config.google_accounts.get("gmail", ""))
-    cal_caps = google_capabilities(config.google_accounts.get("calendar", ""))
-    drive_caps = google_capabilities(config.google_accounts.get("drive", ""))
+    from integrations.google.policy import google_capabilities_union
+    ga = config.google_accounts
+    gmail_ids = ga.get("gmail", [])
+    cal_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    gmail_caps = google_capabilities_union(gmail_ids)
+    cal_caps = google_capabilities_union(cal_ids)
+    drive_caps = google_capabilities_union(drive_ids)
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
@@ -659,6 +695,9 @@ async def chat(
         calendar_write_enabled=cal_caps["calendar_write_enabled"],
         drive_read_enabled=drive_caps["drive_read_enabled"],
         drive_write_enabled=drive_caps["drive_write_enabled"],
+        multi_gmail=len(gmail_ids) > 1,
+        multi_calendar=len(cal_ids) > 1,
+        multi_drive=len(drive_ids) > 1,
     )
     kind_map = _build_kind_map(tool_defs)
     writes_map = build_writes_map(tool_defs)
@@ -756,6 +795,7 @@ async def chat(
         training_type=training_type,
         plan_mode=plan_mode,
         first_user_message=first_user_msg,
+        account_info_map=getattr(registry, "account_info_map", None),
     )
 
     # Append integration-specific instructions to the static portion
@@ -1088,10 +1128,14 @@ async def run_sync(
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
 
-    from integrations.google.policy import google_capabilities
-    gmail_caps = google_capabilities(config.google_accounts.get("gmail", ""))
-    cal_caps = google_capabilities(config.google_accounts.get("calendar", ""))
-    drive_caps = google_capabilities(config.google_accounts.get("drive", ""))
+    from integrations.google.policy import google_capabilities_union
+    ga = config.google_accounts
+    gmail_ids = ga.get("gmail", [])
+    cal_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    gmail_caps = google_capabilities_union(gmail_ids)
+    cal_caps = google_capabilities_union(cal_ids)
+    drive_caps = google_capabilities_union(drive_ids)
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
@@ -1101,6 +1145,9 @@ async def run_sync(
         calendar_write_enabled=cal_caps["calendar_write_enabled"],
         drive_read_enabled=drive_caps["drive_read_enabled"],
         drive_write_enabled=drive_caps["drive_write_enabled"],
+        multi_gmail=len(gmail_ids) > 1,
+        multi_calendar=len(cal_ids) > 1,
+        multi_drive=len(drive_ids) > 1,
     )
 
     # Apply integration permission ceilings — messaging channels have no approval UI,
@@ -1121,7 +1168,10 @@ async def run_sync(
     provider_tools = [{k: v for k, v in t.items() if k not in _internal_fields} for t in tool_defs]
 
     # Build system prompt (returns tuple for caching)
-    static_prompt, volatile_prompt = _build_system_prompt(config, ctx_manager)
+    static_prompt, volatile_prompt = _build_system_prompt(
+        config, ctx_manager,
+        account_info_map=getattr(registry, "account_info_map", None),
+    )
 
     # Append integration-specific instructions (same as chat())
     if integration_tool_defs:

--- a/backend/core/agents/config.py
+++ b/backend/core/agents/config.py
@@ -33,7 +33,7 @@ class AgentConfig:
     drive_enabled: bool = False
     drive_write_enabled: bool = False
 
-    # Per-service Google account assignments {"gmail": "acc_id", "calendar": "acc_id", "drive": "acc_id"}
+    # Per-service Google account assignments {"gmail": ["acc_id", ...], "calendar": [...], "drive": [...]}
     google_accounts: dict = field(default_factory=dict)
 
     # Context directory (absolute path)

--- a/backend/core/agents/reminders/heartbeat.py
+++ b/backend/core/agents/reminders/heartbeat.py
@@ -94,17 +94,30 @@ def _process_self_reminder(reminder: dict) -> None:
 
     from agents.tool_loader import load_integration_tools, build_agent_handlers, INTEGRATION_MODULES
     from agents.engine import build_agent_config
-    from integrations.registry import is_enabled as _is_enabled, get_tool_mode
-    from integrations.google.policy import google_capabilities
+    from integrations.registry import is_enabled as _is_enabled, get_tool_mode, list_google_accounts as _list_ga
+    from integrations.google.policy import google_capabilities_union
     from core.agents.tool_registry import ToolRegistry
     from core.agents.tool_definitions import get_tool_definitions
     from core.agents.tools.real_tools import load_all_real_tools
     from pathlib import Path
 
     config = build_agent_config(agent)
-    google_connected = _is_enabled("google")
+    ga = config.google_accounts
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
+
     integration_tool_defs, integration_executors = load_integration_tools()
-    google_caps = google_capabilities()
+    gmail_caps = google_capabilities_union(gmail_ids)
+    cal_caps = google_capabilities_union(calendar_ids)
+    drive_caps = google_capabilities_union(drive_ids)
     reminder_handlers, sa_handlers = build_agent_handlers(agent["slug"])
 
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
@@ -114,7 +127,15 @@ def _process_self_reminder(reminder: dict) -> None:
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
         web_enabled=True,
-        **google_caps,
+        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
+        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
+        calendar_read_enabled=cal_caps["calendar_read_enabled"],
+        calendar_write_enabled=cal_caps["calendar_write_enabled"],
+        drive_read_enabled=drive_caps["drive_read_enabled"],
+        drive_write_enabled=drive_caps["drive_write_enabled"],
+        multi_gmail=len(gmail_ids) > 1,
+        multi_calendar=len(calendar_ids) > 1,
+        multi_drive=len(drive_ids) > 1,
     )
 
     integration_modes = {name: get_tool_mode(name) for name in INTEGRATION_MODULES}
@@ -133,6 +154,10 @@ def _process_self_reminder(reminder: dict) -> None:
         agent_name=config.agent_name,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
     )
 
     try:

--- a/backend/core/agents/reminders/heartbeat.py
+++ b/backend/core/agents/reminders/heartbeat.py
@@ -71,25 +71,6 @@ def _process_self_reminder(reminder: dict) -> None:
     if reminder.get("recurrence_rule"):
         recurrence_line = "- **Recurrence:** This is a recurring reminder.\n"
 
-    system_prompt = (
-        (
-            f"You are {agent['agent_name']}, a helpful AI assistant.\n\n"
-            f"# Reminder Triggered\n\n"
-            f"A reminder you set has fired. Take appropriate action.\n\n"
-            f"- **Message:** {reminder['message']}\n"
-            f"- **Context:** {reminder.get('context') or 'None'}\n"
-            f"- **Originally set at:** {reminder['created_at']}\n"
-            f"{recurrence_line}\n"
-            f"# Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
-        ),
-        (
-            f"# Current Date & Time\n\n"
-            f"- Date: {date_str}\n"
-            f"- Time: {time_str}\n\n"
-            f"Take any appropriate action using your tools. Be concise."
-        ),
-    )
-
     user_message = f"Your reminder just fired: {reminder['message']}"
 
     from agents.tool_loader import load_integration_tools, build_agent_handlers, INTEGRATION_MODULES
@@ -158,6 +139,28 @@ def _process_self_reminder(reminder: dict) -> None:
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
         account_info_map=account_info_map,
+    )
+
+    from core.agents.ai_service import _google_accounts_context
+    ga_ctx = _google_accounts_context(account_info_map, ga)
+    system_prompt = (
+        (
+            f"You are {agent['agent_name']}, a helpful AI assistant.\n\n"
+            + (f"{ga_ctx}\n\n" if ga_ctx else "")
+            + f"# Reminder Triggered\n\n"
+            f"A reminder you set has fired. Take appropriate action.\n\n"
+            f"- **Message:** {reminder['message']}\n"
+            f"- **Context:** {reminder.get('context') or 'None'}\n"
+            f"- **Originally set at:** {reminder['created_at']}\n"
+            f"{recurrence_line}\n"
+            f"# Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
+        ),
+        (
+            f"# Current Date & Time\n\n"
+            f"- Date: {date_str}\n"
+            f"- Time: {time_str}\n\n"
+            f"Take any appropriate action using your tools. Be concise."
+        ),
     )
 
     try:

--- a/backend/core/agents/router_factory.py
+++ b/backend/core/agents/router_factory.py
@@ -81,17 +81,25 @@ def create_agent_router(
             raise HTTPException(status_code=400, detail="No AI provider configured")
 
         ga = config.google_accounts
-        gmail_account_id = ga.get("gmail", "")
-        calendar_account_id = ga.get("calendar", "")
-        drive_account_id = ga.get("drive", "")
-        google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
+        gmail_ids = ga.get("gmail", [])
+        calendar_ids = ga.get("calendar", [])
+        drive_ids = ga.get("drive", [])
+        google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+        from integrations.registry import list_google_accounts as _list_ga
+        all_ga = _list_ga()
+        account_info_map = {
+            aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+            for aid, a in all_ga.items()
+        }
 
         registry = ToolRegistry(
             context_dir=config.context_dir,
             google_connected=google_connected,
-            gmail_account_id=gmail_account_id,
-            calendar_account_id=calendar_account_id,
-            drive_account_id=drive_account_id,
+            gmail_account_ids=gmail_ids,
+            calendar_account_ids=calendar_ids,
+            drive_account_ids=drive_ids,
+            account_info_map=account_info_map,
         )
 
         # Anthropic API key for smart title generation (haiku)

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -460,7 +460,8 @@ def _process_heartbeat(action: dict) -> None:
         system_prompt = (
             (
                 f"You are {agent['agent_name']}.\n\n"
-                f"# Heartbeat Check\n\n"
+                + (f"{ga_ctx}\n\n" if ga_ctx else "")
+                + f"# Heartbeat Check\n\n"
                 f"You are performing a periodic heartbeat check. Review your checklist "
                 f"and check each item against current data using your tools.\n\n"
                 f"## Your Checklist\n\n{checklist}\n\n"

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -371,9 +371,6 @@ def _process_heartbeat(action: dict) -> None:
     _cfg = _bac(agent)
     ga_ctx = _google_accounts_context(account_info_map, _cfg.google_accounts)
 
-    from core.agents.ai_service import _google_accounts_context
-    ga_ctx = _google_accounts_context(account_info_map, ga)
-
     start_time = time.monotonic()
     try:
         triage_data = None

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -371,6 +371,9 @@ def _process_heartbeat(action: dict) -> None:
     _cfg = _bac(agent)
     ga_ctx = _google_accounts_context(account_info_map, _cfg.google_accounts)
 
+    from core.agents.ai_service import _google_accounts_context
+    ga_ctx = _google_accounts_context(account_info_map, ga)
+
     start_time = time.monotonic()
     try:
         triage_data = None
@@ -378,7 +381,8 @@ def _process_heartbeat(action: dict) -> None:
             triage_result = run_background_turn(
                 system_prompt=(
                     f"You are {agent['agent_name']}.\n\n"
-                    f"# Quick Heartbeat Triage — {date_str}, {time_str}\n\n"
+                    + (f"{ga_ctx}\n\n" if ga_ctx else "")
+                    + f"# Quick Heartbeat Triage — {date_str}, {time_str}\n\n"
                     f"Quickly check the following items using your tools. "
                     f"Respond with ONLY one of:\n"
                     f"- NEEDS_ACTION: <brief reason>\n"
@@ -570,10 +574,18 @@ def _process_cron(action: dict) -> None:
     from agents.tool_loader import format_current_time
     date_str, time_str = format_current_time(tz_name)
 
+    tool_defs, registry, _aim = _build_tools(agent_slug, agent)
+    on_iteration = _make_lease_renewer(action["id"], lease_id)
+
+    from core.agents.ai_service import _google_accounts_context
+    from agents.engine import build_agent_config as _bac2
+    _cfg2 = _bac2(agent)
+    ga_ctx2 = _google_accounts_context(_aim, _cfg2.google_accounts)
     system_prompt = (
         (
             f"You are {agent['agent_name']}.\n\n"
-            f"# Scheduled Action: {action.get('name', 'Unnamed')}\n\n"
+            + (f"{ga_ctx2}\n\n" if ga_ctx2 else "")
+            + f"# Scheduled Action: {action.get('name', 'Unnamed')}\n\n"
             f"{prompt}\n\n"
             f"# Your Knowledge (abbreviated)\n\n{context_snippet}\n\n"
         ),
@@ -584,9 +596,6 @@ def _process_cron(action: dict) -> None:
             f"Take appropriate action using your tools. Be concise."
         ),
     )
-
-    tool_defs, registry, _aim = _build_tools(agent_slug, agent)
-    on_iteration = _make_lease_renewer(action["id"], lease_id)
 
     start_time = time.monotonic()
     try:

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -155,18 +155,34 @@ def _within_active_hours(action: dict) -> bool:
         return current_minutes >= start_minutes or current_minutes < end_minutes
 
 
-def _build_tools(agent_slug: str, agent: dict) -> tuple[list[dict], ToolRegistry]:
-    """Build full tool definitions and registry with integration parity."""
+def _build_tools(agent_slug: str, agent: dict) -> tuple[list[dict], ToolRegistry, dict]:
+    """Build full tool definitions and registry with integration parity.
+
+    Returns (tool_defs, registry, account_info_map).
+    """
     from agents.tool_loader import load_integration_tools, build_agent_handlers, INTEGRATION_MODULES
     from agents.engine import build_agent_config
-    from integrations.registry import is_enabled as _is_enabled, get_tool_mode
-    from integrations.google.policy import google_capabilities
+    from integrations.registry import get_tool_mode, list_google_accounts as _list_ga
+    from integrations.google.policy import google_capabilities_union
     from core.agents.tools.real_tools import load_all_real_tools
 
     config = build_agent_config(agent)
-    google_connected = _is_enabled("google")
+    ga = config.google_accounts
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
+
     integration_tool_defs, integration_executors = load_integration_tools()
-    google_caps = google_capabilities()
+    gmail_caps = google_capabilities_union(gmail_ids)
+    cal_caps = google_capabilities_union(calendar_ids)
+    drive_caps = google_capabilities_union(drive_ids)
     reminder_handlers, sa_handlers = build_agent_handlers(agent_slug)
 
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
@@ -176,7 +192,15 @@ def _build_tools(agent_slug: str, agent: dict) -> tuple[list[dict], ToolRegistry
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
         web_enabled=True,
-        **google_caps,
+        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
+        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
+        calendar_read_enabled=cal_caps["calendar_read_enabled"],
+        calendar_write_enabled=cal_caps["calendar_write_enabled"],
+        drive_read_enabled=drive_caps["drive_read_enabled"],
+        drive_write_enabled=drive_caps["drive_write_enabled"],
+        multi_gmail=len(gmail_ids) > 1,
+        multi_calendar=len(calendar_ids) > 1,
+        multi_drive=len(drive_ids) > 1,
     )
 
     integration_modes = {name: get_tool_mode(name) for name in INTEGRATION_MODULES}
@@ -195,9 +219,13 @@ def _build_tools(agent_slug: str, agent: dict) -> tuple[list[dict], ToolRegistry
         agent_name=config.agent_name,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
     )
 
-    return tool_defs, registry
+    return tool_defs, registry, account_info_map
 
 
 def _make_lease_renewer(action_id: str, lease_id: str | None):
@@ -335,8 +363,13 @@ def _process_heartbeat(action: dict) -> None:
     context = ctx_manager.load_all_context()
     context_snippet = context[:30000] if context else "(no context files)"
 
-    tool_defs, registry = _build_tools(agent_slug, agent)
+    tool_defs, registry, account_info_map = _build_tools(agent_slug, agent)
     on_iteration = _make_lease_renewer(action["id"], lease_id)
+
+    from core.agents.ai_service import _google_accounts_context
+    from agents.engine import build_agent_config as _bac
+    _cfg = _bac(agent)
+    ga_ctx = _google_accounts_context(account_info_map, _cfg.google_accounts)
 
     start_time = time.monotonic()
     try:
@@ -552,7 +585,7 @@ def _process_cron(action: dict) -> None:
         ),
     )
 
-    tool_defs, registry = _build_tools(agent_slug, agent)
+    tool_defs, registry, _aim = _build_tools(agent_slug, agent)
     on_iteration = _make_lease_renewer(action["id"], lease_id)
 
     start_time = time.monotonic()

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1417,6 +1417,9 @@ def get_tool_definitions(
     integration_tools: list[dict] | None = None,
     dynamic_real_tools: list[dict] | None = None,
     import_mode: bool = False,
+    multi_gmail: bool = False,
+    multi_calendar: bool = False,
+    multi_drive: bool = False,
 ) -> list[dict]:
     """Return the full list of tool definitions for the given feature flags.
 
@@ -1477,4 +1480,31 @@ def get_tool_definitions(
     # Append agent-created real tools (loaded from filesystem)
     if dynamic_real_tools:
         tools.extend(dynamic_real_tools)
+
+    multi_services = set()
+    if multi_gmail:
+        multi_services.add("gmail")
+    if multi_calendar:
+        multi_services.add("calendar")
+    if multi_drive:
+        multi_services.add("drive")
+    if multi_services:
+        import copy
+        _ACCOUNT_PROP = {
+            "type": "string",
+            "description": "Email address of the Google account to use. Omit to use the default account.",
+        }
+        tools = [
+            _inject_account_param(copy.deepcopy(t), _ACCOUNT_PROP)
+            if t.get("kind") in multi_services else t
+            for t in tools
+        ]
+
     return tools
+
+
+def _inject_account_param(tool: dict, prop: dict) -> dict:
+    schema = tool.get("input_schema", {})
+    props = schema.get("properties", {})
+    props["account"] = prop
+    return tool

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -306,7 +306,8 @@ class ToolRegistry:
                 "needs_reconnect": True}
 
     def _execute_gmail(self, tool_name: str, args: dict) -> dict:
-        email = args.pop("account", None)
+        email = args.get("account")
+        args = {k: v for k, v in args.items() if k != "account"}
         aid = self._resolve_account("gmail", email, tool_name)
         if isinstance(aid, dict):
             return aid
@@ -363,7 +364,8 @@ class ToolRegistry:
         return {"error": f"Unknown gmail tool: {tool_name}"}
 
     def _execute_calendar(self, tool_name: str, args: dict) -> dict:
-        email = args.pop("account", None)
+        email = args.get("account")
+        args = {k: v for k, v in args.items() if k != "account"}
         aid = self._resolve_account("calendar", email, tool_name)
         if isinstance(aid, dict):
             return aid
@@ -417,7 +419,8 @@ class ToolRegistry:
         return {"error": f"Unknown calendar tool: {tool_name}"}
 
     def _execute_drive(self, tool_name: str, args: dict) -> dict:
-        email = args.pop("account", None)
+        email = args.get("account")
+        args = {k: v for k, v in args.items() if k != "account"}
         aid = self._resolve_account("drive", email, tool_name)
         if isinstance(aid, dict):
             return aid

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -68,14 +68,29 @@ logger = logging.getLogger(__name__)
 class ToolRegistry:
     """Per-agent tool executor. Routes tool calls to the correct handler."""
 
+    _WRITE_TOOLS = {
+        "gmail": {"send_email", "reply_to_email", "create_draft",
+                  "send_email_with_attachment", "reply_to_email_with_attachment"},
+        "calendar": {"create_calendar_event", "update_calendar_event", "delete_calendar_event"},
+        "drive": {"create_drive_folder", "create_drive_file", "move_drive_file",
+                  "rename_drive_file", "copy_drive_file"},
+    }
+    _WRITE_SCOPE_KEY = {"gmail": "gmail", "calendar": "calendar", "drive": "drive"}
+    _WRITE_SCOPE_LEVELS = {
+        "gmail": {"send"},
+        "calendar": {"full"},
+        "drive": {"file", "full"},
+    }
+
     def __init__(
         self,
         context_dir: str,
         gcs_prefix: str = "",
         google_connected: bool = False,
-        gmail_account_id: str = "",
-        calendar_account_id: str = "",
-        drive_account_id: str = "",
+        gmail_account_ids: list[str] | None = None,
+        calendar_account_ids: list[str] | None = None,
+        drive_account_ids: list[str] | None = None,
+        account_info_map: dict[str, dict] | None = None,
         integration_executors: dict | None = None,
         agent_slug: str = "",
         agent_name: str = "",
@@ -85,9 +100,10 @@ class ToolRegistry:
         self.context_dir = context_dir
         self.gcs_prefix = gcs_prefix
         self.google_connected = google_connected
-        self.gmail_account_id = gmail_account_id
-        self.calendar_account_id = calendar_account_id
-        self.drive_account_id = drive_account_id
+        self.gmail_account_ids = gmail_account_ids or []
+        self.calendar_account_ids = calendar_account_ids or []
+        self.drive_account_ids = drive_account_ids or []
+        self.account_info_map: dict[str, dict] = account_info_map or {}
         self.integration_executors: dict = integration_executors or {}
         self.agent_slug = agent_slug
         self.agent_name = agent_name
@@ -245,11 +261,55 @@ class ToolRegistry:
             )
         return {"error": f"Unknown shared_context tool: {tool_name}"}
 
-    def _execute_gmail(self, tool_name: str, args: dict) -> dict:
-        aid = self.gmail_account_id
-        if not aid:
-            return {"error": "No Gmail account assigned. Assign one at Settings → Integrations → Google.",
+    def _resolve_account(self, service: str, email: str | None, tool_name: str) -> str | dict:
+        """Resolve an account for a service. Returns account_id or error dict."""
+        ids = getattr(self, f"{service}_account_ids")
+        if not ids:
+            return {"error": f"No {service.title()} account assigned. Assign one at Settings → Integrations → Google.",
                     "needs_reconnect": True}
+        is_write = tool_name in self._WRITE_TOOLS.get(service, set())
+        if email:
+            matched_id = ""
+            for aid in ids:
+                info = self.account_info_map.get(aid, {})
+                if info.get("email", "").lower() == email.lower():
+                    matched_id = aid
+                    break
+            if not matched_id:
+                available = [self.account_info_map.get(a, {}).get("email", a) for a in ids]
+                return {"error": f"Account '{email}' is not assigned to this agent for {service.title()}. Available: {', '.join(available)}"}
+            info = self.account_info_map.get(matched_id, {})
+            if info.get("connection_status") == "broken":
+                return {"error": f"Account '{email}' has a broken connection. Reconnect at Settings → Integrations → Google.",
+                        "needs_reconnect": True}
+            if is_write:
+                grants = info.get("scope_grants", {})
+                level = grants.get(self._WRITE_SCOPE_KEY.get(service, service), "none")
+                if level not in self._WRITE_SCOPE_LEVELS.get(service, set()):
+                    return {"error": f"Account '{email}' has read-only {service.title()} access and cannot perform write operations."}
+            return matched_id
+        if is_write:
+            for aid in ids:
+                info = self.account_info_map.get(aid, {})
+                if info.get("connection_status") == "broken":
+                    continue
+                grants = info.get("scope_grants", {})
+                level = grants.get(self._WRITE_SCOPE_KEY.get(service, service), "none")
+                if level in self._WRITE_SCOPE_LEVELS.get(service, set()):
+                    return aid
+            return {"error": f"No assigned {service.title()} account has write access for this operation."}
+        for aid in ids:
+            info = self.account_info_map.get(aid, {})
+            if info.get("connection_status") != "broken":
+                return aid
+        return {"error": f"All assigned {service.title()} accounts have broken connections. Reconnect at Settings → Integrations → Google.",
+                "needs_reconnect": True}
+
+    def _execute_gmail(self, tool_name: str, args: dict) -> dict:
+        email = args.pop("account", None)
+        aid = self._resolve_account("gmail", email, tool_name)
+        if isinstance(aid, dict):
+            return aid
         if tool_name == "search_emails":
             return search_emails(aid, query=args["query"], max_results=args.get("max_results", 10))
         elif tool_name == "get_email":
@@ -303,10 +363,10 @@ class ToolRegistry:
         return {"error": f"Unknown gmail tool: {tool_name}"}
 
     def _execute_calendar(self, tool_name: str, args: dict) -> dict:
-        aid = self.calendar_account_id
-        if not aid:
-            return {"error": "No Calendar account assigned. Assign one at Settings → Integrations → Google.",
-                    "needs_reconnect": True}
+        email = args.pop("account", None)
+        aid = self._resolve_account("calendar", email, tool_name)
+        if isinstance(aid, dict):
+            return aid
         if tool_name == "list_calendar_events":
             return list_calendar_events(
                 aid, calendar_id=args.get("calendar_id", "primary"),
@@ -357,10 +417,10 @@ class ToolRegistry:
         return {"error": f"Unknown calendar tool: {tool_name}"}
 
     def _execute_drive(self, tool_name: str, args: dict) -> dict:
-        aid = self.drive_account_id
-        if not aid:
-            return {"error": "No Drive account assigned. Assign one at Settings → Integrations → Google.",
-                    "needs_reconnect": True}
+        email = args.pop("account", None)
+        aid = self._resolve_account("drive", email, tool_name)
+        if isinstance(aid, dict):
+            return aid
         if tool_name == "search_drive_files":
             return search_drive_files(
                 aid, query=args["query"],

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -70,7 +70,8 @@ class ToolRegistry:
 
     _WRITE_TOOLS = {
         "gmail": {"send_email", "reply_to_email", "create_draft",
-                  "send_email_with_attachment", "reply_to_email_with_attachment"},
+                  "send_email_with_attachment", "reply_to_email_with_attachment",
+                  "mark_email_as_read", "batch_mark_emails_as_read"},
         "calendar": {"create_calendar_event", "update_calendar_event", "delete_calendar_event"},
         "drive": {"create_drive_folder", "create_drive_file", "move_drive_file",
                   "rename_drive_file", "copy_drive_file"},

--- a/backend/integrations/google/onboarding.py
+++ b/backend/integrations/google/onboarding.py
@@ -121,16 +121,20 @@ def _clear_stale_assignments(account_id: str, scope_grants: dict) -> None:
     """Clear agent assignments for services that were downgraded to 'none'."""
     try:
         from agents.db import list_agents, update_agent
-        svc_map = {"gmail": "gmail", "calendar": "calendar", "drive": "drive"}
         for agent in list_agents():
             ga = agent.get("google_accounts", {})
             if not isinstance(ga, dict):
                 continue
             changed = False
-            for svc, scope_key in svc_map.items():
-                if ga.get(svc) == account_id and scope_grants.get(scope_key, "none") == "none":
-                    ga[svc] = ""
-                    changed = True
+            for svc in ("gmail", "calendar", "drive"):
+                val = ga.get(svc)
+                if scope_grants.get(svc, "none") == "none":
+                    if isinstance(val, list) and account_id in val:
+                        ga[svc] = [a for a in val if a != account_id]
+                        changed = True
+                    elif isinstance(val, str) and val == account_id:
+                        ga[svc] = []
+                        changed = True
             if changed:
                 update_agent(agent["id"], google_accounts=json.dumps(ga))
     except Exception as e:
@@ -168,13 +172,17 @@ def _clear_agent_references(account_id: str = "") -> None:
                 continue
             changed = False
             if account_id:
-                for svc, aid in list(ga.items()):
-                    if aid == account_id:
-                        ga[svc] = ""
+                for svc in ("gmail", "calendar", "drive"):
+                    val = ga.get(svc)
+                    if isinstance(val, list) and account_id in val:
+                        ga[svc] = [a for a in val if a != account_id]
+                        changed = True
+                    elif isinstance(val, str) and val == account_id:
+                        ga[svc] = []
                         changed = True
             else:
                 if any(v for v in ga.values()):
-                    ga = {"gmail": "", "calendar": "", "drive": ""}
+                    ga = {"gmail": [], "calendar": [], "drive": []}
                     changed = True
             if changed:
                 update_agent(agent["id"], google_accounts=json.dumps(ga))

--- a/backend/integrations/google/policy.py
+++ b/backend/integrations/google/policy.py
@@ -58,3 +58,16 @@ def google_capabilities(account_id: str = "") -> dict[str, bool]:
         "drive_read_enabled": drive in _DRIVE_READ_LEVELS,
         "drive_write_enabled": drive in _DRIVE_WRITE_LEVELS,
     }
+
+
+def google_capabilities_union(account_ids: list[str]) -> dict[str, bool]:
+    """Return capability flags as the union across multiple accounts."""
+    if not account_ids:
+        return dict(_ALL_DISABLED)
+    result = dict(_ALL_DISABLED)
+    for aid in account_ids:
+        caps = google_capabilities(aid)
+        for key, val in caps.items():
+            if val:
+                result[key] = True
+    return result

--- a/backend/integrations/paperclip/webhook.py
+++ b/backend/integrations/paperclip/webhook.py
@@ -166,10 +166,18 @@ async def handle_heartbeat(request: Request):
             )
 
         ga = config.google_accounts
-        gmail_account_id = ga.get("gmail", "")
-        calendar_account_id = ga.get("calendar", "")
-        drive_account_id = ga.get("drive", "")
-        google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
+        gmail_ids = ga.get("gmail", [])
+        calendar_ids = ga.get("calendar", [])
+        drive_ids = ga.get("drive", [])
+        google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+        from integrations.registry import list_google_accounts as _list_ga
+        all_ga = _list_ga()
+        account_info_map = {
+            aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+            for aid, a in all_ga.items()
+        }
+
         integration_tool_defs, integration_executors = _load_integration_tools()
 
         # Force Paperclip writes to "power" — no approval UI in headless mode
@@ -189,9 +197,10 @@ async def handle_heartbeat(request: Request):
             agent_slug=slug,
             reminder_handlers=reminder_handlers,
             scheduled_action_handlers=sa_handlers,
-            gmail_account_id=gmail_account_id,
-            calendar_account_id=calendar_account_id,
-            drive_account_id=drive_account_id,
+            gmail_account_ids=gmail_ids,
+            calendar_account_ids=calendar_ids,
+            drive_account_ids=drive_ids,
+            account_info_map=account_info_map,
         )
 
         # 6. Build task message

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -277,13 +277,13 @@ def migrate_google_json() -> None:
 
     try:
         from agents.db import list_agents, update_agent
-        ga = {}
+        ga: dict[str, list[str]] = {}
         if scope_grants.get("gmail", "none") != "none":
-            ga["gmail"] = account_id
+            ga["gmail"] = [account_id]
         if scope_grants.get("calendar", "none") != "none":
-            ga["calendar"] = account_id
+            ga["calendar"] = [account_id]
         if scope_grants.get("drive", "none") != "none":
-            ga["drive"] = account_id
+            ga["drive"] = [account_id]
 
         if ga:
             import json as _json
@@ -294,6 +294,40 @@ def migrate_google_json() -> None:
         logger.info("Migrated google.json to multi-account format (account_id=%s)", account_id)
     except Exception as e:
         logger.warning("Google migration: credential format updated but agent assignment failed: %s", e)
+
+
+def migrate_agent_google_accounts_to_arrays() -> None:
+    """Convert agent google_accounts from single-value to array format."""
+    import json as _json
+    try:
+        from agents.db import _get_db, _write_lock
+    except Exception:
+        return
+    try:
+        db = _get_db()
+        rows = db.execute("SELECT id, google_accounts FROM agents").fetchall()
+        for row in rows:
+            raw = row["google_accounts"] or "{}"
+            try:
+                parsed = _json.loads(raw) if isinstance(raw, str) else (raw or {})
+            except (ValueError, TypeError):
+                continue
+            changed = False
+            for svc in ("gmail", "calendar", "drive"):
+                val = parsed.get(svc)
+                if isinstance(val, str):
+                    parsed[svc] = [val] if val else []
+                    changed = True
+            if changed:
+                with _write_lock:
+                    db.execute(
+                        "UPDATE agents SET google_accounts = ? WHERE id = ?",
+                        (_json.dumps(parsed), row["id"]),
+                    )
+                    db.commit()
+        logger.info("Agent google_accounts migrated to array format")
+    except Exception as e:
+        logger.warning("Agent google_accounts array migration failed: %s", e)
 
 
 def list_integrations() -> list[dict]:

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -175,10 +175,17 @@ async def process_message(
         return "No AI provider is configured. Please set up an AI provider in Settings."
 
     ga = config.google_accounts
-    gmail_account_id = ga.get("gmail", "")
-    calendar_account_id = ga.get("calendar", "")
-    drive_account_id = ga.get("drive", "")
-    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    from integrations.registry import list_google_accounts as _list_ga
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
@@ -197,9 +204,10 @@ async def process_message(
         agent_slug=slug,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
-        gmail_account_id=gmail_account_id,
-        calendar_account_id=calendar_account_id,
-        drive_account_id=drive_account_id,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
     )
 
     # 5. Get/create Telegram conversation for multi-turn context
@@ -271,10 +279,17 @@ async def process_group_message(
         return "No AI provider is configured. Please set up an AI provider in Settings."
 
     ga = config.google_accounts
-    gmail_account_id = ga.get("gmail", "")
-    calendar_account_id = ga.get("calendar", "")
-    drive_account_id = ga.get("drive", "")
-    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    from integrations.registry import list_google_accounts as _list_ga
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
@@ -293,9 +308,10 @@ async def process_group_message(
         agent_slug=slug,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
-        gmail_account_id=gmail_account_id,
-        calendar_account_id=calendar_account_id,
-        drive_account_id=drive_account_id,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
     )
 
     group_sender_id = f"group:{chat_id}"

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -180,10 +180,17 @@ def _process_message_locked(
     # 8. Build tool registry
     store = CredentialStore()
     ga = config.google_accounts
-    gmail_account_id = ga.get("gmail", "")
-    calendar_account_id = ga.get("calendar", "")
-    drive_account_id = ga.get("drive", "")
-    google_connected = bool(gmail_account_id or calendar_account_id or drive_account_id)
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    from integrations.registry import list_google_accounts as _list_ga
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
 
     integration_tool_defs, integration_executors = _load_integration_tools()
 
@@ -213,17 +220,18 @@ def _process_message_locked(
         agent_slug=agent_slug,
         reminder_handlers=reminder_handlers,
         scheduled_action_handlers=sa_handlers,
-        gmail_account_id=gmail_account_id,
-        calendar_account_id=calendar_account_id,
-        drive_account_id=drive_account_id,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
     )
 
     # 9. Build tool definitions
     dynamic_real_tools = load_all_real_tools(agent_slug)
-    from integrations.google.policy import google_capabilities
-    gmail_caps = google_capabilities(gmail_account_id)
-    cal_caps = google_capabilities(calendar_account_id)
-    drive_caps = google_capabilities(drive_account_id)
+    from integrations.google.policy import google_capabilities_union
+    gmail_caps = google_capabilities_union(gmail_ids)
+    cal_caps = google_capabilities_union(calendar_ids)
+    drive_caps = google_capabilities_union(drive_ids)
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs or None,
         dynamic_real_tools=dynamic_real_tools or None,
@@ -233,6 +241,9 @@ def _process_message_locked(
         calendar_write_enabled=cal_caps["calendar_write_enabled"],
         drive_read_enabled=drive_caps["drive_read_enabled"],
         drive_write_enabled=drive_caps["drive_write_enabled"],
+        multi_gmail=len(gmail_ids) > 1,
+        multi_calendar=len(calendar_ids) > 1,
+        multi_drive=len(drive_ids) > 1,
     )
 
     # Apply integration permission ceilings — messaging channels have no approval UI,

--- a/backend/main.py
+++ b/backend/main.py
@@ -90,9 +90,10 @@ async def lifespan(app: FastAPI):
     from integrations.crm_lite.db import init_db as init_crm_db
     _safe_init("crm_lite", init_crm_db)
 
-    from integrations.registry import is_enabled as integration_enabled, ensure_crm_active, migrate_google_json
+    from integrations.registry import is_enabled as integration_enabled, ensure_crm_active, migrate_google_json, migrate_agent_google_accounts_to_arrays
     ensure_crm_active()
     migrate_google_json()
+    migrate_agent_google_accounts_to_arrays()
 
     if integration_enabled("qb_csv"):
         from integrations.qb_csv.db import init_db as init_qb_csv_db

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -15,7 +15,7 @@ export interface Agent {
   calendar_write_enabled?: boolean;
   drive_enabled?: boolean;
   drive_write_enabled?: boolean;
-  google_accounts?: { gmail?: string; calendar?: string; drive?: string };
+  google_accounts?: { gmail?: string[]; calendar?: string[]; drive?: string[] };
   whatsapp_session_id?: string;
   telegram_enabled: boolean;
   telegram_bot_token?: string;

--- a/frontend/src/dashboard/GoogleIntegrationCard.tsx
+++ b/frontend/src/dashboard/GoogleIntegrationCard.tsx
@@ -122,7 +122,9 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
     try {
       await api(`/api/integrations/google/${accountId}/disconnect`, { method: 'POST' });
       onChanged();
-      setAgents([]);
+      if (assignmentsOpen) {
+        api<{ agents: Agent[] }>('/api/agents').then(data => setAgents(data.agents)).catch(() => {});
+      }
     } catch (err: unknown) {
       setLocalError(err instanceof Error ? err.message : 'Disconnect failed');
     } finally {

--- a/frontend/src/dashboard/GoogleIntegrationCard.tsx
+++ b/frontend/src/dashboard/GoogleIntegrationCard.tsx
@@ -130,11 +130,15 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
     }
   }
 
-  async function updateAgentAccount(agentId: string, service: 'gmail' | 'calendar' | 'drive', accountId: string) {
+  async function toggleAgentAccount(agentId: string, service: 'gmail' | 'calendar' | 'drive', accountId: string) {
     setSavingAgent(agentId);
     const agent = agents.find(a => a.id === agentId);
     const current = agent?.google_accounts || {};
-    const updated = { ...current, [service]: accountId };
+    const currentList = current[service] || [];
+    const newList = currentList.includes(accountId)
+      ? currentList.filter(id => id !== accountId)
+      : [...currentList, accountId];
+    const updated = { ...current, [service]: newList };
     try {
       await api(`/api/agents/${agentId}`, {
         method: 'PUT',
@@ -279,22 +283,29 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
                     <div className="grid grid-cols-3 gap-2">
                       {(['gmail', 'calendar', 'drive'] as const).map(svc => {
                         const available = accountsForService(svc);
+                        const selected = ga[svc] || [];
                         return (
                           <div key={svc}>
                             <label className="text-gray-500 text-[10px] uppercase tracking-wide block mb-0.5">
                               {svc === 'gmail' ? 'Gmail' : svc === 'calendar' ? 'Calendar' : 'Drive'}
                             </label>
-                            <select
-                              value={ga[svc] || ''}
-                              onChange={e => updateAgentAccount(agent.id, svc, e.target.value)}
-                              disabled={savingAgent === agent.id}
-                              className="w-full bg-gray-800 text-gray-300 text-[11px] rounded px-1.5 py-1 border border-gray-700 focus:border-indigo-500 outline-none disabled:opacity-50"
-                            >
-                              <option value="">None</option>
-                              {available.map(a => (
-                                <option key={a.id} value={a.id}>{a.email}</option>
+                            {available.length === 0 && (
+                              <span className="text-gray-600 text-[10px]">No accounts</span>
+                            )}
+                            <div className="space-y-0.5">
+                              {available.map((a, i) => (
+                                <label key={a.id} className="flex items-center gap-1.5 text-[11px] text-gray-300 cursor-pointer">
+                                  <input
+                                    type="checkbox"
+                                    checked={selected.includes(a.id)}
+                                    onChange={() => toggleAgentAccount(agent.id, svc, a.id)}
+                                    disabled={savingAgent === agent.id}
+                                    className="rounded border-gray-600 bg-gray-800 text-indigo-500 w-3 h-3 accent-indigo-500"
+                                  />
+                                  <span>{a.email}{selected.includes(a.id) && i === 0 && selected[0] === a.id && selected.length > 1 ? ' (default)' : ''}</span>
+                                </label>
                               ))}
-                            </select>
+                            </div>
                           </div>
                         );
                       })}


### PR DESCRIPTION
## Summary

- Adds multi-Google-account support: connect multiple Google accounts and assign them per-agent on a per-service basis (Gmail, Calendar, Drive)
- Extends to **multi-account-per-service**: each agent can have multiple accounts assigned per service, with the AI choosing which to use via an optional `account` parameter (email address) in tool schemas
- Smart defaults: write tools auto-select first write-capable account; read tools use first non-broken account. Scope validation prevents using a read-only account for write operations
- System prompt lists available accounts with default markers. Background paths (scheduled actions, reminders, heartbeat) all include account context
- Frontend uses checkboxes instead of single-select dropdowns for agent account assignment
- All 10 ToolRegistry construction sites updated across chat, Telegram, WhatsApp, Paperclip, scheduled actions, reminders, and router_factory
- Backward-compatible: auto-migrates existing single-account format on startup. Tool schemas only include `account` param when 2+ accounts are assigned (deep-copy safe)
- Plan reviewed through 3 rounds with Codex; code reviewed through 3 rounds with Codex

## Test plan

- [ ] Frontend builds without errors (`npm run build`)
- [ ] Backend starts without import errors
- [ ] Existing single-account users auto-migrate to array format on startup
- [ ] Connect two Google accounts via Settings > Integrations > Google
- [ ] In Agent Assignments, check both accounts for Gmail on one agent
- [ ] System prompt mentions both accounts with "(default)" on first
- [ ] AI uses `account` param to pick correct account in chat
- [ ] Omitting `account` on write tool picks first write-capable account
- [ ] Selecting read-only account for `send_email` returns clear scope error
- [ ] Single-account agents work without `account` param in schemas
- [ ] Background scheduled actions/reminders have Google tool access with account context
- [ ] Disconnect account → stale assignments cleaned from all agents
- [ ] `mark_email_as_read` resolves to write-capable account