### PR TITLE
Add golden path test suite for critical backend modules

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -27,10 +27,16 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
 
       - name: Install dependencies
-        run: pip install -r backend/requirements.txt
+        run: pip install -r backend/requirements-dev.txt
+
+      - name: Run tests
+        working-directory: backend
+        run: python -m pytest -x -q --tb=short
 
       - name: Import check — verify all modules load
         working-directory: backend

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+asyncio_mode = auto

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+pytest-asyncio

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,66 @@
+"""Shared test fixtures for the Chatty backend test suite."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def tmp_data_dir(tmp_path):
+    """Create a minimal data directory tree for tests."""
+    data = tmp_path / "data"
+    (data / "agents" / "test-agent" / "context").mkdir(parents=True)
+    (data / "integrations").mkdir(parents=True)
+    return data
+
+
+@pytest.fixture
+def agent_db(monkeypatch, tmp_path):
+    """Fresh agent registry DB using production schema."""
+    import agents.db as db_mod
+
+    db_file = tmp_path / "agents.db"
+    monkeypatch.setattr(db_mod, "DB_PATH", db_file)
+    monkeypatch.setattr(db_mod, "DATA_DIR", tmp_path)
+
+    # Patch DATA_DIR in modules that import their own copy
+    try:
+        import agents.engine as engine_mod
+        monkeypatch.setattr(engine_mod, "DATA_DIR", tmp_path)
+    except ImportError:
+        pass
+
+    db_mod._setup_connection()
+    yield db_mod._connection
+
+    db_mod.close_db()
+
+
+@pytest.fixture
+def encryption_env(monkeypatch, tmp_path):
+    """Isolate encryption: deterministic key, no keychain or file leakage."""
+    from cryptography.fernet import Fernet
+    from core.encryption import EncryptionKeyManager
+
+    key = Fernet.generate_key()
+    monkeypatch.setenv("ENCRYPTION_KEY", key.decode())
+    monkeypatch.setattr(
+        "core.encryption.KEY_FILE_PATH", tmp_path / ".encryption-key"
+    )
+    EncryptionKeyManager._cached_key = None
+    yield key
+    EncryptionKeyManager._cached_key = None
+
+
+async def collect_events(async_gen):
+    """Drain a chat() SSE generator into a list of parsed event dicts."""
+    events = []
+    async for line in async_gen:
+        if line.startswith("data: "):
+            try:
+                events.append(json.loads(line[6:].strip()))
+            except json.JSONDecodeError:
+                pass
+    return events

--- a/backend/tests/test_agent_db.py
+++ b/backend/tests/test_agent_db.py
@@ -1,0 +1,113 @@
+"""Tests for agents/db.py — agent CRUD operations."""
+
+import uuid
+
+from agents.db import (
+    create_agent,
+    delete_agent,
+    get_agent,
+    get_agent_by_slug,
+    list_agents,
+    update_agent,
+)
+
+
+class TestCreateAgent:
+    def test_returns_dict_with_uuid_id(self, agent_db):
+        agent = create_agent("Test Agent")
+        assert isinstance(agent, dict)
+        # Should be a valid UUID
+        uuid.UUID(agent["id"])
+
+    def test_slug_is_lowercase_hyphenated(self, agent_db):
+        agent = create_agent("My Agent")
+        assert agent["slug"] == "my-agent"
+
+    def test_special_chars_stripped_from_slug(self, agent_db):
+        agent = create_agent("Hello, World! @#$%")
+        assert agent["slug"] == "hello-world"
+
+    def test_duplicate_name_gets_uuid_suffix(self, agent_db):
+        first = create_agent("Sales Bot")
+        second = create_agent("Sales Bot")
+        assert first["slug"] == "sales-bot"
+        assert second["slug"].startswith("sales-bot-")
+        assert second["slug"] != first["slug"]
+        # Suffix should be a hex fragment
+        suffix = second["slug"].removeprefix("sales-bot-")
+        assert len(suffix) >= 6
+        int(suffix, 16)
+
+
+class TestGetAgent:
+    def test_returns_correct_agent_by_id(self, agent_db):
+        created = create_agent("Lookup Agent")
+        fetched = get_agent(created["id"])
+        assert fetched is not None
+        assert fetched["id"] == created["id"]
+        assert fetched["agent_name"] == "Lookup Agent"
+
+    def test_nonexistent_id_returns_none(self, agent_db):
+        assert get_agent("nonexistent-id") is None
+
+
+class TestGetAgentBySlug:
+    def test_returns_correct_agent_by_slug(self, agent_db):
+        created = create_agent("Slug Lookup")
+        fetched = get_agent_by_slug("slug-lookup")
+        assert fetched is not None
+        assert fetched["id"] == created["id"]
+
+    def test_nonexistent_slug_returns_none(self, agent_db):
+        assert get_agent_by_slug("no-such-slug") is None
+
+
+class TestListAgents:
+    def test_empty_when_no_agents(self, agent_db):
+        assert list_agents() == []
+
+    def test_returns_all_agents(self, agent_db):
+        create_agent("Agent A")
+        create_agent("Agent B")
+        agents = list_agents()
+        assert len(agents) == 2
+        names = {a["agent_name"] for a in agents}
+        assert names == {"Agent A", "Agent B"}
+
+
+class TestUpdateAgent:
+    def test_changes_name(self, agent_db):
+        agent = create_agent("Old Name")
+        updated = update_agent(agent["id"], agent_name="New Name")
+        assert updated["agent_name"] == "New Name"
+
+    def test_name_change_updates_slug(self, agent_db):
+        agent = create_agent("Before Rename")
+        assert agent["slug"] == "before-rename"
+        updated = update_agent(agent["id"], agent_name="After Rename")
+        assert updated["slug"] == "after-rename"
+
+    def test_ignores_unknown_fields(self, agent_db):
+        agent = create_agent("Stable Agent")
+        updated = update_agent(agent["id"], bogus_field="should be ignored")
+        assert updated is not None
+        assert updated["agent_name"] == "Stable Agent"
+        assert "bogus_field" not in updated
+
+    def test_google_accounts_stored_as_json_text(self, agent_db):
+        agent = create_agent("Google Agent")
+        updated = update_agent(
+            agent["id"],
+            google_accounts='{"gmail": ["acc1@example.com"]}',
+        )
+        assert updated["google_accounts"]["gmail"] == ["acc1@example.com"]
+
+
+class TestDeleteAgent:
+    def test_returns_true_and_agent_is_gone(self, agent_db):
+        agent = create_agent("Doomed Agent")
+        assert delete_agent(agent["id"]) is True
+        assert get_agent(agent["id"]) is None
+
+    def test_nonexistent_returns_false(self, agent_db):
+        assert delete_agent("nonexistent-id") is False

--- a/backend/tests/test_agent_engine.py
+++ b/backend/tests/test_agent_engine.py
@@ -10,7 +10,6 @@ from agents.engine import (
     get_chat_service,
     get_context_manager,
     invalidate_cache,
-    _context_dir,
 )
 from core.agents.config import AgentConfig
 from core.agents.context_manager import ContextManager

--- a/backend/tests/test_agent_engine.py
+++ b/backend/tests/test_agent_engine.py
@@ -1,0 +1,127 @@
+"""Tests for agents.engine — config building and service getters."""
+
+import uuid
+
+import pytest
+
+import agents.engine as engine_mod
+from agents.engine import (
+    build_agent_config,
+    get_chat_service,
+    get_context_manager,
+    invalidate_cache,
+    _context_dir,
+)
+from core.agents.config import AgentConfig
+from core.agents.context_manager import ContextManager
+from core.agents.chat_history.service import ChatHistoryService
+
+
+def _make_agent_row(**overrides) -> dict:
+    """Return a minimal agent DB row dict with sensible defaults."""
+    row = {
+        "id": str(uuid.uuid4()),
+        "agent_name": "TestBot",
+        "slug": "testbot",
+        "personality": "You are helpful.",
+        "provider_override": "",
+        "model_override": "",
+        "gmail_enabled": 0,
+        "gmail_send_enabled": 0,
+        "calendar_enabled": 0,
+        "calendar_write_enabled": 0,
+        "drive_enabled": 0,
+        "drive_write_enabled": 0,
+        "google_accounts": {},
+        "onboarding_complete": 0,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestBuildAgentConfig:
+    """build_agent_config maps a DB row dict to an AgentConfig dataclass."""
+
+    def test_maps_all_fields(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(engine_mod, "DATA_DIR", tmp_path)
+        row = _make_agent_row(
+            personality="Be cool.",
+            provider_override="openai",
+            model_override="gpt-4o",
+        )
+
+        cfg = build_agent_config(row)
+
+        assert isinstance(cfg, AgentConfig)
+        assert cfg.agent_id == row["id"]
+        assert cfg.agent_name == "TestBot"
+        assert cfg.slug == "testbot"
+        assert cfg.personality == "Be cool."
+        assert cfg.provider_override == "openai"
+        assert cfg.model_override == "gpt-4o"
+        assert cfg.google_accounts == {}
+        assert isinstance(cfg.training_topics, list)
+        assert len(cfg.training_topics) > 0
+
+    def test_context_dir_is_absolute_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(engine_mod, "DATA_DIR", tmp_path)
+        row = _make_agent_row(slug="my-agent")
+
+        cfg = build_agent_config(row)
+
+        assert cfg.context_dir.endswith("my-agent/context")
+        from pathlib import Path
+        assert Path(cfg.context_dir).is_absolute()
+
+    def test_personality_falls_back_to_onboarding_default(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(engine_mod, "DATA_DIR", tmp_path)
+        row = _make_agent_row(personality="")
+
+        cfg = build_agent_config(row)
+
+        assert "TestBot" in cfg.personality
+        assert cfg.personality != ""
+
+    def test_bool_conversion_from_int(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(engine_mod, "DATA_DIR", tmp_path)
+        row = _make_agent_row(
+            gmail_enabled=1,
+            gmail_send_enabled=0,
+            calendar_enabled=1,
+            calendar_write_enabled=0,
+            drive_enabled=1,
+            drive_write_enabled=0,
+            onboarding_complete=1,
+        )
+
+        cfg = build_agent_config(row)
+
+        assert cfg.gmail_enabled is True
+        assert cfg.gmail_send_enabled is False
+        assert cfg.calendar_enabled is True
+        assert cfg.calendar_write_enabled is False
+        assert cfg.drive_enabled is True
+        assert cfg.drive_write_enabled is False
+        assert cfg.onboarding_complete is True
+
+
+class TestServiceGetters:
+    """get_context_manager and get_chat_service return the right types."""
+
+    def test_get_context_manager(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(engine_mod, "DATA_DIR", tmp_path)
+
+        cm = get_context_manager("some-slug")
+
+        assert isinstance(cm, ContextManager)
+
+    def test_get_chat_service(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(engine_mod, "DATA_DIR", tmp_path)
+        agent_dir = tmp_path / "some-slug"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            svc = get_chat_service("some-slug")
+            assert isinstance(svc, ChatHistoryService)
+        finally:
+            invalidate_cache("some-slug")

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -1,0 +1,350 @@
+"""Tests for the AI service chat flow, tool execution, and tool mode enforcement."""
+
+import json
+import time
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+
+from core.agents.ai_service import chat, run_sync
+from core.providers.base import AIProvider
+from tests.conftest import collect_events
+
+
+# ---------------------------------------------------------------------------
+# Mock provider
+# ---------------------------------------------------------------------------
+
+class MockAIProvider(AIProvider):
+    """Fake provider that yields canned responses from a queue."""
+
+    def __init__(self, responses=None):
+        super().__init__(model="mock-model")
+        self._responses = responses or [self._default_response()]
+        self._call_index = 0
+
+    @staticmethod
+    def _default_response():
+        return [
+            {"type": "text", "text": "Hello from mock"},
+            {
+                "type": "_turn_complete",
+                "tool_calls": [],
+                "stop_reason": "stop",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        ]
+
+    def set_responses(self, responses):
+        self._responses = responses
+        self._call_index = 0
+
+    async def stream_turn(self, messages, tools, system_prompt):
+        idx = min(self._call_index, len(self._responses) - 1)
+        self._call_index += 1
+        for event in self._responses[idx]:
+            yield event
+
+    def add_tool_results(self, messages, tool_calls, results):
+        messages = list(messages)
+        messages.append({"role": "assistant", "content": [
+            {"type": "tool_use", "id": tc["id"], "name": tc["name"], "input": tc.get("args", {})}
+            for tc in tool_calls
+        ]})
+        messages.append({"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": r["tool_use_id"], "content": r["content"]}
+            for r in results
+        ]})
+        return messages
+
+    async def list_models(self):
+        return ["mock-model"]
+
+    async def validate(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "mock"
+
+
+# ---------------------------------------------------------------------------
+# Minimal config / fixtures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeConfig:
+    slug: str = "test-agent"
+    agent_name: str = "Test Agent"
+    context_dir: str = "/tmp/fake-context"
+    gcs_prefix: str = ""
+    provider_override: str = ""
+    model_override: str = ""
+    google_accounts: dict = field(default_factory=dict)
+    personality: str = "You are a helpful test agent."
+
+
+@pytest.fixture
+def fake_config(tmp_path):
+    ctx_dir = tmp_path / "context"
+    ctx_dir.mkdir()
+    return _FakeConfig(context_dir=str(ctx_dir))
+
+
+@pytest.fixture
+def mock_prov():
+    return MockAIProvider()
+
+
+@pytest.fixture
+def mock_registry(tmp_path):
+    reg = MagicMock()
+    reg.execute_tool = AsyncMock(return_value={"result": "ok"})
+    reg.account_info_map = None
+    return reg
+
+
+@pytest.fixture
+def mock_ctx():
+    ctx = MagicMock()
+    ctx.load_all_context.return_value = ""
+    ctx.topic_files_manifest.return_value = ""
+    ctx.daily_notes_manifest.return_value = ""
+    ctx.today_daily_note_text.return_value = ""
+    ctx.relevance_prefetch.return_value = ""
+    ctx.data_dir = "/tmp/fake"
+    ctx.gcs_prefix = ""
+    return ctx
+
+
+def _no_caps(ids):
+    return {
+        "gmail_read_enabled": False, "gmail_send_enabled": False,
+        "calendar_read_enabled": False, "calendar_write_enabled": False,
+        "drive_read_enabled": False, "drive_write_enabled": False,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _patch_externals(monkeypatch):
+    """Silence side-effects that reach into integrations, GCS, or activity log."""
+    # google_capabilities_union is imported inside chat()/run_sync() — patch at source
+    monkeypatch.setattr(
+        "integrations.google.policy.google_capabilities_union", _no_caps,
+    )
+    # load_all_real_tools is a module-level import in ai_service
+    monkeypatch.setattr(
+        "core.agents.ai_service.load_all_real_tools", lambda path: [],
+    )
+    # These are module-level functions in ai_service
+    monkeypatch.setattr(
+        "core.agents.ai_service._log_chat_completion",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "core.agents.ai_service._sync_context_after_tool",
+        lambda *a, **kw: None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSingleTurn:
+    async def test_simple_text_response(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "hi"}], tool_mode="power")
+        )
+        types = [e["type"] for e in events]
+        assert "text" in types
+        assert types[-1] == "done"
+        text_events = [e for e in events if e["type"] == "text"]
+        assert any("Hello from mock" in e["text"] for e in text_events)
+
+    async def test_usage_event_emitted(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "hi"}], tool_mode="power")
+        )
+        usage = [e for e in events if e["type"] == "usage"]
+        assert len(usage) == 1
+        assert usage[0]["input_tokens"] == 10
+        assert usage[0]["output_tokens"] == 5
+
+
+class TestToolExecution:
+    async def test_tool_call_executes_and_continues(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        mock_prov.set_responses([
+            [
+                {"type": "tool_start", "tool": "list_context_files", "tool_use_id": "tu1"},
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "list_context_files", "id": "tu1", "args": {}}
+                ], "stop_reason": "tool_use", "usage": {"input_tokens": 5, "output_tokens": 3}},
+            ],
+            MockAIProvider._default_response(),
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "list files"}], tool_mode="power")
+        )
+        types = [e["type"] for e in events]
+        assert "tool_start" in types
+        assert "tool_end" in types
+        assert types[-1] == "done"
+        mock_registry.execute_tool.assert_called_once()
+
+    async def test_tool_end_has_elapsed_ms(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        mock_prov.set_responses([
+            [
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "list_context_files", "id": "tu1", "args": {}}
+                ], "stop_reason": "tool_use", "usage": {}},
+            ],
+            MockAIProvider._default_response(),
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "go"}], tool_mode="power")
+        )
+        tool_ends = [e for e in events if e["type"] == "tool_end"]
+        assert len(tool_ends) == 1
+        assert "elapsed_ms" in tool_ends[0]
+
+
+class TestToolModeEnforcement:
+    async def test_normal_mode_emits_confirm_for_write_tool(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        mock_prov.set_responses([
+            [
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "send_email", "id": "tu1", "args": {"to": "a@b.com", "subject": "hi", "body": "test"}}
+                ], "stop_reason": "tool_use", "usage": {}},
+            ],
+            MockAIProvider._default_response(),
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "send email"}],
+                 tool_mode="normal",
+                 integration_tool_defs=[{
+                     "name": "send_email", "kind": "gmail",
+                     "writes": True, "input_schema": {"type": "object", "properties": {}},
+                     "description": "Send an email",
+                 }])
+        )
+        types = [e["type"] for e in events]
+        assert "confirm" in types
+        confirm = next(e for e in events if e["type"] == "confirm")
+        assert confirm["tool"] == "send_email"
+        assert confirm["tool_use_id"] == "tu1"
+
+    async def test_power_mode_executes_write_without_confirm(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        mock_prov.set_responses([
+            [
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "send_email", "id": "tu1", "args": {}}
+                ], "stop_reason": "tool_use", "usage": {}},
+            ],
+            MockAIProvider._default_response(),
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "send email"}],
+                 tool_mode="power",
+                 integration_tool_defs=[{
+                     "name": "send_email", "kind": "gmail",
+                     "writes": True, "input_schema": {"type": "object", "properties": {}},
+                     "description": "Send an email",
+                 }])
+        )
+        types = [e["type"] for e in events]
+        assert "confirm" not in types
+        assert "tool_end" in types
+
+    async def test_context_memory_write_bypasses_confirm_in_normal_mode(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        mock_prov.set_responses([
+            [
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "write_context_file", "id": "tu1", "args": {"filename": "test.md", "content": "data"}}
+                ], "stop_reason": "tool_use", "usage": {}},
+            ],
+            MockAIProvider._default_response(),
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "save this"}], tool_mode="normal")
+        )
+        types = [e["type"] for e in events]
+        assert "confirm" not in types
+        assert "tool_end" in types
+
+
+class TestMultiTurn:
+    async def test_max_iterations_emits_error(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        infinite_tool_response = [
+            {"type": "_turn_complete", "tool_calls": [
+                {"name": "list_context_files", "id": "tu1", "args": {}}
+            ], "stop_reason": "tool_use", "usage": {}},
+        ]
+        mock_prov.set_responses([infinite_tool_response])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "loop"}], tool_mode="power")
+        )
+        types = [e["type"] for e in events]
+        assert "error" in types
+
+
+class TestErrorHandling:
+    async def test_provider_error_yields_error_event(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        mock_prov.set_responses([
+            [{"type": "error", "error": "Rate limited"}],
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "hi"}], tool_mode="power")
+        )
+        errors = [e for e in events if e["type"] == "error"]
+        assert len(errors) == 1
+        assert "Rate limited" in errors[0]["error"]
+
+    async def test_tool_error_continues_loop(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        mock_registry.execute_tool = AsyncMock(return_value={"error": "Tool broke"})
+        mock_prov.set_responses([
+            [
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "list_context_files", "id": "tu1", "args": {}}
+                ], "stop_reason": "tool_use", "usage": {}},
+            ],
+            MockAIProvider._default_response(),
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "go"}], tool_mode="power")
+        )
+        types = [e["type"] for e in events]
+        assert types[-1] == "done"
+        assert "tool_end" in types
+
+
+class TestSSEFormat:
+    async def test_all_events_are_valid_sse(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        raw_lines = []
+        async for line in chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                               [{"role": "user", "content": "hi"}], tool_mode="power"):
+            raw_lines.append(line)
+        for line in raw_lines:
+            assert line.startswith("data: "), f"Not SSE format: {line!r}"
+            assert line.endswith("\n\n"), f"Missing trailing newlines: {line!r}"
+            json.loads(line[6:].strip())
+
+
+class TestRunSync:
+    async def test_returns_accumulated_text(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        result = await run_sync(
+            fake_config, mock_prov, mock_registry, mock_ctx,
+            [{"role": "user", "content": "hi"}],
+        )
+        assert "Hello from mock" in result

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,175 @@
+"""Tests for core.auth — password verification, JWT lifecycle, rate limiting."""
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import bcrypt as _bcrypt
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+TEST_PASSWORD = "correct-horse-battery-staple"
+TEST_JWT_SECRET = "test-secret-key-for-jwt-signing"
+
+
+@pytest.fixture()
+def app_env(monkeypatch):
+    """Patch core.config.settings with known test values for auth + JWT."""
+    from core.config import settings
+
+    monkeypatch.setattr(settings.auth, "password", TEST_PASSWORD)
+    monkeypatch.setattr(settings.jwt, "secret_key", TEST_JWT_SECRET)
+    monkeypatch.setattr(settings.jwt, "algorithm", "HS256")
+    monkeypatch.setattr(settings.jwt, "expire_minutes", 480)
+
+    # Clear rate-limit state so tests don't leak into each other
+    from core.auth import _login_attempts
+    _login_attempts.clear()
+
+    yield settings
+
+
+# ---------------------------------------------------------------------------
+# Password verification
+# ---------------------------------------------------------------------------
+
+class TestVerifyPassword:
+    def test_correct_plaintext(self, app_env):
+        from core.auth import verify_password
+
+        assert verify_password(TEST_PASSWORD) is True
+
+    def test_wrong_plaintext(self, app_env):
+        from core.auth import verify_password
+
+        assert verify_password("wrong-password") is False
+
+    def test_bcrypt_hash_match(self, app_env):
+        from core.auth import verify_password
+
+        hashed = _bcrypt.hashpw(TEST_PASSWORD.encode(), _bcrypt.gensalt()).decode()
+        app_env.auth.password = hashed
+        assert verify_password(TEST_PASSWORD) is True
+
+    def test_bcrypt_hash_mismatch(self, app_env):
+        from core.auth import verify_password
+
+        hashed = _bcrypt.hashpw(b"some-other-password", _bcrypt.gensalt()).decode()
+        app_env.auth.password = hashed
+        assert verify_password(TEST_PASSWORD) is False
+
+
+# ---------------------------------------------------------------------------
+# JWT lifecycle
+# ---------------------------------------------------------------------------
+
+class TestJWTLifecycle:
+    def test_create_decode_roundtrip(self, app_env):
+        from core.auth import create_access_token, decode_access_token
+
+        claims = {"sub": "user", "role": "admin"}
+        token = create_access_token(claims)
+        payload = decode_access_token(token)
+
+        assert payload["sub"] == "user"
+        assert payload["role"] == "admin"
+        assert "exp" in payload
+
+    def test_custom_expiry_honored(self, app_env):
+        from core.auth import create_access_token, decode_access_token
+
+        token_short = create_access_token({"sub": "user"}, expire_minutes=1)
+        token_long = create_access_token({"sub": "user"}, expire_minutes=9999)
+
+        short_exp = decode_access_token(token_short)["exp"]
+        long_exp = decode_access_token(token_long)["exp"]
+        assert long_exp > short_exp
+
+    def test_expired_token_raises(self, app_env):
+        from jose import JWTError
+        from core.auth import create_access_token, decode_access_token
+
+        token = create_access_token({"sub": "user"}, expire_minutes=-1)
+        with pytest.raises(JWTError):
+            decode_access_token(token)
+
+
+# ---------------------------------------------------------------------------
+# get_current_user dependency
+# ---------------------------------------------------------------------------
+
+def _make_request(headers: dict | None = None) -> MagicMock:
+    """Build a mock FastAPI Request with the given headers."""
+    req = MagicMock()
+    req.headers = headers or {}
+    return req
+
+
+class TestGetCurrentUser:
+    def test_valid_bearer_token(self, app_env):
+        from core.auth import create_access_token, get_current_user
+
+        token = create_access_token({"sub": "user", "role": "admin"})
+        request = _make_request({"Authorization": f"Bearer {token}"})
+        payload = asyncio.run(get_current_user(request))
+
+        assert payload["sub"] == "user"
+        assert payload["role"] == "admin"
+
+    def test_missing_header_raises_401(self, app_env):
+        from fastapi import HTTPException
+        from core.auth import get_current_user
+
+        request = _make_request({})
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(get_current_user(request))
+        assert exc_info.value.status_code == 401
+
+    def test_2fa_pending_raises_401(self, app_env):
+        from fastapi import HTTPException
+        from core.auth import create_access_token, get_current_user
+
+        token = create_access_token({"sub": "user", "purpose": "2fa_pending"})
+        request = _make_request({"Authorization": f"Bearer {token}"})
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(get_current_user(request))
+        assert exc_info.value.status_code == 401
+        assert "2FA" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+class TestRateLimiting:
+    def test_allows_under_limit(self, app_env):
+        from core.auth import _check_login_rate
+
+        for _ in range(9):
+            assert _check_login_rate("10.0.0.1") is True
+
+    def test_blocks_at_limit(self, app_env):
+        from core.auth import _check_login_rate
+
+        for _ in range(10):
+            _check_login_rate("10.0.0.2")
+        assert _check_login_rate("10.0.0.2") is False
+
+    def test_window_expires(self, app_env, monkeypatch):
+        from core.auth import _check_login_rate, _login_attempts
+
+        fake_time = 1000.0
+        monkeypatch.setattr(time, "time", lambda: fake_time)
+
+        for _ in range(10):
+            _check_login_rate("10.0.0.3")
+        assert _check_login_rate("10.0.0.3") is False
+
+        # Advance past the 5-minute window
+        fake_time = 1301.0
+        monkeypatch.setattr(time, "time", lambda: fake_time)
+        assert _check_login_rate("10.0.0.3") is True

--- a/backend/tests/test_credentials.py
+++ b/backend/tests/test_credentials.py
@@ -1,0 +1,165 @@
+"""Tests for core.providers.credentials — CredentialStore gap behaviors.
+
+Covers behaviors NOT tested in test_encryption.py:
+- OAuth refresh token preservation on re-auth
+- Token expiry with 60s grace period
+- to_dict() sanitization (key_preview, no raw keys)
+- Active provider switching and removal
+- Ollama credential storage
+"""
+
+import time
+
+import pytest
+
+from core.providers.credentials import CredentialStore
+
+
+@pytest.fixture
+def store_env(encryption_env, tmp_path, monkeypatch):
+    """Isolated CredentialStore: temp data dir, no disk leakage."""
+    from core.providers import credentials
+
+    monkeypatch.setattr(credentials, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(credentials, "PROFILES_PATH", tmp_path / "auth-profiles.json")
+    return CredentialStore()
+
+
+# ---------------------------------------------------------------------------
+# OAuth refresh token preservation
+# ---------------------------------------------------------------------------
+
+class TestOAuthRefreshPreservation:
+    def test_refresh_token_preserved_when_omitted(self, store_env):
+        store = store_env
+        store.set_oauth_tokens("google", "access-1", "refresh-original", 3600)
+
+        # Re-auth omits refresh_token (Google behavior for existing grants)
+        store.set_oauth_tokens("google", "access-2", "", 3600)
+
+        _, profile = store.get_active_profile("google")
+        assert profile["refresh"] == "refresh-original"
+        assert profile["access"] == "access-2"
+
+    def test_refresh_token_updated_when_provided(self, store_env):
+        store = store_env
+        store.set_oauth_tokens("google", "access-1", "refresh-old", 3600)
+        store.set_oauth_tokens("google", "access-2", "refresh-new", 3600)
+
+        _, profile = store.get_active_profile("google")
+        assert profile["refresh"] == "refresh-new"
+
+
+# ---------------------------------------------------------------------------
+# Token expiry with 60s grace period
+# ---------------------------------------------------------------------------
+
+class TestTokenExpiry:
+    def test_expired_token(self, store_env, monkeypatch):
+        store = store_env
+        # Fix time at 10000
+        monkeypatch.setattr(time, "time", lambda: 10000)
+        store.set_oauth_tokens("google", "access", "refresh", 3600)
+        # expires = 10000 + 3600 = 13600
+
+        # Jump past expiry
+        monkeypatch.setattr(time, "time", lambda: 14000)
+        assert store.is_token_expired("google") is True
+
+    def test_within_grace_period(self, store_env, monkeypatch):
+        store = store_env
+        monkeypatch.setattr(time, "time", lambda: 10000)
+        store.set_oauth_tokens("google", "access", "refresh", 3600)
+        # expires = 13600, grace starts at 13540
+
+        # At 13550: 50s before expiry, inside the 60s grace window
+        monkeypatch.setattr(time, "time", lambda: 13550)
+        assert store.is_token_expired("google") is True
+
+    def test_not_expired_outside_grace(self, store_env, monkeypatch):
+        store = store_env
+        monkeypatch.setattr(time, "time", lambda: 10000)
+        store.set_oauth_tokens("google", "access", "refresh", 3600)
+
+        # At 13000: 600s before expiry, well outside grace
+        monkeypatch.setattr(time, "time", lambda: 13000)
+        assert store.is_token_expired("google") is False
+
+
+# ---------------------------------------------------------------------------
+# to_dict() sanitization
+# ---------------------------------------------------------------------------
+
+class TestToDict:
+    def test_api_key_shows_preview_not_raw(self, store_env):
+        store = store_env
+        store.set_api_key("anthropic", "sk-ant-api03-secret-key-ABCD")
+
+        result = store.to_dict()
+        anthropic = result["profiles"]["anthropic"]
+        assert anthropic["key_preview"] == "...ABCD"
+        assert anthropic["configured"] is True
+        # No raw key anywhere in the dict
+        assert "sk-ant" not in str(result)
+
+    def test_oauth_profile_has_no_tokens(self, store_env, monkeypatch):
+        store = store_env
+        monkeypatch.setattr(time, "time", lambda: 10000)
+        store.set_oauth_tokens("google", "ya29.secret-access", "1//refresh", 3600)
+
+        result = store.to_dict()
+        google = result["profiles"]["google"]
+        assert google["type"] == "oauth"
+        assert google["configured"] is True
+        assert "access" not in google
+        assert "refresh" not in google
+
+
+# ---------------------------------------------------------------------------
+# Active provider switching and removal
+# ---------------------------------------------------------------------------
+
+class TestProviderManagement:
+    def test_set_active_provider(self, store_env):
+        store = store_env
+        store.set_api_key("anthropic", "sk-ant-key")
+        store.set_api_key("openai", "sk-openai-key")
+
+        store.set_active_provider("anthropic")
+        assert store.data["active_provider"] == "anthropic"
+
+    def test_remove_active_provider_clears_active(self, store_env):
+        store = store_env
+        store.set_api_key("anthropic", "sk-ant-key")
+        assert store.data["active_provider"] == "anthropic"
+
+        store.remove_provider("anthropic")
+        assert store.data["active_provider"] == ""
+        assert store.data["active_model"] == ""
+        assert "anthropic:default" not in store.data["profiles"]
+
+    def test_remove_inactive_provider_keeps_active(self, store_env):
+        store = store_env
+        store.set_api_key("anthropic", "sk-ant-key")
+        store.set_api_key("openai", "sk-openai-key")
+        # openai is now active (last set_api_key call)
+
+        store.remove_provider("anthropic")
+        assert store.data["active_provider"] == "openai"
+        assert "anthropic:default" not in store.data["profiles"]
+
+
+# ---------------------------------------------------------------------------
+# Ollama storage
+# ---------------------------------------------------------------------------
+
+class TestOllama:
+    def test_set_ollama_stores_correctly(self, store_env):
+        store = store_env
+        store.set_ollama("http://192.168.1.50:11434", model="llama3")
+
+        _, profile = store.get_active_profile("ollama")
+        assert profile["type"] == "ollama_local"
+        assert profile["base_url"] == "http://192.168.1.50:11434"
+        assert store.data["active_provider"] == "ollama"
+        assert store.data["active_model"] == "llama3"

--- a/backend/tests/test_integration_registry.py
+++ b/backend/tests/test_integration_registry.py
@@ -1,0 +1,95 @@
+"""Tests for integrations.registry — enable/disable and status logic."""
+
+import json
+
+import pytest
+
+
+@pytest.fixture()
+def registry_dir(tmp_path, monkeypatch, encryption_env):
+    """Point registry DATA_DIR at a temp directory and stub app_credentials."""
+    import integrations.registry as reg
+
+    integrations_dir = tmp_path / "integrations"
+    integrations_dir.mkdir()
+    monkeypatch.setattr(reg, "DATA_DIR", integrations_dir)
+    monkeypatch.setattr(
+        "integrations.app_credentials.has_app_credentials", lambda _name: False
+    )
+    return integrations_dir
+
+
+class TestIsEnabled:
+    def test_returns_false_when_no_json_file(self, registry_dir):
+        from integrations.registry import is_enabled
+
+        assert is_enabled("odoo") is False
+
+    def test_returns_true_when_enabled(self, registry_dir):
+        from integrations.registry import save_credentials, is_enabled
+
+        save_credentials("odoo", {"enabled": True})
+        assert is_enabled("odoo") is True
+
+    def test_returns_false_when_disabled(self, registry_dir):
+        from integrations.registry import save_credentials, is_enabled
+
+        save_credentials("odoo", {"enabled": False})
+        assert is_enabled("odoo") is False
+
+
+class TestEnableDisable:
+    def test_enable_then_is_enabled_roundtrip(self, registry_dir):
+        from integrations.registry import enable, is_enabled
+
+        assert is_enabled("bamboohr") is False
+        enable("bamboohr")
+        assert is_enabled("bamboohr") is True
+
+    def test_disable_preserves_credential_data(self, registry_dir):
+        from integrations.registry import (
+            disable,
+            enable,
+            get_credentials,
+            save_credentials,
+        )
+
+        save_credentials("odoo", {
+            "url": "https://myodoo.com",
+            "api_key": "secret-key",
+            "enabled": True,
+        })
+        disable("odoo")
+
+        creds = get_credentials("odoo")
+        assert creds["enabled"] is False
+        assert creds["url"] == "https://myodoo.com"
+        assert creds["api_key"] == "secret-key"
+
+
+class TestToolMode:
+    def test_default_is_normal(self, registry_dir):
+        from integrations.registry import get_tool_mode, save_credentials
+
+        save_credentials("odoo", {"enabled": True})
+        assert get_tool_mode("odoo") == "normal"
+
+    def test_set_then_get_roundtrip(self, registry_dir):
+        from integrations.registry import (
+            get_tool_mode,
+            save_credentials,
+            set_tool_mode,
+        )
+
+        save_credentials("odoo", {"enabled": True})
+        set_tool_mode("odoo", "power")
+        assert get_tool_mode("odoo") == "power"
+
+
+class TestListIntegrations:
+    def test_returns_all_available(self, registry_dir):
+        from integrations.registry import AVAILABLE_INTEGRATIONS, list_integrations
+
+        result = list_integrations()
+        ids = {entry["id"] for entry in result}
+        assert ids == set(AVAILABLE_INTEGRATIONS.keys())

--- a/backend/tests/test_tool_definitions.py
+++ b/backend/tests/test_tool_definitions.py
@@ -1,0 +1,151 @@
+"""Tests for tool schema generation and metadata maps."""
+
+from core.agents.tool_definitions import (
+    get_tool_definitions,
+    build_writes_map,
+    build_context_memory_map,
+)
+
+
+def _tool_names(defs: list[dict]) -> set[str]:
+    return {t["name"] for t in defs}
+
+
+class TestDefaultToolSet:
+    def test_includes_core_tools(self):
+        names = _tool_names(get_tool_definitions())
+        assert "list_context_files" in names
+        assert "append_daily_note" in names
+        assert "list_shared_context" in names
+        assert "web_search" in names
+        assert "create_reminder" in names
+
+    def test_excludes_google_when_disabled(self):
+        names = _tool_names(get_tool_definitions())
+        assert "search_emails" not in names
+        assert "send_email" not in names
+        assert "list_calendar_events" not in names
+        assert "search_drive_files" not in names
+
+
+class TestGoogleFlagGating:
+    def test_gmail_read_adds_read_tools(self):
+        names = _tool_names(get_tool_definitions(gmail_read_enabled=True))
+        assert "search_emails" in names
+        assert "send_email" not in names
+
+    def test_gmail_send_adds_write_tools(self):
+        names = _tool_names(get_tool_definitions(gmail_send_enabled=True))
+        assert "send_email" in names
+
+    def test_calendar_read_write_gating(self):
+        read_names = _tool_names(get_tool_definitions(calendar_read_enabled=True))
+        assert "list_calendar_events" in read_names
+        assert "create_calendar_event" not in read_names
+
+        write_names = _tool_names(get_tool_definitions(calendar_write_enabled=True))
+        assert "create_calendar_event" in write_names
+
+    def test_drive_read_write_gating(self):
+        read_names = _tool_names(get_tool_definitions(drive_read_enabled=True))
+        assert "search_drive_files" in read_names
+        assert "create_drive_folder" not in read_names
+
+        write_names = _tool_names(get_tool_definitions(drive_write_enabled=True))
+        assert "create_drive_folder" in write_names
+
+    def test_legacy_gmail_enabled_falls_through_to_read(self):
+        names = _tool_names(get_tool_definitions(gmail_enabled=True))
+        assert "search_emails" in names
+        assert "send_email" not in names
+
+
+class TestFeatureFlags:
+    def test_disabling_web_removes_tools(self):
+        names = _tool_names(get_tool_definitions(web_enabled=False))
+        assert "web_search" not in names
+
+    def test_disabling_memory_removes_tools(self):
+        names = _tool_names(get_tool_definitions(memory_enabled=False))
+        assert "append_daily_note" not in names
+
+    def test_disabling_shared_context_removes_tools(self):
+        names = _tool_names(get_tool_definitions(shared_context_enabled=False))
+        assert "list_shared_context" not in names
+
+
+class TestImportMode:
+    def test_returns_only_readonly_context_and_import_tools(self):
+        defs = get_tool_definitions(import_mode=True)
+        names = _tool_names(defs)
+        assert "list_context_files" in names
+        assert "read_context_file" in names
+        assert "write_context_file" not in names
+        assert "web_search" not in names
+        assert "send_email" not in names
+
+
+class TestMultiAccountInjection:
+    def test_multi_gmail_injects_account_param(self):
+        defs = get_tool_definitions(gmail_read_enabled=True, multi_gmail=True)
+        gmail_tools = [t for t in defs if t.get("kind") == "gmail"]
+        for tool in gmail_tools:
+            props = tool["input_schema"]["properties"]
+            assert "account" in props, f"{tool['name']} missing account param"
+
+    def test_single_account_no_injection(self):
+        defs = get_tool_definitions(gmail_read_enabled=True, multi_gmail=False)
+        gmail_tools = [t for t in defs if t.get("kind") == "gmail"]
+        for tool in gmail_tools:
+            props = tool["input_schema"]["properties"]
+            assert "account" not in props
+
+
+class TestToolMerging:
+    def test_integration_tools_appended(self):
+        custom = [{"name": "custom_tool", "kind": "custom", "input_schema": {"type": "object", "properties": {}}}]
+        names = _tool_names(get_tool_definitions(integration_tools=custom))
+        assert "custom_tool" in names
+
+    def test_dynamic_real_tools_appended(self):
+        dyn = [{"name": "my_script", "kind": "real", "input_schema": {"type": "object", "properties": {}}}]
+        names = _tool_names(get_tool_definitions(dynamic_real_tools=dyn))
+        assert "my_script" in names
+
+
+class TestMetadataMaps:
+    def test_writes_map_classifies_correctly(self):
+        defs = get_tool_definitions(gmail_read_enabled=True, gmail_send_enabled=True)
+        wmap = build_writes_map(defs)
+        assert wmap["send_email"] is True
+        assert wmap["search_emails"] is False
+        assert wmap["list_context_files"] is False
+
+    def test_context_memory_map_classifies_correctly(self):
+        defs = get_tool_definitions()
+        cm_map = build_context_memory_map(defs)
+        assert cm_map["write_context_file"] is True
+        assert cm_map["append_daily_note"] is True
+        assert cm_map["web_search"] is False
+
+
+class TestSchemaIntegrity:
+    def test_all_tools_have_required_fields(self):
+        defs = get_tool_definitions(
+            gmail_read_enabled=True, gmail_send_enabled=True,
+            calendar_read_enabled=True, calendar_write_enabled=True,
+            drive_read_enabled=True, drive_write_enabled=True,
+        )
+        for tool in defs:
+            assert "name" in tool, f"Tool missing name: {tool}"
+            assert "input_schema" in tool, f"{tool['name']} missing input_schema"
+            assert "kind" in tool, f"{tool['name']} missing kind"
+
+    def test_no_duplicate_names(self):
+        defs = get_tool_definitions(
+            gmail_read_enabled=True, gmail_send_enabled=True,
+            calendar_read_enabled=True, calendar_write_enabled=True,
+            drive_read_enabled=True, drive_write_enabled=True,
+        )
+        names = [t["name"] for t in defs]
+        assert len(names) == len(set(names)), f"Duplicate names: {[n for n in names if names.count(n) > 1]}"

--- a/backend/tests/test_tool_loader.py
+++ b/backend/tests/test_tool_loader.py
@@ -1,0 +1,72 @@
+"""Tests for integration tool loading and agent handler construction."""
+
+from unittest.mock import patch, MagicMock
+from types import ModuleType
+
+from agents.tool_loader import format_current_time, load_integration_tools, build_agent_handlers
+
+
+class TestFormatCurrentTime:
+    def test_returns_date_and_time_strings(self):
+        date_str, time_str = format_current_time()
+        assert isinstance(date_str, str)
+        assert isinstance(time_str, str)
+        assert len(date_str) > 0
+        assert len(time_str) > 0
+
+    def test_invalid_timezone_falls_back(self):
+        date_str, time_str = format_current_time("Not/A/Timezone")
+        assert isinstance(date_str, str)
+        assert len(date_str) > 0
+
+
+class TestLoadIntegrationTools:
+    def test_no_integrations_enabled(self):
+        with patch("integrations.registry.is_enabled", return_value=False):
+            defs, execs = load_integration_tools()
+            assert defs == []
+            assert execs == {}
+
+    def test_enabled_integration_loads_tools(self):
+        fake_mod = ModuleType("fake_integration")
+        # todoist's defs_attr is "TODOIST_TOOL_DEFS" per INTEGRATION_MODULES
+        fake_mod.TODOIST_TOOL_DEFS = [{"name": "fake_tool", "kind": "fake", "input_schema": {}}]
+        fake_mod.TOOL_EXECUTORS = {"fake_tool": lambda: None}
+
+        def is_enabled(name):
+            return name == "todoist"
+
+        with patch("integrations.registry.is_enabled", side_effect=is_enabled), \
+             patch("importlib.import_module", return_value=fake_mod):
+            defs, execs = load_integration_tools()
+
+        assert len(defs) == 1
+        assert defs[0]["name"] == "fake_tool"
+        assert defs[0]["integration"] == "todoist"
+        assert "fake_tool" in execs
+
+    def test_failed_import_logged_not_crashed(self):
+        def is_enabled(name):
+            return name == "odoo"
+
+        with patch("integrations.registry.is_enabled", side_effect=is_enabled), \
+             patch("importlib.import_module", side_effect=ImportError("no module")):
+            defs, execs = load_integration_tools()
+
+        assert defs == []
+        assert execs == {}
+
+
+class TestBuildAgentHandlers:
+    def test_returns_expected_handler_keys(self):
+        reminders, scheduled = build_agent_handlers("test-agent")
+        assert set(reminders.keys()) == {"create_reminder", "list_reminders", "cancel_reminder"}
+        assert set(scheduled.keys()) == {
+            "create_scheduled_action", "list_scheduled_actions",
+            "update_scheduled_action", "delete_scheduled_action",
+        }
+
+    def test_handlers_are_callable(self):
+        reminders, scheduled = build_agent_handlers("test-agent")
+        for name, fn in {**reminders, **scheduled}.items():
+            assert callable(fn), f"{name} is not callable"

--- a/backend/tests/test_tool_registry.py
+++ b/backend/tests/test_tool_registry.py
@@ -1,0 +1,165 @@
+"""Tests for ToolRegistry — tool dispatch and context file operations."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from core.agents.tool_registry import ToolRegistry
+
+
+def _make_registry(context_dir: str) -> ToolRegistry:
+    """Create a minimal ToolRegistry pointing at a real context directory."""
+    return ToolRegistry(context_dir=context_dir, gcs_prefix="")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Context tools: real filesystem ──────────────────────────────────────────
+
+
+class TestListContextFiles:
+    def test_empty_dir_returns_empty_list(self, tmp_path):
+        ctx_dir = str(tmp_path / "context")
+        Path(ctx_dir).mkdir()
+        reg = _make_registry(ctx_dir)
+        result = _run(reg.execute_tool("list_context_files", {}, "context"))
+        assert result == {"files": []}
+
+    def test_lists_written_files(self, tmp_path):
+        ctx_dir = str(tmp_path / "context")
+        Path(ctx_dir).mkdir()
+        reg = _make_registry(ctx_dir)
+        _run(reg.execute_tool(
+            "write_context_file",
+            {"filename": "notes.md", "content": "hello"},
+            "context",
+        ))
+        result = _run(reg.execute_tool("list_context_files", {}, "context"))
+        names = [f["name"] for f in result["files"]]
+        assert "notes.md" in names
+
+
+class TestWriteReadRoundTrip:
+    def test_write_then_read_returns_content(self, tmp_path):
+        ctx_dir = str(tmp_path / "context")
+        reg = _make_registry(ctx_dir)
+        write_result = _run(reg.execute_tool(
+            "write_context_file",
+            {"filename": "profile.md", "content": "# My Profile\nName: Test"},
+            "context",
+        ))
+        assert write_result["ok"] is True
+
+        read_result = _run(reg.execute_tool(
+            "read_context_file",
+            {"filename": "profile.md"},
+            "context",
+        ))
+        assert read_result["content"] == "# My Profile\nName: Test"
+        assert read_result["filename"] == "profile.md"
+
+
+class TestAppendToContextFile:
+    def test_append_adds_content(self, tmp_path):
+        ctx_dir = str(tmp_path / "context")
+        reg = _make_registry(ctx_dir)
+        _run(reg.execute_tool(
+            "write_context_file",
+            {"filename": "log.md", "content": "Line 1"},
+            "context",
+        ))
+        append_result = _run(reg.execute_tool(
+            "append_to_context_file",
+            {"filename": "log.md", "content": "Line 2"},
+            "context",
+        ))
+        assert append_result["ok"] is True
+
+        read_result = _run(reg.execute_tool(
+            "read_context_file",
+            {"filename": "log.md"},
+            "context",
+        ))
+        assert "Line 1" in read_result["content"]
+        assert "Line 2" in read_result["content"]
+
+
+class TestDeleteContextFile:
+    def test_delete_removes_file(self, tmp_path):
+        ctx_dir = str(tmp_path / "context")
+        reg = _make_registry(ctx_dir)
+        _run(reg.execute_tool(
+            "write_context_file",
+            {"filename": "temp.md", "content": "temporary"},
+            "context",
+        ))
+        del_result = _run(reg.execute_tool(
+            "delete_context_file",
+            {"filename": "temp.md"},
+            "context",
+        ))
+        assert del_result["deleted"] is True
+
+        read_result = _run(reg.execute_tool(
+            "read_context_file",
+            {"filename": "temp.md"},
+            "context",
+        ))
+        assert "error" in read_result
+
+
+class TestPathTraversal:
+    def test_write_traversal_blocked(self, tmp_path):
+        ctx_dir = str(tmp_path / "context")
+        Path(ctx_dir).mkdir()
+        reg = _make_registry(ctx_dir)
+        result = _run(reg.execute_tool(
+            "write_context_file",
+            {"filename": "../escape.md", "content": "pwned"},
+            "context",
+        ))
+        assert "error" in result
+
+    def test_read_traversal_blocked(self, tmp_path):
+        ctx_dir = str(tmp_path / "context")
+        Path(ctx_dir).mkdir()
+        reg = _make_registry(ctx_dir)
+        result = _run(reg.execute_tool(
+            "read_context_file",
+            {"filename": "../../etc/passwd.md"},
+            "context",
+        ))
+        assert "error" in result
+
+
+# ── Routing errors ──────────────────────────────────────────────────────────
+
+
+class TestRouting:
+    def test_unknown_kind_returns_error(self, tmp_path):
+        reg = _make_registry(str(tmp_path))
+        result = _run(reg.execute_tool("anything", {}, "nonexistent_kind"))
+        assert "error" in result
+        assert "Unknown tool kind" in result["error"]
+
+    def test_unknown_tool_within_kind_returns_error(self, tmp_path):
+        reg = _make_registry(str(tmp_path))
+        result = _run(reg.execute_tool("bogus_tool", {}, "context"))
+        assert "error" in result
+        assert "Unknown context tool" in result["error"]
+
+
+# ── Error handling ──────────────────────────────────────────────────────────
+
+
+class TestErrorHandling:
+    def test_exception_returns_error_dict(self, tmp_path):
+        """An exception inside a handler is caught and returned as an error dict."""
+        reg = _make_registry(str(tmp_path))
+        # read_context_file with missing required arg triggers a KeyError
+        result = _run(reg.execute_tool("read_context_file", {}, "context"))
+        assert "error" in result
+        assert "Tool error" in result["error"]


### PR DESCRIPTION
## Summary

- 102 new tests across 9 test files covering core engine (ai_service, tool_registry, tool_definitions), agent management (db, engine, tool_loader), auth (password/JWT/rate limiting), credentials, and integration registry
- Test infrastructure: `pytest.ini`, `conftest.py` with shared fixtures, `requirements-dev.txt` (compartmentalized — users deploying via Railway never install pytest)
- CI: `pr-checks.yml` now runs `pytest` on every PR before the existing import/smoke checks

## Test plan

- [x] All 221 tests pass locally (102 new + 119 existing) in 2.7s
- [x] Existing test files unbroken
- [x] No test touches real `data/` directory or makes network calls
- [x] `requirements.txt` unchanged — test deps only in `requirements-dev.txt`
- [ ] CI "Run tests" step passes on this PR