### PR TITLE
Add Opus/Sonnet model switcher to chat composer

### DIFF
--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { api } from '../core/api/client';
+import type { ProviderStatus } from '../core/types';
 import { useAgentChat, type ToolMode } from './hooks/useAgentChat';
 import { useConversations } from './hooks/useConversations';
 import { useScrollDirection } from './hooks/useScrollDirection';
@@ -69,6 +70,8 @@ export function AgentPage() {
   const [showSidebar, setShowSidebar] = useState(false);
   const [openaiAvailable, setOpenaiAvailable] = useState(false);
   const [alwaysPowerMode, setAlwaysPowerMode] = useState(false);
+  const [activeProvider, setActiveProvider] = useState('');
+  const [activeModel, setActiveModel] = useState('');
   const isMobile = useIsMobile();
   const prevOnboardingComplete = useRef<boolean | null>(null);
 
@@ -112,6 +115,27 @@ export function AgentPage() {
       .then(d => setOpenaiAvailable(d.generate_available))
       .catch(() => {});
   }, [agentId]);
+
+  useEffect(() => {
+    api<ProviderStatus>('/api/providers')
+      .then(p => { setActiveProvider(p.active_provider); setActiveModel(p.active_model); })
+      .catch(() => {});
+  }, []);
+
+  const handleSwitchModel = useCallback(async (model: string) => {
+    if (!activeProvider) return;
+    const prev = activeModel;
+    setActiveModel(model);
+    try {
+      await api('/api/providers/active', {
+        method: 'PUT',
+        body: JSON.stringify({ provider: activeProvider, model }),
+      });
+    } catch (e) {
+      setActiveModel(prev);
+      alert(`Failed to switch model: ${e instanceof Error ? e.message : 'unknown error'}`);
+    }
+  }, [activeProvider, activeModel]);
 
   useEffect(() => {
     api<{ always_power_mode: boolean }>('/api/setup/admin-settings')
@@ -587,6 +611,9 @@ export function AgentPage() {
               toolMode={chat.toolMode}
               onToolModeChange={handleToolModeChange}
               alwaysPowerMode={alwaysPowerMode}
+              activeProvider={activeProvider}
+              activeModel={activeModel}
+              onSwitchModel={handleSwitchModel}
               agentName={agent.agent_name}
               agentSlug={agent.slug}
               conversationSource={convs.conversations.find(c => c.id === convs.activeId)?.source}

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -36,6 +36,9 @@ interface Props {
   importMode?: boolean;
   onCancelImport?: () => void;
   greetingPending?: boolean;
+  activeProvider?: string;
+  activeModel?: string;
+  onSwitchModel?: (model: string) => void;
 }
 
 const TOOL_MODES: { key: ToolMode; label: string }[] = [
@@ -44,11 +47,16 @@ const TOOL_MODES: { key: ToolMode; label: string }[] = [
   { key: 'power', label: 'Power' },
 ];
 
+const ANTHROPIC_MODEL_TABS: { id: string; label: string }[] = [
+  { id: 'claude-opus-4-6', label: 'Opus' },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet' },
+];
+
 export function AgentChatPanel({
   messages, isStreaming, onSend, onStop, onApprove, onDeny,
   onApprovePlan, onIteratePlan, scrollRef: externalScrollRef,
   contextUsage, toolMode, onToolModeChange, alwaysPowerMode, agentName, agentSlug, conversationSource, importMode, onCancelImport,
-  greetingPending,
+  greetingPending, activeProvider, activeModel, onSwitchModel,
 }: Props) {
   const [input, setInput] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -263,6 +271,38 @@ export function AgentChatPanel({
                       {m.label}
                     </div>
                   ))}
+                </div>
+              )}
+
+              {/* Anthropic model switcher (Opus / Sonnet) */}
+              {activeProvider === 'anthropic' && onSwitchModel && (
+                <div
+                  title="Switch Anthropic model"
+                  style={{
+                    display: 'flex', border: '1px solid rgba(230,235,242,0.07)',
+                    borderRadius: 3, overflow: 'hidden',
+                    opacity: isStreaming ? 0.5 : 1,
+                  }}
+                >
+                  {ANTHROPIC_MODEL_TABS.map(m => {
+                    const isActive = activeModel === m.id;
+                    return (
+                      <div
+                        key={m.id}
+                        onClick={() => !isStreaming && !isActive && onSwitchModel(m.id)}
+                        style={{
+                          padding: '3px 10px',
+                          fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                          fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase',
+                          color: isActive ? '#0E1013' : 'rgba(237,240,244,0.62)',
+                          background: isActive ? 'var(--color-ch-accent, #C8D1D9)' : 'transparent',
+                          cursor: isStreaming || isActive ? 'default' : 'pointer',
+                        }}
+                      >
+                        {m.label}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>


### PR DESCRIPTION
When the active provider is Anthropic, show two segmented buttons (Opus, Sonnet) next to the tool-mode selector so users can switch models inline without leaving the chat — useful for trading cost against capability mid-conversation. Reuses the existing PUT /api/providers/active endpoint; selection is optimistic with rollback on failure and disabled while a turn is streaming. The switcher is hidden for non-Anthropic providers.