### PR TITLE
Add tag filter to CRM contacts list

### DIFF
--- a/backend/integrations/crm_lite/client.py
+++ b/backend/integrations/crm_lite/client.py
@@ -13,6 +13,17 @@ DEAL_STAGES = ["lead", "qualified", "proposal", "negotiation", "won", "lost"]
 CONTACT_STATUSES = ["active", "inactive", "archived"]
 TASK_PRIORITIES = ["low", "medium", "high"]
 
+# SQL fragment for whitespace-tolerant boundary matching against the comma-separated tags column.
+# Strips whitespace adjacent to commas so the filter survives free-form input like "PT, ET, MT".
+_TAGS_NORMALIZED_SQL = "(',' || REPLACE(REPLACE(tags, ', ', ','), ' ,', ',') || ',')"
+
+
+def _normalize_tags(raw: str) -> str:
+    """Clean a comma-separated tag string: strip whitespace around each label, drop empties."""
+    if not raw:
+        return ""
+    return ",".join(label for label in (part.strip() for part in raw.split(",")) if label)
+
 
 # ── Contacts ──────────────────────────────────────────────────────────────────
 
@@ -26,7 +37,7 @@ def create_contact(
         cursor = db.execute(
             """INSERT INTO contacts (name, email, phone, company, title, source, status, tags, notes)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (name, email, phone, company, title, source, status, tags, notes),
+            (name, email, phone, company, title, source, status, _normalize_tags(tags), notes),
         )
         db.commit()
     return get_contact(cursor.lastrowid)
@@ -45,8 +56,9 @@ def search_contacts(query: str, status: str | None = None, tags: str | None = No
         conditions.append("status = ?")
         params.append(status)
     if tags:
-        conditions.append("tags LIKE ?")
-        params.append(f"%{tags}%")
+        # Boundary-aware match so tag "ET" doesn't accidentally match "WEST" or "BUDGET"
+        conditions.append(f"{_TAGS_NORMALIZED_SQL} LIKE ?")
+        params.append(f"%,{tags.strip()},%")
     params.append(limit)
     where = " AND ".join(conditions)
     rows = _get_db().execute(
@@ -56,7 +68,10 @@ def search_contacts(query: str, status: str | None = None, tags: str | None = No
     return [dict(r) for r in rows]
 
 
-def list_contacts(offset: int = 0, limit: int = 50, status: str | None = None, sort: str = "updated_at") -> dict:
+def list_contacts(
+    offset: int = 0, limit: int = 50, status: str | None = None,
+    tags: str | None = None, sort: str = "updated_at",
+) -> dict:
     allowed_sorts = {"updated_at", "created_at", "name", "company"}
     sort_col = sort if sort in allowed_sorts else "updated_at"
 
@@ -65,6 +80,9 @@ def list_contacts(offset: int = 0, limit: int = 50, status: str | None = None, s
     if status:
         conditions.append("status = ?")
         params.append(status)
+    if tags:
+        conditions.append(f"{_TAGS_NORMALIZED_SQL} LIKE ?")
+        params.append(f"%,{tags.strip()},%")
 
     where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
@@ -78,9 +96,25 @@ def list_contacts(offset: int = 0, limit: int = 50, status: str | None = None, s
     return {"contacts": [dict(r) for r in rows], "total": total, "limit": limit, "offset": offset}
 
 
+def list_distinct_tags() -> list[str]:
+    """Return sorted list of unique tag labels currently in use across all contacts."""
+    rows = _get_db().execute(
+        "SELECT tags FROM contacts WHERE tags != ''"
+    ).fetchall()
+    seen: set[str] = set()
+    for row in rows:
+        for raw in row["tags"].split(","):
+            label = raw.strip()
+            if label:
+                seen.add(label)
+    return sorted(seen, key=str.lower)
+
+
 def update_contact(contact_id: int, **fields) -> dict | None:
     allowed = {"name", "email", "phone", "company", "title", "source", "status", "tags", "notes"}
     filtered = {k: v for k, v in fields.items() if k in allowed}
+    if "tags" in filtered:
+        filtered["tags"] = _normalize_tags(filtered["tags"] or "")
     if not filtered:
         return get_contact(contact_id)
     set_clause = ", ".join(f"{k} = ?" for k in filtered)

--- a/backend/integrations/crm_lite/router.py
+++ b/backend/integrations/crm_lite/router.py
@@ -140,13 +140,23 @@ class ActivityCreate(BaseModel):
 
 @router.get("/contacts")
 async def list_contacts(
-    q: str = "", status: str = "", limit: int = Query(50, ge=1, le=1000), offset: int = Query(0, ge=0),
+    q: str = "", status: str = "", tags: str = "",
+    limit: int = Query(50, ge=1, le=1000), offset: int = Query(0, ge=0),
     user=Depends(_require_crm),
 ):
     if q:
-        contacts = crm.search_contacts(q, status=status or None)
+        contacts = crm.search_contacts(q, status=status or None, tags=tags or None)
         return {"contacts": contacts, "total": len(contacts)}
-    return crm.list_contacts(offset=offset, limit=limit, status=status or None)
+    return crm.list_contacts(
+        offset=offset, limit=limit,
+        status=status or None, tags=tags or None,
+    )
+
+
+@router.get("/tags")
+async def list_tags(user=Depends(_require_crm)):
+    """Return all distinct tag labels currently used by contacts."""
+    return {"tags": crm.list_distinct_tags()}
 
 
 @router.get("/contacts/{contact_id}")

--- a/frontend/src/crm/ContactsPage.tsx
+++ b/frontend/src/crm/ContactsPage.tsx
@@ -22,23 +22,35 @@ export function ContactsPage() {
   const [total, setTotal] = useState(0);
   const [search, setSearch] = useState('');
   const [status, setStatus] = useState<string>('all');
+  const [tagFilter, setTagFilter] = useState<string>('');
+  const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const navigate = useNavigate();
   const isMobile = useIsMobile();
 
+  const loadTags = useCallback(async () => {
+    try {
+      const data = await api<{ tags: string[] }>('/api/crm/tags');
+      setAvailableTags(data.tags);
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => { loadTags(); }, [loadTags]);
+
   const load = useCallback(async () => {
     setLoading(true);
     const params = new URLSearchParams();
     if (search) params.set('q', search);
     if (status !== 'all') params.set('status', status);
+    if (tagFilter) params.set('tags', tagFilter);
     params.set('limit', '100');
     const data = await api<{ contacts: CrmContact[]; total: number }>(`/api/crm/contacts?${params}`);
     setContacts(data.contacts);
     setTotal(data.total);
     setLoading(false);
-  }, [search, status]);
+  }, [search, status, tagFilter]);
 
   useEffect(() => {
     const t = setTimeout(load, search ? 300 : 0);
@@ -87,6 +99,23 @@ export function ContactsPage() {
             );
           })}
         </div>
+        {availableTags.length > 0 && (
+          <select
+            value={tagFilter}
+            onChange={e => setTagFilter(e.target.value)}
+            style={{
+              background: BG_RAISED, border: `1px solid ${LINE}`, color: INK,
+              borderRadius: 4, padding: '8px 10px', fontSize: 13,
+              fontFamily: FONT_SANS, outline: 'none', flexShrink: 0,
+              minWidth: isMobile ? '100%' : 160,
+            }}
+          >
+            <option value="">All tags</option>
+            {availableTags.map(t => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+        )}
       </div>
 
       {loading ? (
@@ -146,8 +175,8 @@ export function ContactsPage() {
         </>
       )}
 
-      {showCreate && <ContactForm onClose={() => setShowCreate(false)} onSaved={() => { setShowCreate(false); load(); }} />}
-      {showImport && <SmartImportModal onClose={() => setShowImport(false)} onImported={() => { setShowImport(false); load(); }} />}
+      {showCreate && <ContactForm onClose={() => setShowCreate(false)} onSaved={() => { setShowCreate(false); load(); loadTags(); }} />}
+      {showImport && <SmartImportModal onClose={() => setShowImport(false)} onImported={() => { setShowImport(false); load(); loadTags(); }} />}
     </div>
   );
 }


### PR DESCRIPTION
Tags were already stored on contacts and exposed in the create/edit form, but there was no way to filter the contact list by tag. Adds a "All tags" dropdown next to the status tabs, populated from a new GET /api/crm/tags endpoint that returns the distinct labels currently in use.

Backend filtering uses boundary-aware matching with whitespace normalization, so a query for "ET" doesn't accidentally hit "WEST" and tolerates the comma-space separators that free-form input typically produces ("test, pt, et"). Same fix is applied to the search_contacts path, which had the same substring-match bug. New tag input is normalized on create/update so future data is clean.