### PR TITLE
Add semantic memory second brain — vector search, auto-extraction, skill packs

### DIFF
--- a/backend/agents/engine.py
+++ b/backend/agents/engine.py
@@ -123,11 +123,18 @@ async def _backfill_vectors(db):
     try:
         await db.check_embedding_config()
         remaining = 1
-        while remaining > 0:
+        failures = 0
+        while remaining > 0 and failures < 3:
             result = await db.backfill_embeddings(batch_size=32)
             remaining = result.get("remaining", 0)
+            if result.get("error"):
+                failures += 1
+            else:
+                failures = 0
             if remaining > 0:
                 await asyncio.sleep(5)
+        if failures >= 3:
+            logger.warning("Vector backfill stopped after %d consecutive failures", failures)
     except Exception as e:
         logger.debug("Vector backfill error: %s", e)
 

--- a/backend/agents/engine.py
+++ b/backend/agents/engine.py
@@ -109,7 +109,6 @@ def _get_initialized_memory_db(slug: str):
 
     # Schedule background embedding backfill (non-blocking)
     if db.vec_available:
-        import asyncio
         try:
             loop = asyncio.get_running_loop()
             loop.create_task(_backfill_vectors(db))
@@ -130,8 +129,7 @@ async def _backfill_vectors(db):
             if remaining > 0:
                 await asyncio.sleep(5)
     except Exception as e:
-        import logging
-        logging.getLogger(__name__).debug("Vector backfill error: %s", e)
+        logger.debug("Vector backfill error: %s", e)
 
 
 def ensure_memory_db(slug: str):

--- a/backend/agents/engine.py
+++ b/backend/agents/engine.py
@@ -11,6 +11,7 @@ The LRU cache holds the initialized DB + context manager so we don't
 re-init SQLite on every request.
 """
 
+import asyncio
 import logging
 from functools import lru_cache
 from pathlib import Path
@@ -105,7 +106,32 @@ def _get_initialized_memory_db(slug: str):
     # Reindex all files on first init so FTS5 has data
     ctx_manager = get_context_manager(slug)
     db.reindex_all(ctx_manager)
+
+    # Schedule background embedding backfill (non-blocking)
+    if db.vec_available:
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_backfill_vectors(db))
+        except RuntimeError:
+            pass  # No event loop — backfill will happen on first async access
+
     return db
+
+
+async def _backfill_vectors(db):
+    """Background task to embed chunks missing vectors."""
+    try:
+        await db.check_embedding_config()
+        remaining = 1
+        while remaining > 0:
+            result = await db.backfill_embeddings(batch_size=32)
+            remaining = result.get("remaining", 0)
+            if remaining > 0:
+                await asyncio.sleep(5)
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).debug("Vector backfill error: %s", e)
 
 
 def ensure_memory_db(slug: str):

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -326,8 +326,8 @@ def _is_duplicate_import(ctx_manager: ContextManager, content_hash: str) -> bool
     """Check if content with this hash was already imported for this agent."""
     try:
         from agents import db as agent_db
-        # Get agent_id from the data_dir path (slug is the last component)
-        slug = Path(ctx_manager.data_dir).name
+        # data_dir is data/agents/{slug}/context — slug is the parent dir name
+        slug = Path(ctx_manager.data_dir).parent.name
         agent = agent_db.get_agent_by_slug(slug)
         if not agent:
             return False

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -332,8 +332,8 @@ def _is_duplicate_import(ctx_manager: ContextManager, content_hash: str) -> bool
         if not agent:
             return False
 
-        sources = agent_db.get_import_sources(agent["id"])
-        for source in sources:
+        source = agent_db.get_import_source(agent["id"])
+        if source:
             hashes_json = source.get("file_hashes", "{}")
             if isinstance(hashes_json, str):
                 hashes = json.loads(hashes_json)

--- a/backend/agents/import_service/tools.py
+++ b/backend/agents/import_service/tools.py
@@ -307,12 +307,43 @@ def _write_import_context(args: dict, ctx_manager: ContextManager) -> dict:
     if not _safe_import_filename(filename):
         return {"error": f"Cannot write to '{filename}'. Allowed targets: {sorted(_ALLOWED_WRITE_TARGETS)} or daily/YYYY-MM-DD.md"}
 
+    # Content dedup: check if identical content was already imported
+    if content:
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        if _is_duplicate_import(ctx_manager, content_hash):
+            logger.info("Import dedup: skipping '%s' (content already imported)", filename)
+            return {"skipped": filename, "reason": "duplicate_content"}
+
     if _DAILY_RE.match(filename):
         daily_dir = Path(ctx_manager.data_dir) / "daily"
         daily_dir.mkdir(exist_ok=True)
 
     ctx_manager.write_context(filename, content)
     return {"written": filename, "size_bytes": len(content.encode("utf-8"))}
+
+
+def _is_duplicate_import(ctx_manager: ContextManager, content_hash: str) -> bool:
+    """Check if content with this hash was already imported for this agent."""
+    try:
+        from agents import db as agent_db
+        # Get agent_id from the data_dir path (slug is the last component)
+        slug = Path(ctx_manager.data_dir).name
+        agent = agent_db.get_agent_by_slug(slug)
+        if not agent:
+            return False
+
+        sources = agent_db.get_import_sources(agent["id"])
+        for source in sources:
+            hashes_json = source.get("file_hashes", "{}")
+            if isinstance(hashes_json, str):
+                hashes = json.loads(hashes_json)
+            else:
+                hashes = hashes_json
+            if content_hash in hashes.values():
+                return True
+    except Exception as e:
+        logger.debug("Dedup check failed: %s", e)
+    return False
 
 
 def _finalize_import(

--- a/backend/cli/commands.py
+++ b/backend/cli/commands.py
@@ -61,7 +61,7 @@ async def handle_command(input_str: str, session, renderer) -> "str | Session | 
         _cmd_help()
 
     elif cmd == "/search":
-        _cmd_search(arg, session)
+        await _cmd_search(arg, session)
 
     elif cmd == "/facts":
         _cmd_facts(arg, session)
@@ -148,12 +148,12 @@ def _cmd_help():
     console.print(table)
 
 
-def _cmd_search(query: str, session):
+async def _cmd_search(query: str, session):
     if not query:
         console.print("[red]Usage: /search <query>[/]")
         return
-    from core.agents.memory.search_tools import search_memory
-    result = search_memory(
+    from core.agents.memory.search_tools import search_memory_async
+    result = await search_memory_async(
         str(session.ctx_manager.data_dir),
         session.config.gcs_prefix,
         query,

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -373,9 +373,11 @@ def _build_system_prompt(
             "",
         ])
 
-    # Relevance pre-fetch — on first message, inject relevant context
+    # Relevance pre-fetch — on first message, inject relevant context (semantic + keyword)
     if first_user_message:
-        relevant = ctx_manager.relevance_prefetch(first_user_message)
+        from core.agents.memory.db import get_instance as _get_memory_db
+        _memory_db = _get_memory_db(str(ctx_manager.data_dir))
+        relevant = ctx_manager.relevance_prefetch(first_user_message, memory_db=_memory_db)
         if relevant:
             prefetch_parts: list[str] = []
             prefetch_chars = 0
@@ -763,6 +765,18 @@ async def chat(
                     **last,
                     "content": last.get("content", "") + "\n\n[KNOWLEDGE CHECKPOINT]",
                 }
+                # Fire background fact extraction
+                try:
+                    import asyncio
+                    from core.agents.memory.extractor import extract_facts_from_messages
+                    asyncio.ensure_future(extract_facts_from_messages(
+                        messages=current_messages,
+                        data_dir=str(config.data_dir),
+                        gcs_prefix=config.gcs_prefix,
+                        agent_config={"auto_extract_facts": True},
+                    ))
+                except Exception:
+                    pass
 
     # ── Plan mode: add virtual exit_plan_mode tool ──────────────────
     if plan_mode:

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -771,9 +771,9 @@ async def chat(
                     from core.agents.memory.extractor import extract_facts_from_messages
                     asyncio.ensure_future(extract_facts_from_messages(
                         messages=current_messages,
-                        data_dir=str(config.data_dir),
+                        data_dir=config.context_dir,
                         gcs_prefix=config.gcs_prefix,
-                        agent_config={"auto_extract_facts": True},
+                        agent_config=config.__dict__,
                     ))
                 except Exception:
                     pass

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -767,16 +767,15 @@ async def chat(
                 }
                 # Fire background fact extraction
                 try:
-                    import asyncio
                     from core.agents.memory.extractor import extract_facts_from_messages
                     asyncio.ensure_future(extract_facts_from_messages(
-                        messages=current_messages,
+                        messages=list(current_messages),
                         data_dir=config.context_dir,
                         gcs_prefix=config.gcs_prefix,
-                        agent_config=config.__dict__,
+                        agent_config=dict(config.__dict__),
                     ))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Background fact extraction failed to schedule: %s", e)
 
     # ── Plan mode: add virtual exit_plan_mode tool ──────────────────
     if plan_mode:

--- a/backend/core/agents/context_manager.py
+++ b/backend/core/agents/context_manager.py
@@ -515,9 +515,15 @@ class ContextManager:
                     return None
                 return await service.embed_single(message)
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(asyncio.run, _get_embedding())
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            future = executor.submit(asyncio.run, _get_embedding())
+            try:
                 embedding = future.result(timeout=5)
+            except (concurrent.futures.TimeoutError, TimeoutError):
+                executor.shutdown(wait=False, cancel_futures=True)
+                return []
+            finally:
+                executor.shutdown(wait=False)
 
             if not embedding:
                 return []

--- a/backend/core/agents/context_manager.py
+++ b/backend/core/agents/context_manager.py
@@ -429,14 +429,22 @@ class ContextManager:
     # match threshold; no fixed top-K, no content truncation.
     # ------------------------------------------------------------------
 
-    def relevance_prefetch(self, first_user_message: str) -> list[dict]:
+    def relevance_prefetch(self, first_user_message: str, memory_db=None) -> list[dict]:
         """Score topic files and recent daily notes against the user message.
 
+        If memory_db is provided and has vector search available, uses semantic
+        hybrid search for better recall. Falls back to BM25-lite keyword matching.
+
         Returns a list of `{"kind": "topic"|"daily", "name": str, "content": str}`
-        for every file whose match score exceeds 0. Caller injects them
-        fully (no truncation) into the system prompt under a "likely
-        relevant" block.
+        for every relevant match. Caller injects them into the system prompt.
         """
+        # Try semantic search first
+        if memory_db and memory_db.vec_available:
+            semantic_results = self._semantic_prefetch(first_user_message, memory_db)
+            if semantic_results:
+                return semantic_results
+
+        # Fallback: BM25-lite keyword matching
         query_tokens = _tokenize(first_user_message)
         if not query_tokens:
             return []
@@ -487,6 +495,52 @@ class ContextManager:
         # Sort by score descending, no truncation
         results.sort(key=lambda pair: pair[0], reverse=True)
         return [item for _, item in results]
+
+    def _semantic_prefetch(self, message: str, memory_db) -> list[dict]:
+        """Use hybrid search for proactive memory surfacing."""
+        try:
+            import asyncio
+            from core.agents.memory.embeddings import get_embedding_service
+
+            service = get_embedding_service()
+
+            # Get embedding for the message
+            try:
+                loop = asyncio.get_running_loop()
+                # Can't embed synchronously in async context — fall back
+                return []
+            except RuntimeError:
+                embedding = asyncio.run(service.embed_single(message))
+
+            if not embedding:
+                return []
+
+            # Run hybrid search
+            search_results = memory_db.hybrid_search(
+                query=message, query_embedding=embedding, limit=8,
+            )
+
+            if not search_results:
+                return []
+
+            # Hydrate full content for injection into prompt
+            conn = memory_db.get_db()
+            results = []
+            for hit in search_results:
+                row = conn.execute(
+                    "SELECT content FROM memory_documents WHERE id=?", (hit["id"],)
+                ).fetchone()
+                if row and row["content"]:
+                    results.append({
+                        "kind": hit["source_type"],
+                        "name": hit.get("title") or hit.get("source_id", ""),
+                        "content": row["content"],
+                    })
+
+            return results
+        except Exception as e:
+            logger.debug("Semantic prefetch failed: %s", e)
+            return []
 
 
 def _score_match(query_tokens: set[str], *, name: str, headline: str, body: str) -> float:

--- a/backend/core/agents/context_manager.py
+++ b/backend/core/agents/context_manager.py
@@ -499,8 +499,9 @@ class ContextManager:
     def _semantic_prefetch(self, message: str, memory_db) -> list[dict]:
         """Use hybrid search for proactive memory surfacing.
 
-        Note: This is called from a sync context (_build_system_prompt) but needs
-        async embedding. We use a dedicated thread to avoid blocking the event loop.
+        Called from sync _build_system_prompt but needs async embedding.
+        Uses a dedicated thread with a short timeout so first-message latency
+        stays reasonable even if the embedding provider is slow.
         """
         try:
             import asyncio
@@ -514,10 +515,9 @@ class ContextManager:
                     return None
                 return await service.embed_single(message)
 
-            # Run async embedding in a new thread to avoid event loop conflicts
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
                 future = executor.submit(asyncio.run, _get_embedding())
-                embedding = future.result(timeout=10)
+                embedding = future.result(timeout=5)
 
             if not embedding:
                 return []

--- a/backend/core/agents/context_manager.py
+++ b/backend/core/agents/context_manager.py
@@ -497,25 +497,32 @@ class ContextManager:
         return [item for _, item in results]
 
     def _semantic_prefetch(self, message: str, memory_db) -> list[dict]:
-        """Use hybrid search for proactive memory surfacing."""
+        """Use hybrid search for proactive memory surfacing.
+
+        Note: This is called from a sync context (_build_system_prompt) but needs
+        async embedding. We use a dedicated thread to avoid blocking the event loop.
+        """
         try:
             import asyncio
+            import concurrent.futures
             from core.agents.memory.embeddings import get_embedding_service
 
             service = get_embedding_service()
 
-            # Get embedding for the message
-            try:
-                loop = asyncio.get_running_loop()
-                # Can't embed synchronously in async context — fall back
-                return []
-            except RuntimeError:
-                embedding = asyncio.run(service.embed_single(message))
+            async def _get_embedding():
+                if not await service.is_available():
+                    return None
+                return await service.embed_single(message)
+
+            # Run async embedding in a new thread to avoid event loop conflicts
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(asyncio.run, _get_embedding())
+                embedding = future.result(timeout=10)
 
             if not embedding:
                 return []
 
-            # Run hybrid search
+            # Run hybrid search (sync — no async needed)
             search_results = memory_db.hybrid_search(
                 query=message, query_embedding=embedding, limit=8,
             )

--- a/backend/core/agents/memory/db.py
+++ b/backend/core/agents/memory/db.py
@@ -837,7 +837,7 @@ class MemoryDB:
                 )
                 with self._write_lock:
                     conn.execute("DELETE FROM memory_vectors")
-                    conn.execute("DELETE FROM memory_chunks")
+                    # Keep chunks — they'll be re-embedded by backfill
                     conn.execute("DELETE FROM memory_embedding_config WHERE id=1")
                     conn.execute(
                         "INSERT INTO memory_embedding_config (id, provider, model, dimensions) VALUES (1, ?, ?, ?)",

--- a/backend/core/agents/memory/db.py
+++ b/backend/core/agents/memory/db.py
@@ -267,9 +267,11 @@ class MemoryDB:
             import sqlite_vec  # noqa: F401
             conn = self.get_db()
             conn.enable_load_extension(True)
-            sqlite_vec.load(conn)
-            conn.enable_load_extension(False)
-            self._vec_available = True
+            try:
+                sqlite_vec.load(conn)
+                self._vec_available = True
+            finally:
+                conn.enable_load_extension(False)
         except ImportError:
             logger.info("sqlite-vec not installed — vector search disabled")
         except Exception as e:
@@ -643,10 +645,12 @@ class MemoryDB:
                     continue
                 if memory_type and doc["memory_type"] != memory_type:
                     continue
-                if date_from and doc["date"] and doc["date"] < date_from:
-                    continue
-                if date_to and doc["date"] and doc["date"] > date_to:
-                    continue
+                if date_from:
+                    if not doc["date"] or doc["date"] < date_from:
+                        continue
+                if date_to:
+                    if not doc["date"] or doc["date"] > date_to:
+                        continue
 
                 # Get snippet from best matching chunk
                 chunk_snippet = self._get_chunk_snippet(doc["id"])
@@ -764,7 +768,10 @@ class MemoryDB:
                WHERE mv.chunk_id IS NULL""",
         ).fetchone()[0]
 
-        return {"processed": processed, "remaining": remaining}
+        result = {"processed": processed, "remaining": remaining}
+        if processed == 0 and remaining > 0:
+            result["error"] = "all row inserts failed"
+        return result
 
     async def check_embedding_config(self) -> None:
         """Check if embedding provider changed; invalidate vectors if so."""

--- a/backend/core/agents/memory/db.py
+++ b/backend/core/agents/memory/db.py
@@ -149,7 +149,8 @@ def _chunk_text(text: str) -> list[str]:
                     end = nl_break + 1
 
         chunks.append(text[start:end])
-        start = max(start + 1, end - CHUNK_OVERLAP)
+        # Advance by at least half the chunk size to avoid near-duplicate chunks
+        start = max(start + CHUNK_SIZE // 2, end - CHUNK_OVERLAP)
 
     return chunks
 
@@ -393,55 +394,8 @@ class MemoryDB:
                 )
             conn.commit()
 
-        # Embed chunks (outside write lock — async would be ideal but keep sync for now)
-        if embed and self._vec_available:
-            self._embed_doc_chunks(doc_id)
-
-    def _embed_doc_chunks(self, doc_id: int) -> None:
-        """Embed all chunks for a document. Fire-and-forget on failure."""
-        import asyncio
-        try:
-            from .embeddings import get_embedding_service
-            service = get_embedding_service()
-
-            # Run async embedding in a new event loop if needed
-            try:
-                loop = asyncio.get_running_loop()
-                loop.create_task(self._async_embed_chunks(doc_id, service))
-            except RuntimeError:
-                asyncio.run(self._async_embed_chunks(doc_id, service))
-        except Exception as e:
-            logger.debug("Chunk embedding skipped: %s", e)
-
-    async def _async_embed_chunks(self, doc_id: int, service) -> None:
-        """Async helper to embed chunks for a document."""
-        if not await service.is_available():
-            return
-
-        conn = self.get_db()
-        chunks = conn.execute(
-            "SELECT id, content FROM memory_chunks WHERE doc_id=? ORDER BY chunk_index",
-            (doc_id,),
-        ).fetchall()
-        if not chunks:
-            return
-
-        texts = [c["content"] for c in chunks]
-        embeddings = await service.embed(texts)
-        if not embeddings:
-            return
-
-        import sqlite_vec
-        with self._write_lock:
-            for chunk_row, embedding in zip(chunks, embeddings):
-                try:
-                    conn.execute(
-                        "INSERT OR REPLACE INTO memory_vectors (chunk_id, embedding) VALUES (?, ?)",
-                        (chunk_row["id"], sqlite_vec.serialize_float32(embedding)),
-                    )
-                except Exception as e:
-                    logger.debug("Vector insert failed for chunk %d: %s", chunk_row["id"], e)
-            conn.commit()
+        # Embedding happens via backfill (avoids thread-safety issues with
+        # fire-and-forget async tasks accessing the SQLite connection).
 
     def remove_document(self, source_type: str, source_id: str) -> None:
         """Remove a document and its chunks/vectors from all indexes."""
@@ -836,8 +790,13 @@ class MemoryDB:
                     stored["provider"], stored["model"], info["provider"], info["model"],
                 )
                 with self._write_lock:
-                    conn.execute("DELETE FROM memory_vectors")
-                    # Keep chunks — they'll be re-embedded by backfill
+                    # Drop and recreate vector table (dimensions may have changed)
+                    conn.execute("DROP TABLE IF EXISTS memory_vectors")
+                    conn.execute(
+                        f"CREATE VIRTUAL TABLE memory_vectors USING vec0("
+                        f"chunk_id INTEGER PRIMARY KEY, "
+                        f"embedding float[{info['dimensions']}] distance_metric=cosine)"
+                    )
                     conn.execute("DELETE FROM memory_embedding_config WHERE id=1")
                     conn.execute(
                         "INSERT INTO memory_embedding_config (id, provider, model, dimensions) VALUES (1, ?, ?, ?)",

--- a/backend/core/agents/memory/db.py
+++ b/backend/core/agents/memory/db.py
@@ -1,12 +1,13 @@
-"""Per-agent memory database — FTS5 full-text search + temporal facts.
+"""Per-agent memory database — FTS5 full-text search + semantic vectors + temporal facts.
 
 Follows the same patterns as ChatHistoryDB: single shared SQLite connection,
 WAL mode, threading write-lock, GCS backup/restore.  Each agent gets its own
 memory.db alongside its chat_history.db.
 
-Zero new dependencies — FTS5 is built into Python's sqlite3.
+Vector search via sqlite-vec (optional — graceful degradation if unavailable).
 """
 
+import hashlib
 import logging
 import re
 import sqlite3
@@ -46,6 +47,7 @@ CREATE TABLE IF NOT EXISTS memory_documents (
     content     TEXT    NOT NULL,
     memory_type TEXT,
     date        TEXT,
+    content_hash TEXT,
     created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
     updated_at  TEXT    NOT NULL DEFAULT (datetime('now')),
     UNIQUE(source_type, source_id)
@@ -54,6 +56,42 @@ CREATE TABLE IF NOT EXISTS memory_documents (
 CREATE INDEX IF NOT EXISTS idx_memdoc_source ON memory_documents(source_type, source_id);
 CREATE INDEX IF NOT EXISTS idx_memdoc_type   ON memory_documents(memory_type) WHERE memory_type IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_memdoc_date   ON memory_documents(date)        WHERE date IS NOT NULL;
+
+-- Chunks for vector embeddings (one document → many chunks)
+CREATE TABLE IF NOT EXISTS memory_chunks (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    doc_id      INTEGER NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    content     TEXT    NOT NULL,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(doc_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_doc ON memory_chunks(doc_id);
+
+-- Embedding provider/model config (singleton row)
+CREATE TABLE IF NOT EXISTS memory_embedding_config (
+    id          INTEGER PRIMARY KEY CHECK (id = 1),
+    provider    TEXT    NOT NULL,
+    model       TEXT    NOT NULL,
+    dimensions  INTEGER NOT NULL,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Skill packs (reusable prompt recipes)
+CREATE TABLE IF NOT EXISTS skill_packs (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    name            TEXT    NOT NULL UNIQUE,
+    description     TEXT    NOT NULL DEFAULT '',
+    prompt          TEXT    NOT NULL,
+    category        TEXT,
+    tags            TEXT,
+    trigger_pattern TEXT,
+    usage_count     INTEGER NOT NULL DEFAULT 0,
+    auto_generated  INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+);
 
 -- Temporal facts (entity-relationship triples with validity windows)
 CREATE TABLE IF NOT EXISTS facts (
@@ -75,6 +113,45 @@ CREATE INDEX IF NOT EXISTS idx_facts_subject ON facts(subject);
 CREATE INDEX IF NOT EXISTS idx_facts_valid   ON facts(valid_from, valid_to);
 CREATE INDEX IF NOT EXISTS idx_facts_type    ON facts(memory_type) WHERE memory_type IS NOT NULL;
 """
+
+# Chunking constants
+CHUNK_SIZE = 2000  # ~500 tokens
+CHUNK_OVERLAP = 100
+
+
+def _chunk_text(text: str) -> list[str]:
+    """Split text into chunks for embedding. Prefers paragraph/sentence boundaries."""
+    if len(text) <= CHUNK_SIZE:
+        return [text]
+
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = start + CHUNK_SIZE
+
+        if end >= len(text):
+            chunks.append(text[start:])
+            break
+
+        # Try to break at paragraph boundary
+        para_break = text.rfind("\n\n", start + CHUNK_SIZE // 2, end)
+        if para_break > start:
+            end = para_break + 2
+        else:
+            # Try sentence boundary
+            sent_break = text.rfind(". ", start + CHUNK_SIZE // 2, end)
+            if sent_break > start:
+                end = sent_break + 2
+            else:
+                # Try newline
+                nl_break = text.rfind("\n", start + CHUNK_SIZE // 2, end)
+                if nl_break > start:
+                    end = nl_break + 1
+
+        chunks.append(text[start:end])
+        start = max(start + 1, end - CHUNK_OVERLAP)
+
+    return chunks
 
 # FTS5 setup is separate because CREATE VIRTUAL TABLE doesn't support IF NOT EXISTS
 # inside executescript cleanly on all Python/SQLite combos.
@@ -128,7 +205,7 @@ def _sanitize_fts_query(raw: str) -> str:
 # ---------------------------------------------------------------------------
 
 class MemoryDB:
-    """Per-agent memory database with FTS5 search and temporal facts."""
+    """Per-agent memory database with FTS5 search, vector embeddings, and temporal facts."""
 
     def __init__(self, data_dir: Path, gcs_prefix: str, db_filename: str = "memory.db"):
         self.data_dir = data_dir
@@ -137,6 +214,7 @@ class MemoryDB:
         self._connection: sqlite3.Connection | None = None
         self._write_lock = threading.Lock()
         self._backup_mutex = threading.Lock()
+        self._vec_available = False
 
     def get_db(self) -> sqlite3.Connection:
         if self._connection is None:
@@ -146,6 +224,10 @@ class MemoryDB:
     @property
     def write_lock(self) -> threading.Lock:
         return self._write_lock
+
+    @property
+    def vec_available(self) -> bool:
+        return self._vec_available
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -172,8 +254,48 @@ class MemoryDB:
             else:
                 raise
 
+        self._load_sqlite_vec()
+        self._migrate_schema()
+
         _instances[str(self.data_dir)] = self
-        logger.info("MemoryDB initialized at %s", self.db_path)
+        logger.info("MemoryDB initialized at %s (vec=%s)", self.db_path, self._vec_available)
+
+    def _load_sqlite_vec(self) -> None:
+        """Attempt to load sqlite-vec extension."""
+        try:
+            import sqlite_vec  # noqa: F401
+            conn = self.get_db()
+            conn.enable_load_extension(True)
+            sqlite_vec.load(conn)
+            conn.enable_load_extension(False)
+            self._vec_available = True
+        except ImportError:
+            logger.info("sqlite-vec not installed — vector search disabled")
+        except Exception as e:
+            logger.warning("sqlite-vec failed to load: %s", e)
+
+    def _migrate_schema(self) -> None:
+        """Apply incremental schema migrations."""
+        conn = self.get_db()
+        # Add content_hash column if missing
+        try:
+            conn.execute("SELECT content_hash FROM memory_documents LIMIT 0")
+        except sqlite3.OperationalError:
+            conn.execute("ALTER TABLE memory_documents ADD COLUMN content_hash TEXT")
+            conn.commit()
+
+        # Create vector table if sqlite-vec available
+        if self._vec_available:
+            try:
+                conn.execute("SELECT chunk_id FROM memory_vectors LIMIT 0")
+            except sqlite3.OperationalError:
+                from .embeddings import DIMENSIONS
+                conn.execute(
+                    f"CREATE VIRTUAL TABLE IF NOT EXISTS memory_vectors USING vec0("
+                    f"chunk_id INTEGER PRIMARY KEY, "
+                    f"embedding float[{DIMENSIONS}] distance_metric=cosine)"
+                )
+                conn.commit()
 
     def init_db(self) -> dict:
         """Initialize with integrity check and GCS restore."""
@@ -201,33 +323,150 @@ class MemoryDB:
         content: str,
         memory_type: str | None = None,
         date: str | None = None,
+        embed: bool = True,
     ) -> None:
-        """Upsert a document into memory_documents (FTS5 triggers handle the index)."""
+        """Upsert a document into memory_documents and optionally create chunks/vectors.
+
+        If embed=False, chunks are still created (for later backfill) but no
+        embeddings are computed.
+        """
         memory_type = validate_memory_type(memory_type)
         conn = self.get_db()
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
         with self._write_lock:
+            # Check if content is unchanged
+            existing = conn.execute(
+                "SELECT id, content_hash FROM memory_documents WHERE source_type=? AND source_id=?",
+                (source_type, source_id),
+            ).fetchone()
+
+            if existing and existing["content_hash"] == content_hash:
+                # Content unchanged — check if chunks exist
+                chunk_count = conn.execute(
+                    "SELECT COUNT(*) FROM memory_chunks WHERE doc_id=?", (existing["id"],)
+                ).fetchone()[0]
+                if chunk_count > 0:
+                    return  # Nothing to do
+
+            # Upsert the document
             conn.execute(
                 """INSERT INTO memory_documents
-                       (source_type, source_id, title, content, memory_type, date, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+                       (source_type, source_id, title, content, memory_type, date, content_hash, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
                    ON CONFLICT(source_type, source_id)
                    DO UPDATE SET title=excluded.title,
                                  content=excluded.content,
                                  memory_type=excluded.memory_type,
                                  date=excluded.date,
+                                 content_hash=excluded.content_hash,
                                  updated_at=datetime('now')""",
-                (source_type, source_id, title, content, memory_type, date),
+                (source_type, source_id, title, content, memory_type, date, content_hash),
             )
             conn.commit()
 
+            # Get the doc_id
+            row = conn.execute(
+                "SELECT id FROM memory_documents WHERE source_type=? AND source_id=?",
+                (source_type, source_id),
+            ).fetchone()
+            doc_id = row["id"]
+
+            # Delete old chunks and their vectors
+            old_chunks = conn.execute(
+                "SELECT id FROM memory_chunks WHERE doc_id=?", (doc_id,)
+            ).fetchall()
+            if old_chunks and self._vec_available:
+                for c in old_chunks:
+                    try:
+                        conn.execute("DELETE FROM memory_vectors WHERE chunk_id=?", (c["id"],))
+                    except Exception:
+                        pass
+            conn.execute("DELETE FROM memory_chunks WHERE doc_id=?", (doc_id,))
+
+            # Create new chunks
+            chunks = _chunk_text(content)
+            for i, chunk_text in enumerate(chunks):
+                conn.execute(
+                    "INSERT INTO memory_chunks (doc_id, chunk_index, content) VALUES (?, ?, ?)",
+                    (doc_id, i, chunk_text),
+                )
+            conn.commit()
+
+        # Embed chunks (outside write lock — async would be ideal but keep sync for now)
+        if embed and self._vec_available:
+            self._embed_doc_chunks(doc_id)
+
+    def _embed_doc_chunks(self, doc_id: int) -> None:
+        """Embed all chunks for a document. Fire-and-forget on failure."""
+        import asyncio
+        try:
+            from .embeddings import get_embedding_service
+            service = get_embedding_service()
+
+            # Run async embedding in a new event loop if needed
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._async_embed_chunks(doc_id, service))
+            except RuntimeError:
+                asyncio.run(self._async_embed_chunks(doc_id, service))
+        except Exception as e:
+            logger.debug("Chunk embedding skipped: %s", e)
+
+    async def _async_embed_chunks(self, doc_id: int, service) -> None:
+        """Async helper to embed chunks for a document."""
+        if not await service.is_available():
+            return
+
+        conn = self.get_db()
+        chunks = conn.execute(
+            "SELECT id, content FROM memory_chunks WHERE doc_id=? ORDER BY chunk_index",
+            (doc_id,),
+        ).fetchall()
+        if not chunks:
+            return
+
+        texts = [c["content"] for c in chunks]
+        embeddings = await service.embed(texts)
+        if not embeddings:
+            return
+
+        import sqlite_vec
+        with self._write_lock:
+            for chunk_row, embedding in zip(chunks, embeddings):
+                try:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO memory_vectors (chunk_id, embedding) VALUES (?, ?)",
+                        (chunk_row["id"], sqlite_vec.serialize_float32(embedding)),
+                    )
+                except Exception as e:
+                    logger.debug("Vector insert failed for chunk %d: %s", chunk_row["id"], e)
+            conn.commit()
+
     def remove_document(self, source_type: str, source_id: str) -> None:
-        """Remove a document from the index."""
+        """Remove a document and its chunks/vectors from all indexes."""
         conn = self.get_db()
         with self._write_lock:
-            conn.execute(
-                "DELETE FROM memory_documents WHERE source_type=? AND source_id=?",
+            doc = conn.execute(
+                "SELECT id FROM memory_documents WHERE source_type=? AND source_id=?",
                 (source_type, source_id),
-            )
+            ).fetchone()
+            if doc:
+                # Explicit vector deletion (virtual tables don't honor CASCADE)
+                if self._vec_available:
+                    chunks = conn.execute(
+                        "SELECT id FROM memory_chunks WHERE doc_id=?", (doc["id"],)
+                    ).fetchall()
+                    for c in chunks:
+                        try:
+                            conn.execute("DELETE FROM memory_vectors WHERE chunk_id=?", (c["id"],))
+                        except Exception:
+                            pass
+                conn.execute("DELETE FROM memory_chunks WHERE doc_id=?", (doc["id"],))
+                conn.execute(
+                    "DELETE FROM memory_documents WHERE source_type=? AND source_id=?",
+                    (source_type, source_id),
+                )
             conn.commit()
 
     def search(
@@ -288,48 +527,71 @@ class MemoryDB:
     # ------------------------------------------------------------------
 
     def reindex_all(self, ctx_manager) -> dict:
-        """Full rebuild of FTS5 index from files on disk.
+        """Rebuild FTS5 index from files on disk, preserving chunks/vectors for unchanged content.
 
         *ctx_manager* is a ContextManager instance for this agent.
         Called on startup after init_db().
         """
         conn = self.get_db()
-        stats = {"documents_indexed": 0, "facts_reindexed": 0}
+        stats = {"documents_indexed": 0, "unchanged": 0, "removed": 0, "facts_reindexed": 0}
 
-        with self._write_lock:
-            # Clear existing document index (facts survive in their own table)
-            conn.execute("DELETE FROM memory_documents WHERE source_type != 'fact'")
-            conn.commit()
+        # 1. Collect all files that should exist
+        expected: dict[tuple[str, str], tuple[str, str, str | None, str | None]] = {}
+        # Format: (source_type, source_id) → (title, content, memory_type, date)
 
-        # 1. Index MEMORY.md
+        # MEMORY.md
         memory = ctx_manager.read_memory()
         if memory:
-            self.index_document("memory", "MEMORY.md", "MEMORY.md", memory)
-            stats["documents_indexed"] += 1
+            expected[("memory", "MEMORY.md")] = ("MEMORY.md", memory, None, None)
 
-        # 2. Index daily notes
+        # Daily notes
         daily_dir = ctx_manager.daily_dir
         if daily_dir.exists():
             for f in sorted(daily_dir.glob("*.md")):
-                note_date = f.stem  # e.g. "2026-04-12"
+                note_date = f.stem
                 content = f.read_text(encoding="utf-8", errors="replace")
                 if content.strip():
-                    self.index_document("daily", note_date, note_date, content, date=note_date)
-                    stats["documents_indexed"] += 1
+                    expected[("daily", note_date)] = (note_date, content, None, note_date)
 
-        # 3. Index topic files (skip soul.md, MEMORY.md, _-prefixed)
+        # Topic files (skip soul.md, MEMORY.md, _-prefixed)
         skip = {"soul.md", "memory.md"}
         for f in sorted(ctx_manager.data_dir.glob("*.md")):
             if f.name.startswith("_") or f.name.lower() in skip:
                 continue
             content = f.read_text(encoding="utf-8", errors="replace")
             if content.strip():
-                self.index_document("topic", f.name, f.name, content)
-                stats["documents_indexed"] += 1
+                expected[("topic", f.name)] = (f.name, content, None, None)
 
-        # 4. Re-index existing facts from the facts table
-        rows = conn.execute("SELECT id, subject, predicate, object, valid_from, memory_type FROM facts WHERE valid_to IS NULL").fetchall()
-        for row in rows:
+        # 2. Upsert expected docs (skipping unchanged ones)
+        for (src_type, src_id), (title, content, mem_type, doc_date) in expected.items():
+            new_hash = hashlib.sha256(content.encode()).hexdigest()
+            existing = conn.execute(
+                "SELECT id, content_hash FROM memory_documents WHERE source_type=? AND source_id=?",
+                (src_type, src_id),
+            ).fetchone()
+
+            if existing and existing["content_hash"] == new_hash:
+                stats["unchanged"] += 1
+                continue
+
+            self.index_document(src_type, src_id, title, content, memory_type=mem_type, date=doc_date, embed=False)
+            stats["documents_indexed"] += 1
+
+        # 3. Remove docs that no longer exist on disk
+        all_docs = conn.execute(
+            "SELECT source_type, source_id FROM memory_documents WHERE source_type != 'fact'"
+        ).fetchall()
+        for row in all_docs:
+            key = (row["source_type"], row["source_id"])
+            if key not in expected:
+                self.remove_document(row["source_type"], row["source_id"])
+                stats["removed"] += 1
+
+        # 4. Re-index active facts
+        fact_rows = conn.execute(
+            "SELECT id, subject, predicate, object, valid_from, memory_type FROM facts WHERE valid_to IS NULL"
+        ).fetchall()
+        for row in fact_rows:
             self.index_document(
                 "fact",
                 str(row["id"]),
@@ -337,11 +599,258 @@ class MemoryDB:
                 f"{row['subject']} {row['predicate']} {row['object']}",
                 memory_type=row["memory_type"],
                 date=row["valid_from"],
+                embed=False,
             )
             stats["facts_reindexed"] += 1
 
         logger.info("MemoryDB reindex complete: %s", stats)
         return stats
+
+    # ------------------------------------------------------------------
+    # Hybrid search (FTS5 + vector)
+    # ------------------------------------------------------------------
+
+    def hybrid_search(
+        self,
+        query: str,
+        query_embedding: list[float] | None = None,
+        source_type: str | None = None,
+        memory_type: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        """Hybrid search combining FTS5 keyword + vector similarity via RRF."""
+        # FTS5 results
+        fts_results = self.search(
+            query, source_type=source_type, memory_type=memory_type,
+            date_from=date_from, date_to=date_to, limit=50,
+        )
+
+        # If no vector search possible, return FTS5 only
+        if not self._vec_available or not query_embedding:
+            return fts_results[:limit]
+
+        # Vector results
+        vec_results = self._vector_search(
+            query_embedding, source_type=source_type, memory_type=memory_type,
+            date_from=date_from, date_to=date_to, limit=50,
+        )
+
+        # RRF merge
+        return self._rrf_merge(fts_results, vec_results, limit)
+
+    def _vector_search(
+        self,
+        query_embedding: list[float],
+        source_type: str | None = None,
+        memory_type: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        limit: int = 50,
+    ) -> list[dict]:
+        """KNN vector search with post-filtering."""
+        conn = self.get_db()
+        try:
+            import sqlite_vec
+            query_blob = sqlite_vec.serialize_float32(query_embedding)
+
+            # Over-fetch to account for post-filtering
+            rows = conn.execute(
+                """SELECT v.chunk_id, v.distance, mc.doc_id
+                   FROM memory_vectors v
+                   JOIN memory_chunks mc ON mc.id = v.chunk_id
+                   WHERE v.embedding MATCH ? AND k = 200""",
+                (query_blob,),
+            ).fetchall()
+
+            # Post-filter and deduplicate by doc_id
+            seen_docs: dict[int, float] = {}  # doc_id → best distance
+            for row in rows:
+                doc_id = row["doc_id"]
+                distance = row["distance"]
+                if doc_id not in seen_docs or distance < seen_docs[doc_id]:
+                    seen_docs[doc_id] = distance
+
+            if not seen_docs:
+                return []
+
+            # Hydrate document metadata and apply filters
+            placeholders = ",".join("?" * len(seen_docs))
+            sql = f"SELECT id, source_type, source_id, title, memory_type, date FROM memory_documents WHERE id IN ({placeholders})"
+            params: list = list(seen_docs.keys())
+
+            docs = conn.execute(sql, params).fetchall()
+
+            results = []
+            for doc in docs:
+                # Apply filters
+                if source_type and doc["source_type"] != source_type:
+                    continue
+                if memory_type and doc["memory_type"] != memory_type:
+                    continue
+                if date_from and doc["date"] and doc["date"] < date_from:
+                    continue
+                if date_to and doc["date"] and doc["date"] > date_to:
+                    continue
+
+                # Get snippet from best matching chunk
+                chunk_snippet = self._get_chunk_snippet(doc["id"])
+                results.append({
+                    "id": doc["id"],
+                    "source_type": doc["source_type"],
+                    "source_id": doc["source_id"],
+                    "title": doc["title"],
+                    "memory_type": doc["memory_type"],
+                    "date": doc["date"],
+                    "snippet": chunk_snippet,
+                    "rank": -1.0 / (1.0 + seen_docs[doc["id"]]),  # Convert distance to negative rank
+                })
+
+            # Sort by distance (best first)
+            results.sort(key=lambda r: seen_docs[r["id"]])
+            return results[:limit]
+
+        except Exception as e:
+            logger.warning("Vector search failed: %s", e)
+            return []
+
+    def _get_chunk_snippet(self, doc_id: int) -> str:
+        """Get a 200-char snippet from the first chunk of a document."""
+        conn = self.get_db()
+        row = conn.execute(
+            "SELECT content FROM memory_chunks WHERE doc_id=? ORDER BY chunk_index LIMIT 1",
+            (doc_id,),
+        ).fetchone()
+        if row:
+            text = row["content"]
+            return text[:200] + "…" if len(text) > 200 else text
+        return ""
+
+    def _rrf_merge(self, fts_results: list[dict], vec_results: list[dict], limit: int) -> list[dict]:
+        """Reciprocal Rank Fusion merge of FTS5 and vector results."""
+        K = 60  # RRF constant
+        scores: dict[int, float] = {}
+        docs_by_id: dict[int, dict] = {}
+
+        for rank, doc in enumerate(fts_results):
+            doc_id = doc["id"]
+            scores[doc_id] = scores.get(doc_id, 0) + 1.0 / (K + rank)
+            docs_by_id[doc_id] = doc
+
+        for rank, doc in enumerate(vec_results):
+            doc_id = doc["id"]
+            scores[doc_id] = scores.get(doc_id, 0) + 1.0 / (K + rank)
+            if doc_id not in docs_by_id:
+                docs_by_id[doc_id] = doc
+
+        # Sort by RRF score descending
+        sorted_ids = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)
+
+        results = []
+        for doc_id in sorted_ids[:limit]:
+            doc = docs_by_id[doc_id]
+            doc["rank"] = -scores[doc_id]  # Negative for BM25 compatibility
+            results.append(doc)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Vector backfill
+    # ------------------------------------------------------------------
+
+    async def backfill_embeddings(self, batch_size: int = 32) -> dict:
+        """Embed chunks that are missing vectors. Returns {processed, remaining}."""
+        if not self._vec_available:
+            return {"processed": 0, "remaining": 0, "error": "sqlite-vec not available"}
+
+        from .embeddings import get_embedding_service
+        service = get_embedding_service()
+        if not await service.is_available():
+            return {"processed": 0, "remaining": 0, "error": "no embedding provider"}
+
+        conn = self.get_db()
+
+        # Find chunks without vectors
+        rows = conn.execute(
+            """SELECT mc.id, mc.content
+               FROM memory_chunks mc
+               LEFT JOIN memory_vectors mv ON mv.chunk_id = mc.id
+               WHERE mv.chunk_id IS NULL
+               LIMIT ?""",
+            (batch_size,),
+        ).fetchall()
+
+        if not rows:
+            return {"processed": 0, "remaining": 0}
+
+        texts = [r["content"] for r in rows]
+        embeddings = await service.embed(texts)
+        if not embeddings:
+            return {"processed": 0, "remaining": len(rows), "error": "embedding call failed"}
+
+        import sqlite_vec
+        processed = 0
+        with self._write_lock:
+            for row, embedding in zip(rows, embeddings):
+                try:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO memory_vectors (chunk_id, embedding) VALUES (?, ?)",
+                        (row["id"], sqlite_vec.serialize_float32(embedding)),
+                    )
+                    processed += 1
+                except Exception as e:
+                    logger.debug("Vector insert failed for chunk %d: %s", row["id"], e)
+            conn.commit()
+
+        # Count remaining
+        remaining = conn.execute(
+            """SELECT COUNT(*) FROM memory_chunks mc
+               LEFT JOIN memory_vectors mv ON mv.chunk_id = mc.id
+               WHERE mv.chunk_id IS NULL""",
+        ).fetchone()[0]
+
+        return {"processed": processed, "remaining": remaining}
+
+    async def check_embedding_config(self) -> None:
+        """Check if embedding provider changed; invalidate vectors if so."""
+        if not self._vec_available:
+            return
+
+        from .embeddings import get_embedding_service
+        service = get_embedding_service()
+        if not await service.is_available():
+            return
+
+        info = service.get_provider_info()
+        if not info:
+            return
+
+        conn = self.get_db()
+        stored = conn.execute("SELECT provider, model FROM memory_embedding_config WHERE id=1").fetchone()
+
+        if stored:
+            if stored["provider"] != info["provider"] or stored["model"] != info["model"]:
+                logger.info(
+                    "Embedding provider changed (%s/%s → %s/%s) — invalidating vectors",
+                    stored["provider"], stored["model"], info["provider"], info["model"],
+                )
+                with self._write_lock:
+                    conn.execute("DELETE FROM memory_vectors")
+                    conn.execute("DELETE FROM memory_chunks")
+                    conn.execute("DELETE FROM memory_embedding_config WHERE id=1")
+                    conn.execute(
+                        "INSERT INTO memory_embedding_config (id, provider, model, dimensions) VALUES (1, ?, ?, ?)",
+                        (info["provider"], info["model"], info["dimensions"]),
+                    )
+                    conn.commit()
+        else:
+            with self._write_lock:
+                conn.execute(
+                    "INSERT OR REPLACE INTO memory_embedding_config (id, provider, model, dimensions) VALUES (1, ?, ?, ?)",
+                    (info["provider"], info["model"], info["dimensions"]),
+                )
+                conn.commit()
 
     # ------------------------------------------------------------------
     # Temporal facts

--- a/backend/core/agents/memory/embeddings.py
+++ b/backend/core/agents/memory/embeddings.py
@@ -82,8 +82,7 @@ class EmbeddingService:
             base_url = ollama_profile["base_url"].rstrip("/")
             if await self._check_ollama(base_url):
                 self._provider = "ollama"
-                self._model = _OLLAMA_EMBED_MODEL
-                logger.info("Embedding provider: Ollama (%s)", base_url)
+                logger.info("Embedding provider: Ollama (%s, model=%s)", base_url, self._model)
                 return
 
         # 2. Try OpenAI
@@ -124,6 +123,7 @@ class EmbeddingService:
                 # Check if any embedding model is available
                 embed_models = [m for m in models if "embed" in m or "nomic" in m]
                 if embed_models:
+                    self._model = embed_models[0].split(":")[0]
                     return True
                 # Pull nomic-embed-text if not present (don't block on it)
                 logger.info("Ollama available but no embedding model found")
@@ -140,7 +140,7 @@ class EmbeddingService:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 f"{base_url}/api/embed",
-                json={"model": _OLLAMA_EMBED_MODEL, "input": texts},
+                json={"model": self._model or _OLLAMA_EMBED_MODEL, "input": texts},
             )
             resp.raise_for_status()
             data = resp.json()

--- a/backend/core/agents/memory/embeddings.py
+++ b/backend/core/agents/memory/embeddings.py
@@ -1,0 +1,217 @@
+"""Embedding service for semantic vector search.
+
+Provides embeddings from the user's configured AI provider. Resolution order:
+1. Ollama (if configured + reachable) — free, local
+2. OpenAI text-embedding-3-small
+3. Google text-embedding-004
+4. None — vector features disabled
+
+All providers are normalized to 768 dimensions.
+"""
+
+import logging
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DIMENSIONS = 768
+_OLLAMA_EMBED_MODEL = "nomic-embed-text"
+
+
+class EmbeddingService:
+    """Provider-agnostic embedding generation."""
+
+    def __init__(self):
+        self._provider: str | None = None
+        self._model: str | None = None
+        self._checked = False
+
+    def get_provider_info(self) -> dict | None:
+        if not self._provider:
+            return None
+        return {
+            "provider": self._provider,
+            "model": self._model,
+            "dimensions": DIMENSIONS,
+        }
+
+    async def is_available(self) -> bool:
+        if self._checked:
+            return self._provider is not None
+        await self._detect_provider()
+        return self._provider is not None
+
+    async def embed(self, texts: list[str]) -> list[list[float]] | None:
+        if not await self.is_available():
+            return None
+        try:
+            if self._provider == "ollama":
+                return await self._embed_ollama(texts)
+            elif self._provider == "openai":
+                return await self._embed_openai(texts)
+            elif self._provider == "google":
+                return await self._embed_google(texts)
+        except Exception as e:
+            logger.warning("Embedding failed (%s): %s", self._provider, e)
+            return None
+        return None
+
+    async def embed_single(self, text: str) -> list[float] | None:
+        result = await self.embed([text])
+        if result and len(result) > 0:
+            return result[0]
+        return None
+
+    async def _detect_provider(self):
+        """Detect the best available embedding provider."""
+        self._checked = True
+
+        from core.providers.credentials import CredentialStore
+        store = CredentialStore()
+        profiles = store.data.get("profiles", {})
+
+        # 1. Try Ollama
+        ollama_profile = profiles.get("ollama:default", {})
+        if ollama_profile.get("type") == "ollama_local" and ollama_profile.get("base_url"):
+            base_url = ollama_profile["base_url"].rstrip("/")
+            if await self._check_ollama(base_url):
+                self._provider = "ollama"
+                self._model = _OLLAMA_EMBED_MODEL
+                logger.info("Embedding provider: Ollama (%s)", base_url)
+                return
+
+        # 2. Try OpenAI
+        openai_profile = profiles.get("openai:default", {})
+        openai_key = None
+        if openai_profile.get("type") == "api_key":
+            openai_key = openai_profile.get("key")
+        elif openai_profile.get("type") == "chatgpt_oauth":
+            openai_key = openai_profile.get("access")
+        if openai_key:
+            self._provider = "openai"
+            self._model = "text-embedding-3-small"
+            logger.info("Embedding provider: OpenAI (text-embedding-3-small)")
+            return
+
+        # 3. Try Google
+        google_profile = profiles.get("google:default", {})
+        if google_profile.get("type") == "oauth" and google_profile.get("access"):
+            self._provider = "google"
+            self._model = "text-embedding-004"
+            logger.info("Embedding provider: Google (text-embedding-004)")
+            return
+
+        # 4. Try Anthropic (no native embeddings — skip)
+        # Anthropic doesn't offer an embeddings API directly
+
+        logger.info("No embedding provider available — vector search disabled")
+
+    async def _check_ollama(self, base_url: str) -> bool:
+        """Check if Ollama is reachable and has an embedding model."""
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                resp = await client.get(f"{base_url}/api/tags")
+                if resp.status_code != 200:
+                    return False
+                data = resp.json()
+                models = [m.get("name", "") for m in data.get("models", [])]
+                # Check if any embedding model is available
+                embed_models = [m for m in models if "embed" in m or "nomic" in m]
+                if embed_models:
+                    return True
+                # Pull nomic-embed-text if not present (don't block on it)
+                logger.info("Ollama available but no embedding model found")
+                return False
+        except Exception:
+            return False
+
+    async def _embed_ollama(self, texts: list[str]) -> list[list[float]]:
+        from core.providers.credentials import CredentialStore
+        store = CredentialStore()
+        profile = store.data.get("profiles", {}).get("ollama:default", {})
+        base_url = profile.get("base_url", "http://localhost:11434").rstrip("/")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{base_url}/api/embed",
+                json={"model": _OLLAMA_EMBED_MODEL, "input": texts},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data["embeddings"]
+
+    async def _embed_openai(self, texts: list[str]) -> list[list[float]]:
+        from core.providers.credentials import CredentialStore
+        store = CredentialStore()
+        profile = store.data.get("profiles", {}).get("openai:default", {})
+
+        api_key = None
+        if profile.get("type") == "api_key":
+            api_key = profile.get("key")
+        elif profile.get("type") == "chatgpt_oauth":
+            api_key = profile.get("access")
+
+        if not api_key:
+            raise RuntimeError("OpenAI API key not available")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                "https://api.openai.com/v1/embeddings",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "model": "text-embedding-3-small",
+                    "input": texts,
+                    "dimensions": DIMENSIONS,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return [item["embedding"] for item in data["data"]]
+
+    async def _embed_google(self, texts: list[str]) -> list[list[float]]:
+        import google.generativeai as genai
+        from core.providers.credentials import CredentialStore
+        from core.providers.oauth import refresh_google_token
+
+        store = CredentialStore()
+        profile = store.data.get("profiles", {}).get("google:default", {})
+
+        if profile.get("type") == "oauth":
+            access_token = await refresh_google_token(profile)
+            if not access_token:
+                raise RuntimeError("Google token refresh failed")
+        else:
+            raise RuntimeError("Google credentials not available")
+
+        # Use the REST API directly for embeddings
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            embeddings = []
+            # Google's batch embed endpoint
+            resp = await client.post(
+                "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContents",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json={
+                    "requests": [
+                        {"model": "models/text-embedding-004", "content": {"parts": [{"text": t}]}}
+                        for t in texts
+                    ],
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            for item in data.get("embeddings", []):
+                embeddings.append(item["values"])
+            return embeddings
+
+
+# Module-level singleton
+_service: EmbeddingService | None = None
+
+
+def get_embedding_service() -> EmbeddingService:
+    global _service
+    if _service is None:
+        _service = EmbeddingService()
+    return _service

--- a/backend/core/agents/memory/embeddings.py
+++ b/backend/core/agents/memory/embeddings.py
@@ -171,15 +171,15 @@ class EmbeddingService:
             return [item["embedding"] for item in data["data"]]
 
     async def _embed_google(self, texts: list[str]) -> list[list[float]]:
-        import google.generativeai as genai
         from core.providers.credentials import CredentialStore
         from core.providers.oauth import refresh_google_token
 
         store = CredentialStore()
         profile = store.data.get("profiles", {}).get("google:default", {})
 
-        if profile.get("type") == "oauth":
-            access_token = await refresh_google_token(profile)
+        if profile.get("type") == "oauth" and profile.get("refresh"):
+            token_data = await refresh_google_token(profile["refresh"])
+            access_token = token_data.get("access_token") if token_data else None
             if not access_token:
                 raise RuntimeError("Google token refresh failed")
         else:

--- a/backend/core/agents/memory/embeddings.py
+++ b/backend/core/agents/memory/embeddings.py
@@ -55,6 +55,10 @@ class EmbeddingService:
                 return await self._embed_google(texts)
         except Exception as e:
             logger.warning("Embedding failed (%s): %s", self._provider, e)
+            # Reset on auth failures so next call re-detects provider
+            if "401" in str(e) or "403" in str(e) or "auth" in str(e).lower():
+                self._checked = False
+                self._provider = None
             return None
         return None
 
@@ -194,7 +198,11 @@ class EmbeddingService:
                 headers={"Authorization": f"Bearer {access_token}"},
                 json={
                     "requests": [
-                        {"model": "models/text-embedding-004", "content": {"parts": [{"text": t}]}}
+                        {
+                            "model": "models/text-embedding-004",
+                            "content": {"parts": [{"text": t}]},
+                            "outputDimensionality": DIMENSIONS,
+                        }
                         for t in texts
                     ],
                 },

--- a/backend/core/agents/memory/extractor.py
+++ b/backend/core/agents/memory/extractor.py
@@ -78,8 +78,20 @@ async def extract_facts_from_messages(
         if not facts_json:
             return {"extracted": 0, "skipped": 0}
 
-        facts = json.loads(facts_json)
-        if not isinstance(facts, list):
+        parsed = json.loads(facts_json)
+        # OpenAI json_object mode may wrap the array in a dict
+        if isinstance(parsed, dict):
+            # Look for a list value in the response
+            facts = None
+            for v in parsed.values():
+                if isinstance(v, list):
+                    facts = v
+                    break
+            if facts is None:
+                return {"extracted": 0, "skipped": 0, "error": "invalid_response"}
+        elif isinstance(parsed, list):
+            facts = parsed
+        else:
             return {"extracted": 0, "skipped": 0, "error": "invalid_response"}
 
         # Store facts
@@ -156,11 +168,11 @@ async def _call_extraction_api(conversation_text: str, agent_config: dict) -> st
 
     timeout = httpx.Timeout(10.0)
 
-    if active_provider == "anthropic" or "anthropic:default" in profiles:
+    if active_provider == "anthropic":
         return await _extract_anthropic(conversation_text, profiles, timeout)
-    elif active_provider == "openai" or "openai:default" in profiles:
+    elif active_provider == "openai":
         return await _extract_openai(conversation_text, profiles, timeout)
-    elif active_provider == "google" or "google:default" in profiles:
+    elif active_provider == "google":
         return await _extract_google(conversation_text, profiles, timeout)
 
     return None

--- a/backend/core/agents/memory/extractor.py
+++ b/backend/core/agents/memory/extractor.py
@@ -1,0 +1,264 @@
+"""Automatic knowledge extraction from conversation messages.
+
+Extracts structured facts (subject-predicate-object triples) from recent
+conversation turns using the agent's configured AI provider. Runs as a
+background task at each knowledge checkpoint.
+"""
+
+import asyncio
+import json
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+_EXTRACTION_PROMPT = """\
+Extract structured facts from the conversation below. For each fact, provide:
+- subject: the entity (person, project, company, concept)
+- predicate: the relationship or property
+- object: the value
+- memory_type: one of (person, decision, preference, insight, reference, milestone)
+- confidence: 0.0-1.0 (only extract clearly stated facts, not implications)
+
+Rules:
+- Only extract facts explicitly stated in the messages
+- Skip greetings, small talk, and meta-conversation
+- Prefer atomic facts (one relationship per entry)
+- Use present tense for current facts, past tense for historical
+
+Return a JSON array. If no facts to extract, return [].
+
+Example output:
+[{"subject": "John", "predicate": "works at", "object": "Acme Corp", "memory_type": "person", "confidence": 0.9}]
+"""
+
+# Rate limiting: track last extraction time per conversation
+_last_extraction: dict[str, float] = {}
+_MIN_INTERVAL_SECONDS = 60
+
+
+async def extract_facts_from_messages(
+    messages: list[dict],
+    data_dir: str,
+    gcs_prefix: str,
+    agent_config: dict,
+) -> dict:
+    """Extract facts from recent messages and store them.
+
+    Returns {extracted: int, skipped: int, error: str|None}.
+    """
+    # Rate limit
+    conv_key = f"{data_dir}:{id(messages)}"
+    now = time.time()
+    if conv_key in _last_extraction and (now - _last_extraction[conv_key]) < _MIN_INTERVAL_SECONDS:
+        return {"extracted": 0, "skipped": 0, "error": "rate_limited"}
+    _last_extraction[conv_key] = now
+
+    # Check opt-in setting
+    if not agent_config.get("auto_extract_facts", True):
+        return {"extracted": 0, "skipped": 0, "error": "disabled"}
+
+    # Filter to last 4 user/assistant messages
+    recent = [m for m in messages if m.get("role") in ("user", "assistant")][-4:]
+    if not recent:
+        return {"extracted": 0, "skipped": 0}
+
+    # Skip trivial content
+    total_chars = sum(len(m.get("content", "")) for m in recent)
+    if total_chars < 50:
+        return {"extracted": 0, "skipped": 0, "error": "trivial_content"}
+
+    # Build extraction messages
+    conversation_text = "\n".join(
+        f"{m['role'].upper()}: {m.get('content', '')}" for m in recent
+    )
+
+    try:
+        facts_json = await _call_extraction_api(conversation_text, agent_config)
+        if not facts_json:
+            return {"extracted": 0, "skipped": 0}
+
+        facts = json.loads(facts_json)
+        if not isinstance(facts, list):
+            return {"extracted": 0, "skipped": 0, "error": "invalid_response"}
+
+        # Store facts
+        from .search_tools import _get_db
+        db = _get_db(data_dir, gcs_prefix)
+
+        extracted = 0
+        skipped = 0
+        for fact in facts:
+            if not _valid_fact(fact):
+                continue
+
+            # Dedup against active facts
+            existing = db.query_facts(
+                subject=fact["subject"],
+                predicate=fact["predicate"],
+                include_expired=False,
+                limit=5,
+            )
+
+            # Check for exact duplicates
+            duplicate = False
+            for existing_fact in existing:
+                if (existing_fact["subject"].lower() == fact["subject"].lower() and
+                    existing_fact["predicate"].lower() == fact["predicate"].lower()):
+                    if existing_fact["object"].lower() == fact["object"].lower():
+                        duplicate = True
+                        break
+                    else:
+                        # Object changed — expire old fact
+                        db.invalidate_fact(existing_fact["id"])
+
+            if duplicate:
+                skipped += 1
+                continue
+
+            db.add_fact(
+                subject=fact["subject"],
+                predicate=fact["predicate"],
+                object_=fact["object"],
+                created_by="auto_extractor",
+                confidence=min(float(fact.get("confidence", 0.8)), 0.9),
+                memory_type=fact.get("memory_type"),
+            )
+            extracted += 1
+
+        if extracted > 0:
+            try:
+                db.backup_to_gcs()
+            except Exception:
+                pass
+
+        return {"extracted": extracted, "skipped": skipped}
+
+    except asyncio.TimeoutError:
+        return {"extracted": 0, "skipped": 0, "error": "timeout"}
+    except Exception as e:
+        logger.debug("Fact extraction failed: %s", e)
+        return {"extracted": 0, "skipped": 0, "error": str(e)}
+
+
+async def _call_extraction_api(conversation_text: str, agent_config: dict) -> str | None:
+    """Call the cheapest available model for extraction."""
+    import httpx
+    from core.providers.credentials import CredentialStore
+
+    store = CredentialStore()
+    active_provider = store.data.get("active_provider", "")
+    profiles = store.data.get("profiles", {})
+
+    # Skip for Ollama-only (local models too slow for background extraction)
+    if active_provider == "ollama":
+        return None
+
+    timeout = httpx.Timeout(10.0)
+
+    if active_provider == "anthropic" or "anthropic:default" in profiles:
+        return await _extract_anthropic(conversation_text, profiles, timeout)
+    elif active_provider == "openai" or "openai:default" in profiles:
+        return await _extract_openai(conversation_text, profiles, timeout)
+    elif active_provider == "google" or "google:default" in profiles:
+        return await _extract_google(conversation_text, profiles, timeout)
+
+    return None
+
+
+async def _extract_anthropic(text: str, profiles: dict, timeout) -> str | None:
+    import httpx
+    profile = profiles.get("anthropic:default", {})
+    api_key = profile.get("key") or profile.get("token")
+    if not api_key:
+        return None
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(
+            "https://api.anthropic.com/v1/messages",
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": "claude-haiku-4-5-20251001",
+                "max_tokens": 1024,
+                "system": _EXTRACTION_PROMPT,
+                "messages": [{"role": "user", "content": text}],
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        content = data.get("content", [])
+        if content and content[0].get("type") == "text":
+            return content[0]["text"]
+    return None
+
+
+async def _extract_openai(text: str, profiles: dict, timeout) -> str | None:
+    import httpx
+    profile = profiles.get("openai:default", {})
+    api_key = profile.get("key") or profile.get("access")
+    if not api_key:
+        return None
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [
+                    {"role": "system", "content": _EXTRACTION_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+                "max_tokens": 1024,
+                "response_format": {"type": "json_object"},
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        choices = data.get("choices", [])
+        if choices:
+            return choices[0]["message"]["content"]
+    return None
+
+
+async def _extract_google(text: str, profiles: dict, timeout) -> str | None:
+    import httpx
+    from core.providers.oauth import refresh_google_token
+
+    profile = profiles.get("google:default", {})
+    access_token = await refresh_google_token(profile)
+    if not access_token:
+        return None
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={
+                "system_instruction": {"parts": [{"text": _EXTRACTION_PROMPT}]},
+                "contents": [{"role": "user", "parts": [{"text": text}]}],
+                "generationConfig": {"maxOutputTokens": 1024},
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        candidates = data.get("candidates", [])
+        if candidates:
+            parts = candidates[0].get("content", {}).get("parts", [])
+            if parts:
+                return parts[0].get("text", "")
+    return None
+
+
+def _valid_fact(fact: dict) -> bool:
+    """Validate a fact dict has required fields."""
+    return bool(
+        isinstance(fact, dict)
+        and fact.get("subject", "").strip()
+        and fact.get("predicate", "").strip()
+        and fact.get("object", "").strip()
+    )

--- a/backend/core/agents/memory/extractor.py
+++ b/backend/core/agents/memory/extractor.py
@@ -47,8 +47,8 @@ async def extract_facts_from_messages(
 
     Returns {extracted: int, skipped: int, error: str|None}.
     """
-    # Rate limit
-    conv_key = f"{data_dir}:{id(messages)}"
+    # Rate limit per agent
+    conv_key = data_dir
     now = time.time()
     if conv_key in _last_extraction and (now - _last_extraction[conv_key]) < _MIN_INTERVAL_SECONDS:
         return {"extracted": 0, "skipped": 0, "error": "rate_limited"}
@@ -242,7 +242,10 @@ async def _extract_google(text: str, profiles: dict, timeout) -> str | None:
     from core.providers.oauth import refresh_google_token
 
     profile = profiles.get("google:default", {})
-    access_token = await refresh_google_token(profile)
+    if not profile.get("refresh"):
+        return None
+    token_data = await refresh_google_token(profile["refresh"])
+    access_token = token_data.get("access_token") if token_data else None
     if not access_token:
         return None
 

--- a/backend/core/agents/memory/search_tools.py
+++ b/backend/core/agents/memory/search_tools.py
@@ -29,7 +29,7 @@ def _get_db(data_dir: str, gcs_prefix: str) -> MemoryDB:
 # search_memory
 # ------------------------------------------------------------------
 
-def search_memory(
+async def search_memory_async(
     data_dir: str,
     gcs_prefix: str,
     query: str,
@@ -52,7 +52,7 @@ def search_memory(
     # Try to get a query embedding for hybrid search
     query_embedding = None
     if db.vec_available:
-        query_embedding = _get_query_embedding(query)
+        query_embedding = await _get_query_embedding_async(query)
 
     results = db.hybrid_search(
         query=query,
@@ -66,20 +66,43 @@ def search_memory(
     return {"query": query, "results": results, "total": len(results)}
 
 
-def _get_query_embedding(query: str) -> list[float] | None:
-    """Get embedding for a search query. Returns None on any failure."""
+def search_memory(
+    data_dir: str,
+    gcs_prefix: str,
+    query: str,
+    source_type: str | None = None,
+    memory_type: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    limit: int = 20,
+) -> dict:
+    """Sync wrapper — falls back to FTS5 only (no embedding in sync context)."""
+    if not query or not query.strip():
+        return {"error": "query is required"}
     try:
-        import asyncio
+        limit = max(1, min(int(limit), 100))
+    except (TypeError, ValueError):
+        limit = 20
+
+    db = _get_db(data_dir, gcs_prefix)
+    results = db.hybrid_search(
+        query=query,
+        query_embedding=None,
+        source_type=source_type,
+        memory_type=validate_memory_type(memory_type),
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+    )
+    return {"query": query, "results": results, "total": len(results)}
+
+
+async def _get_query_embedding_async(query: str) -> list[float] | None:
+    """Get embedding for a search query (async). Returns None on failure."""
+    try:
         from .embeddings import get_embedding_service
         service = get_embedding_service()
-
-        try:
-            loop = asyncio.get_running_loop()
-            # If we're already in an async context, we can't run synchronously
-            # Return None and fall back to FTS5-only
-            return None
-        except RuntimeError:
-            return asyncio.run(service.embed_single(query))
+        return await service.embed_single(query)
     except Exception:
         return None
 

--- a/backend/core/agents/memory/search_tools.py
+++ b/backend/core/agents/memory/search_tools.py
@@ -39,7 +39,7 @@ def search_memory(
     date_to: str | None = None,
     limit: int = 20,
 ) -> dict:
-    """Full-text search across daily notes, MEMORY.md, topic files, and facts."""
+    """Hybrid search (FTS5 + vector) across daily notes, MEMORY.md, topic files, and facts."""
     if not query or not query.strip():
         return {"error": "query is required"}
     try:
@@ -48,8 +48,15 @@ def search_memory(
         limit = 20
 
     db = _get_db(data_dir, gcs_prefix)
-    results = db.search(
+
+    # Try to get a query embedding for hybrid search
+    query_embedding = None
+    if db.vec_available:
+        query_embedding = _get_query_embedding(query)
+
+    results = db.hybrid_search(
         query=query,
+        query_embedding=query_embedding,
         source_type=source_type,
         memory_type=validate_memory_type(memory_type),
         date_from=date_from,
@@ -57,6 +64,24 @@ def search_memory(
         limit=limit,
     )
     return {"query": query, "results": results, "total": len(results)}
+
+
+def _get_query_embedding(query: str) -> list[float] | None:
+    """Get embedding for a search query. Returns None on any failure."""
+    try:
+        import asyncio
+        from .embeddings import get_embedding_service
+        service = get_embedding_service()
+
+        try:
+            loop = asyncio.get_running_loop()
+            # If we're already in an async context, we can't run synchronously
+            # Return None and fall back to FTS5-only
+            return None
+        except RuntimeError:
+            return asyncio.run(service.embed_single(query))
+    except Exception:
+        return None
 
 
 # ------------------------------------------------------------------

--- a/backend/core/agents/skills/__init__.py
+++ b/backend/core/agents/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Skill packs — reusable prompt recipes that agents can save and execute."""

--- a/backend/core/agents/skills/db.py
+++ b/backend/core/agents/skills/db.py
@@ -1,0 +1,140 @@
+"""Skill packs CRUD operations using the agent's MemoryDB connection."""
+
+import json
+import logging
+import re
+
+from core.agents.memory.db import get_instance
+
+logger = logging.getLogger(__name__)
+
+_MAX_TRIGGER_PATTERN_LEN = 200
+_NESTED_QUANTIFIER_RE = re.compile(r"(\.\*){2,}|\(\.\*\)\*|\(\.\+\)\+")
+
+
+def list_skills(data_dir: str, category: str | None = None) -> list[dict]:
+    """List available skill packs."""
+    db = get_instance(data_dir)
+    if not db:
+        return []
+
+    conn = db.get_db()
+    sql = "SELECT id, name, description, category, usage_count FROM skill_packs"
+    params: list = []
+    if category:
+        sql += " WHERE category = ?"
+        params.append(category)
+    sql += " ORDER BY usage_count DESC, name"
+
+    rows = conn.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_skill(data_dir: str, name: str) -> dict | None:
+    """Get a skill by name."""
+    db = get_instance(data_dir)
+    if not db:
+        return None
+
+    conn = db.get_db()
+    row = conn.execute(
+        "SELECT * FROM skill_packs WHERE name = ?", (name,)
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def save_skill(
+    data_dir: str,
+    name: str,
+    prompt: str,
+    description: str = "",
+    category: str | None = None,
+    tags: list[str] | None = None,
+    trigger_pattern: str | None = None,
+) -> dict:
+    """Save a new skill pack."""
+    if not name or not name.strip():
+        return {"error": "name is required"}
+    if not prompt or not prompt.strip():
+        return {"error": "prompt is required"}
+
+    # Validate trigger_pattern if provided
+    if trigger_pattern:
+        if len(trigger_pattern) > _MAX_TRIGGER_PATTERN_LEN:
+            return {"error": f"trigger_pattern too long (max {_MAX_TRIGGER_PATTERN_LEN} chars)"}
+        if _NESTED_QUANTIFIER_RE.search(trigger_pattern):
+            return {"error": "trigger_pattern contains unsafe nested quantifiers"}
+        try:
+            re.compile(trigger_pattern)
+        except re.error as e:
+            return {"error": f"trigger_pattern is invalid regex: {e}"}
+
+    db = get_instance(data_dir)
+    if not db:
+        return {"error": "memory database not available"}
+
+    conn = db.get_db()
+    tags_json = json.dumps(tags) if tags else None
+
+    with db.write_lock:
+        try:
+            conn.execute(
+                """INSERT INTO skill_packs (name, description, prompt, category, tags, trigger_pattern)
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(name) DO UPDATE SET
+                       description=excluded.description,
+                       prompt=excluded.prompt,
+                       category=excluded.category,
+                       tags=excluded.tags,
+                       trigger_pattern=excluded.trigger_pattern,
+                       updated_at=datetime('now')""",
+                (name.strip(), description, prompt.strip(), category, tags_json, trigger_pattern),
+            )
+            conn.commit()
+        except Exception as e:
+            return {"error": str(e)}
+
+    return {"name": name.strip(), "ok": True}
+
+
+def run_skill(data_dir: str, name: str, params: dict | None = None) -> dict:
+    """Execute a skill by name, expanding {{param}} placeholders."""
+    skill = get_skill(data_dir, name)
+    if not skill:
+        return {"error": f"Skill '{name}' not found"}
+
+    prompt = skill["prompt"]
+
+    # Substitute parameters
+    if params:
+        for key, value in params.items():
+            prompt = prompt.replace(f"{{{{{key}}}}}", str(value))
+
+    # Increment usage count
+    db = get_instance(data_dir)
+    if db:
+        conn = db.get_db()
+        with db.write_lock:
+            conn.execute(
+                "UPDATE skill_packs SET usage_count = usage_count + 1, updated_at = datetime('now') WHERE name = ?",
+                (name,),
+            )
+            conn.commit()
+
+    return {"name": name, "prompt": prompt, "ok": True}
+
+
+def delete_skill(data_dir: str, name: str) -> dict:
+    """Delete a skill pack."""
+    db = get_instance(data_dir)
+    if not db:
+        return {"error": "memory database not available"}
+
+    conn = db.get_db()
+    with db.write_lock:
+        cursor = conn.execute("DELETE FROM skill_packs WHERE name = ?", (name,))
+        conn.commit()
+        if cursor.rowcount == 0:
+            return {"error": f"Skill '{name}' not found"}
+
+    return {"name": name, "deleted": True}

--- a/backend/core/agents/skills/tools.py
+++ b/backend/core/agents/skills/tools.py
@@ -1,0 +1,27 @@
+"""Skill pack tool handlers — dispatched via kind="skill" in ToolRegistry."""
+
+from . import db
+
+
+async def execute_skill_tool(tool_name: str, tool_args: dict, data_dir: str) -> dict:
+    """Route skill tool calls to the appropriate handler."""
+    if tool_name == "list_skills":
+        return db.list_skills(data_dir, category=tool_args.get("category"))
+    elif tool_name == "run_skill":
+        name = tool_args.get("name", "")
+        params = tool_args.get("params")
+        return db.run_skill(data_dir, name, params)
+    elif tool_name == "save_skill":
+        return db.save_skill(
+            data_dir=data_dir,
+            name=tool_args.get("name", ""),
+            prompt=tool_args.get("prompt", ""),
+            description=tool_args.get("description", ""),
+            category=tool_args.get("category"),
+            tags=tool_args.get("tags"),
+            trigger_pattern=tool_args.get("trigger_pattern"),
+        )
+    elif tool_name == "delete_skill":
+        return db.delete_skill(data_dir, tool_args.get("name", ""))
+    else:
+        return {"error": f"Unknown skill tool: {tool_name}"}

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -298,6 +298,79 @@ MEMORY_TOOLS = [
     },
 ]
 
+# ── Skill pack tools ────────────────────────────────────────────────────────
+
+SKILL_TOOLS = [
+    {
+        "name": "list_skills",
+        "description": "List available skill packs (reusable prompt recipes you've saved).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "description": "Optional category filter.",
+                },
+            },
+        },
+        "kind": "skill",
+        "writes": False,
+    },
+    {
+        "name": "run_skill",
+        "description": "Execute a saved skill pack by name. Returns the expanded prompt text for you to follow.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the skill to execute.",
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Key-value parameters to substitute into {{param}} placeholders.",
+                },
+            },
+            "required": ["name"],
+        },
+        "kind": "skill",
+        "writes": True,
+    },
+    {
+        "name": "save_skill",
+        "description": "Save a reusable skill pack (prompt recipe) for future use. Use {{param_name}} for variable placeholders.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Unique name for this skill.",
+                },
+                "prompt": {
+                    "type": "string",
+                    "description": "The prompt template. Use {{param}} for variable parts.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Brief description of what this skill does.",
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Category for organization (e.g. 'email', 'analysis', 'writing').",
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Tags for discovery.",
+                },
+            },
+            "required": ["name", "prompt"],
+        },
+        "kind": "skill",
+        "writes": True,
+    },
+]
+
 # ── Shared context tools ─────────────────────────────────────────────────────
 
 SHARED_CONTEXT_TOOLS = [
@@ -1437,6 +1510,7 @@ def get_tool_definitions(
     tools = list(CONTEXT_TOOLS)
     if memory_enabled:
         tools.extend(MEMORY_TOOLS)
+        tools.extend(SKILL_TOOLS)
     if shared_context_enabled:
         tools.extend(SHARED_CONTEXT_TOOLS)
 

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -132,7 +132,7 @@ class ToolRegistry:
             if kind == "context":
                 return self._execute_context(tool_name, tool_args)
             elif kind == "memory":
-                return self._execute_memory(tool_name, tool_args)
+                return await self._execute_memory(tool_name, tool_args)
             elif kind == "skill":
                 from core.agents.skills.tools import execute_skill_tool
                 return await execute_skill_tool(tool_name, tool_args, self.context_dir)
@@ -181,7 +181,7 @@ class ToolRegistry:
             return delete_context_file(self.context_dir, args["filename"])
         return {"error": f"Unknown context tool: {tool_name}"}
 
-    def _execute_memory(self, tool_name: str, args: dict) -> dict:
+    async def _execute_memory(self, tool_name: str, args: dict) -> dict:
         from core.agents.tools.memory_tools import (
             append_daily_note, read_daily_note, list_daily_notes,
             read_memory, update_memory, consolidate_memory,

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -133,6 +133,9 @@ class ToolRegistry:
                 return self._execute_context(tool_name, tool_args)
             elif kind == "memory":
                 return self._execute_memory(tool_name, tool_args)
+            elif kind == "skill":
+                from core.agents.skills.tools import execute_skill_tool
+                return await execute_skill_tool(tool_name, tool_args, self.data_dir)
             elif kind == "shared_context":
                 return self._execute_shared_context(tool_name, tool_args)
             elif kind == "gmail":

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -135,7 +135,7 @@ class ToolRegistry:
                 return self._execute_memory(tool_name, tool_args)
             elif kind == "skill":
                 from core.agents.skills.tools import execute_skill_tool
-                return await execute_skill_tool(tool_name, tool_args, self.data_dir)
+                return await execute_skill_tool(tool_name, tool_args, self.context_dir)
             elif kind == "shared_context":
                 return self._execute_shared_context(tool_name, tool_args)
             elif kind == "gmail":
@@ -187,7 +187,7 @@ class ToolRegistry:
             read_memory, update_memory, consolidate_memory,
         )
         from core.agents.memory.search_tools import (
-            search_memory, add_fact, query_facts, invalidate_fact,
+            search_memory_async, add_fact, query_facts, invalidate_fact,
         )
 
         # Memory tools use context_dir (not agent_data_dir) because
@@ -208,7 +208,7 @@ class ToolRegistry:
         elif tool_name == "update_memory":
             return update_memory(ctx_dir, prefix, args["content"])
         elif tool_name == "search_memory":
-            return search_memory(
+            return await search_memory_async(
                 ctx_dir, prefix, args["query"],
                 source_type=args.get("source_type"),
                 memory_type=args.get("memory_type"),

--- a/backend/core/agents/tools/context_tools.py
+++ b/backend/core/agents/tools/context_tools.py
@@ -103,23 +103,38 @@ def _safe_filename(filename: str) -> bool:
     return True
 
 
+def _source_type_for(filename: str) -> str | None:
+    """Return the index source_type for a context file, or None to skip."""
+    if filename == "MEMORY.md":
+        return "memory"
+    if filename == "soul.md" or filename.startswith("_"):
+        return None
+    return "topic"
+
+
 def _index_context_file(data_dir: str, filename: str, content: str) -> None:
     """Update the FTS5/vector index for a context file write."""
+    src_type = _source_type_for(filename)
+    if not src_type:
+        return
     try:
         from core.agents.memory.db import get_instance
         db = get_instance(data_dir)
         if db:
-            db.index_document("topic", filename, filename, content, embed=True)
+            db.index_document(src_type, filename, filename, content, embed=True)
     except Exception as e:
         logger.debug("Context file indexing skipped for %s: %s", filename, e)
 
 
 def _remove_context_index(data_dir: str, filename: str) -> None:
     """Remove a deleted context file from the FTS5/vector index."""
+    src_type = _source_type_for(filename)
+    if not src_type:
+        return
     try:
         from core.agents.memory.db import get_instance
         db = get_instance(data_dir)
         if db:
-            db.remove_document("topic", filename)
+            db.remove_document(src_type, filename)
     except Exception as e:
         logger.debug("Context file index removal skipped for %s: %s", filename, e)

--- a/backend/core/agents/tools/context_tools.py
+++ b/backend/core/agents/tools/context_tools.py
@@ -52,6 +52,8 @@ def write_context_file(data_dir: str, filename: str, content: str) -> dict:
     path = d / filename
     path.write_text(content, encoding="utf-8")
     logger.info("Agent wrote context file: %s", filename)
+
+    _index_context_file(data_dir, filename, content)
     return {"filename": filename, "ok": True}
 
 
@@ -71,6 +73,8 @@ def append_to_context_file(data_dir: str, filename: str, content: str) -> dict:
     new_content = existing + "\n" + content if existing else content
     path.write_text(new_content, encoding="utf-8")
     logger.info("Agent appended to context file: %s", filename)
+
+    _index_context_file(data_dir, filename, new_content)
     return {"filename": filename, "ok": True}
 
 
@@ -85,6 +89,8 @@ def delete_context_file(data_dir: str, filename: str) -> dict:
 
     path.unlink()
     logger.info("Agent deleted context file: %s", filename)
+
+    _remove_context_index(data_dir, filename)
     return {"filename": filename, "deleted": True}
 
 
@@ -95,3 +101,25 @@ def _safe_filename(filename: str) -> bool:
     if "/" in filename or "\\" in filename or ".." in filename:
         return False
     return True
+
+
+def _index_context_file(data_dir: str, filename: str, content: str) -> None:
+    """Update the FTS5/vector index for a context file write."""
+    try:
+        from core.agents.memory.db import get_instance
+        db = get_instance(data_dir)
+        if db:
+            db.index_document("topic", filename, filename, content, embed=True)
+    except Exception as e:
+        logger.debug("Context file indexing skipped for %s: %s", filename, e)
+
+
+def _remove_context_index(data_dir: str, filename: str) -> None:
+    """Remove a deleted context file from the FTS5/vector index."""
+    try:
+        from core.agents.memory.db import get_instance
+        db = get_instance(data_dir)
+        if db:
+            db.remove_document("topic", filename)
+    except Exception as e:
+        logger.debug("Context file index removal skipped for %s: %s", filename, e)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,3 +27,4 @@ qrcode[pil]
 todoist-api-python
 prompt_toolkit
 rich
+sqlite-vec

--- a/docs/ob1-integration-research.md
+++ b/docs/ob1-integration-research.md
@@ -1,0 +1,184 @@
+# OB1 Integration Research
+
+Notes from a research session exploring how to incorporate ideas from
+[OB1](https://github.com/NateBJones-Projects/OB1) into Chatty.
+
+## Background
+
+### What OB1 is
+
+OB1 ("Open Brain") is an infrastructure layer that creates a unified, portable
+memory system for AI tools. Tagline: *"The infrastructure layer for your
+thinking. One database, one AI gateway, one chat channel."*
+
+It solves fragmented AI memory by consolidating thoughts into a single
+searchable store that any AI client (Claude, ChatGPT, Cursor, etc.) can read
+and write through a Model Context Protocol (MCP) server.
+
+**Tech stack:**
+- Postgres + pgvector (via Supabase, or self-hosted)
+- TypeScript/JavaScript edge functions for ingestion + embedding
+- MCP server as the AI-facing interface
+- Slack/Discord capture bots for quick ingestion
+- Import recipes for ChatGPT, Obsidian, Gmail, Twitter/X, Instagram, etc.
+- SvelteKit / Next.js dashboard options
+
+**How it works:**
+1. User spins up a Supabase project (or self-hosts on Kubernetes); OB1 ships
+   SQL migrations creating tables like `thoughts`, `skills`, `sources`.
+2. Content is ingested (Slack DM, import recipe, etc.). Edge functions embed
+   each thought and fingerprint it for dedup.
+3. An MCP server exposes tools like `search_thoughts`, `capture`, `list_skills`.
+4. Any MCP-aware AI client connects to the same endpoint, so memory is shared
+   and portable across tools.
+5. "Skill packs" are rows in a table — reusable prompt recipes that agents can
+   pull down and execute. Skills can be auto-generated from work sessions.
+
+### What Supabase is
+
+Open-source Firebase alternative — managed Postgres with batteries:
+- Real Postgres + pgvector for embeddings/similarity search
+- Auto-generated REST and GraphQL APIs (PostgREST)
+- Row-level security
+- Edge Functions (Deno-based serverless)
+- Auth, file storage, realtime subscriptions
+
+You get a connection string + HTTPS API URL + JWT, and you can read/write your
+data from anywhere. Hosted at supabase.com or self-hostable.
+
+## Why this matters for Chatty
+
+Chatty already has the bones: `core/agents/memory/` (FTS5 search),
+`shared_context/`, `dreaming/` (context archival), and a pluggable
+`agents/import_service/`. OB1 overlaps significantly but adds vector search,
+content fingerprinting, more import recipes, skill packs, and — most
+importantly — **portability across AI tools** via MCP.
+
+The hard constraint from `CLAUDE.md`: no required Postgres, no external
+services. Chatty must remain SQLite-only and one-click-deployable on Railway.
+
+## Approach 1 — Integrate with OB1 directly
+
+Add OB1 as an optional integration (mirroring `integrations/quickbooks/` or
+`integrations/google/`). User connects their own Supabase/OB1 project; agents
+get tools like `ob1_search_thoughts`, `ob1_capture`, `ob1_list_skills` via the
+existing `_load_integration_tools()` path.
+
+| Option | What it does | Tradeoff |
+|---|---|---|
+| **A. Tool-only** | Agents call OB1 tools when they choose to. Local memory unchanged. | Simplest, fully optional. But two parallel memory systems. |
+| **B. Write-through mirror** | When OB1 is connected, every `memory.save()` and `shared_context.write()` also writes to OB1. Reads stay local. | Portability "just works." Adds latency + a Supabase failure mode. |
+| **C. Canonical when connected** | OB1 *replaces* the local memory store; SQLite becomes a cache. | Maximum portability. Violates no-external-services principle and is the biggest refactor. |
+
+Recommendation if going this route: **B + treat OB1's MCP server as the
+connection surface** (Chatty becomes an MCP client) rather than talking to
+Supabase directly.
+
+## Approach 2 — Absorb the good ideas (recommended)
+
+Don't depend on OB1; cherry-pick its best ideas into Chatty's existing
+modules.
+
+### Tier 1 — high leverage, fits cleanly
+
+| Idea from OB1 | Where it lands in Chatty |
+|---|---|
+| **Semantic / vector search on memory** (alongside existing FTS5) | `core/agents/memory/db.py` — add `sqlite-vec` (pure-SQLite extension, no Postgres). Hybrid retrieval = FTS5 + vector. |
+| **Content fingerprinting + dedup** | `agents/import_service/scrubber.py` — hash each chunk on import, skip dupes. |
+| **More import recipes** (ChatGPT export, Obsidian vault, Twitter archive, Instagram archive) | New files under `agents/import_service/adapters/`. ChatGPT export is highest demand. |
+| **Skill packs** as portable JSON | New `core/agents/skills/` module — reusable prompt/recipe bundles. Start local; marketplace later. |
+
+### Tier 2 — worthwhile but bigger surface
+
+- **Unified "Thoughts" view** in the dashboard — a tab listing everything
+  across sources with vector search.
+- **Quick-capture inbox** — a dedicated triage queue separate from
+  `shared_context` so raw thoughts don't pollute agent context. Telegram /
+  WhatsApp already provide the channel.
+- **Self-improving skills** — agent notices a repeated workflow and offers
+  "save as skill?". Novel UX, needs care to avoid noise.
+
+### Tier 3 — the strategic move
+
+**Make Chatty itself an MCP server.** OB1's whole pitch is "your memory,
+portable across Claude / Cursor / ChatGPT." If Chatty exposes its `memory`,
+`shared_context`, and skills via an MCP endpoint, **Chatty becomes the OB1**,
+except free, open source, and with a real UI. No Supabase ever required.
+Sharpens Chatty's value prop: *"your AI brain, queryable from every tool you
+use."*
+
+### Skip / defer
+
+- Adopting Supabase/Postgres — against `CLAUDE.md`'s no-external-services
+  principle; `sqlite-vec` covers ~95% of the value.
+- Slack / Discord capture bots — Telegram + WhatsApp already serve that role
+  for the small-business audience.
+
+## Suggested first slice
+
+Tier 1 rows 1+2 in a single PR:
+
+1. Add `sqlite-vec` dependency, verify it loads on Railway's image.
+2. New `memory_vectors` table + embedding pipeline.
+3. Hybrid-rank FTS5 + vector results in `memory/search_tools.py`.
+4. Fingerprint-based dedup in `agents/import_service/scrubber.py`.
+
+A few hundred lines, makes Chatty's memory noticeably smarter, no
+external-service dependencies. Validate `sqlite-vec` on Railway in a 10-minute
+spike before committing.
+
+## Reference repos worth studying
+
+### Memory layers (the OB1 category, more mature)
+
+| Repo | What to learn |
+|---|---|
+| **mem0** (`mem0ai/mem0`) | Reference implementation for "memory as a service." Hybrid vector + graph + facts. Best blueprint for what `core/agents/memory/` could become. |
+| **Letta** (`letta-ai/letta`, formerly MemGPT) | Self-editing memory blocks; hierarchical core/archival memory split — directly relevant to `dreaming/`. |
+| **Zep** + **Graphiti** (`getzep/*`) | Temporal knowledge graphs — memory that understands *when* things happened. |
+| **Cognee** (`topoteretes/cognee`) | Research-flavored graph + vector blend. Skim, don't copy. |
+
+### Multi-provider AI platforms (Chatty's broader category)
+
+| Repo | What to learn — and what to avoid |
+|---|---|
+| **AnythingLLM** (`Mintplex-Labs/anything-llm`) | Closest direct analog. Steal: connector breadth, workspace-as-isolation. Avoid: enterprise-leaning bloat. |
+| **LibreChat** (`danny-avila/LibreChat`) | Most polished multi-provider chat UI. Reference for provider abstraction, MCP client integration, plugins. |
+| **Khoj** (`khoj-ai/khoj`) | Closest spiritual sibling — single-user, local-first, second-brain angle, multi-provider. |
+| **Open WebUI** (`open-webui/open-webui`) | Self-hosted UX patterns, plugin/tool/function-calling architecture, "Pipelines" concept. |
+| **LobeChat** (`lobehub/lobe-chat`) | UI patterns and an agent marketplace concept. |
+
+### Personal capture / "thoughts" inbox
+
+| Repo | What to learn |
+|---|---|
+| **Memos** (`usememos/memos`) | Lightweight thought-capture UX. |
+| **Karakeep** (`karakeep-app/karakeep`, formerly Hoarder) | AI auto-tagging on ingest — applicable to `import_service`. |
+
+### Connectors / RAG infrastructure
+
+| Repo | What to learn |
+|---|---|
+| **Onyx** (`onyx-dot-app/onyx`, formerly Danswer) | Best-in-class open-source connector library (Gmail, Drive, Slack, Notion, Confluence). Copy adapter patterns, not architecture. |
+| **LlamaIndex** (`run-llama/llama_index`) | Ingestion pipelines and retrieval strategies (hybrid search, re-ranking, sub-document chunking). Read for ideas; don't take as a dep. |
+
+### Agent orchestration
+
+| Repo | What to learn |
+|---|---|
+| **CrewAI** (`crewAIInc/crewAI`) | Role-based multi-agent collaboration patterns. Adjacent to `paperclip`. |
+| **AutoGen** (`microsoft/autogen`) | Conversation-based agent orchestration. Academic but influential. |
+
+### Top three to study first
+
+1. **mem0** — what semantic memory should feel like.
+2. **Letta** — self-editing memory blocks and the dreaming/archival pattern.
+3. **AnythingLLM** — what Chatty looks like if it grows up "wrong"
+   (enterprise-heavy), so we know what to avoid while mining for ideas.
+
+## Guiding filter
+
+Most of these references are more mature than Chatty in their narrow domain.
+The temptation is to absorb everything and lose focus. Chatty's edge is
+**"a personal AI for small-business owners that deploys in one click"** —
+every borrowed idea should pass that filter.


### PR DESCRIPTION
## Summary

- Add sqlite-vec hybrid search (FTS5 keyword + vector similarity via Reciprocal Rank Fusion) with Ollama/OpenAI/Google embedding fallback chain
- Proactive memory surfacing: semantically relevant memories auto-injected into agent context on first message
- Automatic fact extraction from conversations at knowledge checkpoints (background task)
- Skill packs: agents can save, list, and run reusable prompt recipe templates
- Import-time content dedup via SHA256 hash check
- Fix: context file writes now update FTS5/vector index (was a latent bug)
- Content-hash-aware reindex preserves existing embeddings across restarts
- CLI `/search` uses async hybrid search for semantic results

## Review fixes (cross-model Claude × Codex review)

- ThreadPoolExecutor semantic prefetch no longer blocks past 5s timeout
- Backfill loop stops after 3 consecutive failures instead of retrying forever
- SQLite extension loading disabled in `finally` block on load failure
- Date filters exclude undated documents when date range is specified
- MEMORY.md indexed with correct `source_type`, `soul.md`/`_*.md` skipped
- Ollama uses detected embedding model instead of hardcoded `nomic-embed-text`
- Import dedup calls correct `get_import_source` (singular) method
- Backfill returns error when all per-row inserts fail (prevents silent infinite loop)
- Context file remove uses correct source_type matching

## Test plan

- [x] sqlite-vec loads and creates vector table (`vec=True` in logs)
- [x] Ollama nomic-embed-text produces 768-dim embeddings
- [x] FTS5 keyword search still works ("dog" → pets.md)
- [x] Semantic search finds matches FTS5 misses ("canine" → pets.md, "feline" → cat daily note, "financial planning" → work.md)
- [x] Hybrid RRF merge ranks results correctly
- [x] Proactive surfacing: agent loads relevant context on first message
- [x] Facts stored and queryable
- [x] Skill packs save/list/run all work
- [x] Content-hash reindex preserves embeddings for unchanged docs
- [x] Vector backfill processes chunks missing vectors
- [x] CLI `/search` with semantic results (async fix)
- [x] Graceful degradation without embedding provider (FTS5-only fallback)
- [ ] Test on Railway (python:3.12-slim Docker image)