### PR TITLE
Fix Google connection health: diagnostics, alerts, and self-healing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,21 @@
 - Keep deployment simple — avoid requiring Postgres, Redis, or any external services
 - See `DEPLOY.md` for full Railway setup guide
 
+### Railway CLI
+
+For debugging production or running diagnostics against the deployed instance:
+
+```bash
+brew install railway
+railway login          # opens browser for auth
+railway link           # select project, environment, and service
+railway ssh -- "cd /app/backend && python3 -c 'print(\"hello\")'"
+```
+
+SSH requires a registered key: `railway ssh keys add --key ~/.ssh/id_ed25519.pub`
+
+If host key verification fails, add Railway's SSH host: `ssh-keyscan -H ssh.railway.com >> ~/.ssh/known_hosts`
+
 ## Local Development
 
 ```bash

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -244,7 +244,7 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
             info = account_info_map.get(aid, {})
             email = info.get("email", aid)
             status = " **[DISCONNECTED]**" if info.get("connection_status") == "broken" else ""
-            suffix = " (default)" if i == 0 and not status else ""
+            suffix = " (default)" if i == 0 else ""
             entries.append(f"  - {email}{suffix}{status}")
         label = service.title()
         sections.append(f"**{label}** accounts:\n" + "\n".join(entries))

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -220,7 +220,20 @@ When you've naturally covered the key topics:
 
 
 def _google_accounts_context(account_info_map: dict[str, dict], google_accounts: dict) -> str:
-    """Build system prompt section listing available Google accounts per service."""
+    """Build system prompt section listing available and broken Google accounts."""
+    # Collect broken accounts across all assigned services
+    broken_emails = []
+    seen_broken = set()
+    for svc in ("gmail", "calendar", "drive"):
+        for aid in google_accounts.get(svc, []):
+            if aid in seen_broken:
+                continue
+            info = account_info_map.get(aid, {})
+            if info.get("connection_status") == "broken":
+                broken_emails.append(info.get("email", aid))
+                seen_broken.add(aid)
+
+    # Multi-account context (existing behavior)
     sections = []
     for service in ("gmail", "calendar", "drive"):
         ids = google_accounts.get(service, [])
@@ -230,22 +243,35 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
         for i, aid in enumerate(ids):
             info = account_info_map.get(aid, {})
             email = info.get("email", aid)
-            suffix = " (default)" if i == 0 else ""
-            entries.append(f"  - {email}{suffix}")
+            status = " **[DISCONNECTED]**" if info.get("connection_status") == "broken" else ""
+            suffix = " (default)" if i == 0 and not status else ""
+            entries.append(f"  - {email}{suffix}{status}")
         label = service.title()
         sections.append(f"**{label}** accounts:\n" + "\n".join(entries))
-    if not sections:
-        return ""
-    return (
-        "## Google Accounts\n\n"
-        "You have multiple Google accounts available. Use the `account` parameter "
-        "in Gmail/Calendar/Drive tools to specify which account to use.\n"
-        "- For read operations: the first listed account is used by default.\n"
-        "- For write operations (send email, create event, etc.): the first account "
-        "with write access is used by default.\n"
-        "Always specify `account` when context makes the intended account clear.\n\n"
-        + "\n\n".join(sections)
-    )
+
+    parts = []
+    if sections:
+        parts.append(
+            "## Google Accounts\n\n"
+            "You have multiple Google accounts available. Use the `account` parameter "
+            "in Gmail/Calendar/Drive tools to specify which account to use.\n"
+            "- For read operations: the first listed connected account is used by default.\n"
+            "- For write operations (send email, create event, etc.): the first connected "
+            "account with write access is used by default.\n"
+            "Always specify `account` when context makes the intended account clear.\n\n"
+            + "\n\n".join(sections)
+        )
+
+    if broken_emails:
+        parts.append(
+            "## Google Connection Issues\n\n"
+            "The following Google accounts have broken connections. "
+            "Their tools (Gmail, Calendar, Drive) are unavailable until reconnected. "
+            "If the user asks, direct them to Settings → Integrations → Google to reconnect.\n\n"
+            + "\n".join(f"- {email}" for email in broken_emails)
+        )
+
+    return "\n\n".join(parts)
 
 
 def _build_system_prompt(

--- a/backend/core/agents/alerts/service.py
+++ b/backend/core/agents/alerts/service.py
@@ -109,6 +109,24 @@ def resolve_alert(alert_id: str) -> dict:
     return {"ok": True, "id": alert_id}
 
 
+def resolve_by_source(source: str, source_id: str, agent: str | None = None) -> int:
+    """Resolve all active/acknowledged alerts matching the given source and source_id."""
+    conn = db.get_db()
+    now = _now_utc()
+    query = (
+        "UPDATE alerts SET status = 'resolved', resolved_at = ? "
+        "WHERE source = ? AND source_id = ? AND status IN ('active', 'acknowledged')"
+    )
+    params: list = [now, source, source_id]
+    if agent:
+        query += " AND agent = ?"
+        params.append(agent)
+    with db.write_lock():
+        cursor = conn.execute(query, params)
+        conn.commit()
+    return cursor.rowcount
+
+
 def get_active_alerts_text(agent: str, max_alerts: int = 5) -> str:
     alerts = list_alerts(agent=agent, status="active", limit=max_alerts)
     if not alerts:

--- a/backend/core/agents/scheduled_actions/sweeper.py
+++ b/backend/core/agents/scheduled_actions/sweeper.py
@@ -27,13 +27,27 @@ def sweep() -> None:
 
         service.ensure_default_actions_all()
 
-        if cleaned_history or cleaned_alerts or cleaned_usage or fixed_drift or released_leases:
+        healed_google = _try_heal_google()
+
+        if cleaned_history or cleaned_alerts or cleaned_usage or fixed_drift or released_leases or healed_google:
             logger.info(
-                "Sweeper: cleaned %d history, %d alerts, %d usage, fixed %d drifted, released %d leases",
-                cleaned_history, cleaned_alerts, cleaned_usage, fixed_drift, released_leases,
+                "Sweeper: cleaned %d history, %d alerts, %d usage, fixed %d drifted, released %d leases, healed %d Google",
+                cleaned_history, cleaned_alerts, cleaned_usage, fixed_drift, released_leases, healed_google,
             )
     except Exception as e:
         logger.error("Sweeper failed: %s", e)
+
+
+def _try_heal_google() -> int:
+    try:
+        from integrations.google.client import try_heal_broken_accounts
+        healed = try_heal_broken_accounts()
+        if healed:
+            logger.info("Sweeper: self-healed %d Google account(s): %s", len(healed), healed)
+        return len(healed)
+    except Exception as e:
+        logger.debug("Google self-heal skipped: %s", e)
+        return 0
 
 
 def _cleanup_context_usage(retention_days: int = 90) -> int:

--- a/backend/integrations/google/client.py
+++ b/backend/integrations/google/client.py
@@ -14,6 +14,8 @@ import logging
 import threading
 import time
 
+import httpx
+
 from core.providers.oauth import refresh_google_token
 
 logger = logging.getLogger(__name__)
@@ -80,17 +82,33 @@ def _ensure_fresh_token(account_id: str, force: bool = False) -> str:
             return access
 
         if not refresh:
+            _mark_broken(account_id)
             raise GoogleAuthError(
                 "Google access expired and no refresh token is stored. Reconnect Google."
             )
 
         try:
             tokens = _run_sync(refresh_google_token(refresh))
-        except Exception as e:
-            logger.error("Google token refresh failed for account %s: %s", account_id, e)
-            _mark_broken(account_id)
+        except httpx.HTTPStatusError as e:
+            is_permanent = (
+                e.response.status_code == 400
+                and "invalid_grant" in e.response.text
+            )
+            if is_permanent:
+                logger.error("Google refresh token revoked for account %s", account_id)
+                _mark_broken(account_id)
+                raise GoogleAuthError(
+                    "Google refresh token revoked. Reconnect at Settings → Integrations → Google."
+                ) from e
+            logger.warning("Transient Google refresh error for account %s (HTTP %d): %s",
+                           account_id, e.response.status_code, e)
             raise GoogleAuthError(
-                "Google connection expired. Reconnect at Settings → Integrations → Google."
+                "Temporary Google error. Will retry on next request."
+            ) from e
+        except Exception as e:
+            logger.warning("Transient Google refresh error for account %s: %s", account_id, e)
+            raise GoogleAuthError(
+                "Temporary Google error. Will retry on next request."
             ) from e
 
         new_access = tokens.get("access_token", "")
@@ -98,6 +116,7 @@ def _ensure_fresh_token(account_id: str, force: bool = False) -> str:
         new_refresh = tokens.get("refresh_token", refresh)
 
         _save_refreshed_tokens(account_id, new_access, new_refresh, new_expires)
+        _mark_ok(account_id)
         return new_access
 
 
@@ -114,15 +133,107 @@ def _run_sync(coro):
 
 
 def _mark_broken(account_id: str) -> None:
-    """Set connection_status=broken for a specific account."""
+    """Set connection_status=broken for a specific account and alert assigned agents."""
     try:
         from integrations.registry import get_google_account, save_google_account
         acct = get_google_account(account_id)
         if acct:
             acct["connection_status"] = "broken"
+            first_break = not acct.get("broken_at")
+            if first_break:
+                acct["broken_at"] = time.time()
             save_google_account(account_id, acct)
+            if first_break:
+                _fire_broken_alerts(account_id, acct.get("email", account_id))
     except Exception as e:
         logger.warning("Failed to mark Google account %s broken: %s", account_id, e)
+
+
+def _mark_ok(account_id: str) -> None:
+    """Restore connection_status=ok and resolve alerts if previously broken."""
+    try:
+        from integrations.registry import get_google_account, save_google_account
+        acct = get_google_account(account_id)
+        if not acct:
+            return
+        was_broken = acct.get("connection_status") == "broken"
+        if not was_broken:
+            return
+        acct["connection_status"] = "ok"
+        acct.pop("broken_at", None)
+        save_google_account(account_id, acct)
+        try:
+            from core.agents.alerts.service import resolve_by_source
+            resolve_by_source("google_connection", f"google:{account_id}")
+        except Exception as e:
+            logger.warning("Failed to resolve alerts for Google account %s: %s", account_id, e)
+        logger.info("Google account %s (%s) restored to ok", account_id, acct.get("email", "?"))
+    except Exception as e:
+        logger.warning("Failed to mark Google account %s ok: %s", account_id, e)
+
+
+def _fire_broken_alerts(account_id: str, email: str) -> None:
+    """Create a google_connection alert for each agent assigned to this account."""
+    try:
+        from agents.db import list_agents
+        from core.agents.alerts.service import create_alert
+        for agent in list_agents():
+            ga = agent.get("google_accounts", {})
+            if not isinstance(ga, dict):
+                continue
+            uses_account = any(
+                account_id in (ga.get(svc) or [])
+                for svc in ("gmail", "calendar", "drive")
+            )
+            if uses_account:
+                create_alert(
+                    agent=agent["slug"],
+                    title=f"Google connection broken: {email}",
+                    message=(
+                        f"The Google account {email} has lost its connection. "
+                        f"Email, calendar, and drive tools for this account are disabled. "
+                        f"Reconnect at Settings → Integrations → Google."
+                    ),
+                    source="google_connection",
+                    source_id=f"google:{account_id}",
+                )
+    except Exception as e:
+        logger.warning("Failed to create broken connection alerts: %s", e)
+
+
+def try_heal_broken_accounts() -> list[str]:
+    """Retry refresh for legacy broken accounts (no broken_at). Returns healed IDs."""
+    from integrations.registry import list_google_accounts
+    healed = []
+    for account_id, acct in list_google_accounts().items():
+        if acct.get("connection_status") != "broken":
+            continue
+        if acct.get("broken_at"):
+            continue
+        refresh_token = acct.get("refresh_token", "")
+        if not refresh_token:
+            continue
+        try:
+            tokens = _run_sync(refresh_google_token(refresh_token))
+            _save_refreshed_tokens(
+                account_id,
+                tokens.get("access_token", ""),
+                tokens.get("refresh_token", refresh_token),
+                tokens.get("expires_in", 3600),
+            )
+            _mark_ok(account_id)
+            healed.append(account_id)
+            logger.info("Self-healed legacy broken Google account %s (%s)",
+                         account_id, acct.get("email", "?"))
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 400 and "invalid_grant" in e.response.text:
+                _mark_broken(account_id)
+                logger.info("Legacy broken account %s confirmed revoked", account_id)
+            else:
+                logger.debug("Legacy heal retry failed for %s (HTTP %d)", account_id, e.response.status_code)
+        except Exception as e:
+            logger.debug("Legacy heal retry failed for %s: %s", account_id, e)
+    return healed
 
 
 # ── Service factories ────────────────────────────────────────────────────────

--- a/backend/integrations/google/onboarding.py
+++ b/backend/integrations/google/onboarding.py
@@ -108,8 +108,8 @@ async def setup_from_oauth(
     try:
         from core.agents.alerts.service import resolve_by_source
         resolve_by_source("google_connection", f"google:{account_id}")
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Resolve alerts on reconnect: %s", e)
 
     _clear_stale_assignments(account_id, scope_grants)
 

--- a/backend/integrations/google/onboarding.py
+++ b/backend/integrations/google/onboarding.py
@@ -105,6 +105,12 @@ async def setup_from_oauth(
 
     save_google_account(account_id, account_data, create=True)
 
+    try:
+        from core.agents.alerts.service import resolve_by_source
+        resolve_by_source("google_connection", f"google:{account_id}")
+    except Exception:
+        pass
+
     _clear_stale_assignments(account_id, scope_grants)
 
     logger.info("Google account connected: id=%s email=%s scope_grants=%s", account_id, email, scope_grants)


### PR DESCRIPTION
## Summary

- **Root cause fix**: Only mark permanent OAuth failures (`invalid_grant`) as broken — transient network/server errors no longer permanently disable Google tools for agents
- **Targeted alerts**: When a Google account breaks, fire a `google_connection` alert per affected agent with reconnect instructions. Alerts auto-resolve when the account is healed or reconnected
- **Agent awareness**: `_google_accounts_context()` now surfaces broken accounts in system prompts across all paths (chat, heartbeat, cron, reminders), so agents know why their tools are missing instead of failing with confused reasoning
- **Legacy self-healing**: Sweeper retries broken accounts from before this fix (no `broken_at` field) every 5 minutes
- **Railway CLI**: Added setup instructions to CLAUDE.md for production diagnostics

## Test plan

- [ ] Verify 262 existing tests pass (`pytest tests/ -x -q`)
- [ ] SSH into Railway, mark an account broken, verify alert appears in UI
- [ ] Verify chat system prompt mentions broken connection
- [ ] Verify heartbeat runs with broken-account context (doesn't skip non-Google checks)
- [ ] Reconnect Google account, verify alert auto-resolves
- [ ] Simulate transient refresh error (5xx), verify account stays "ok"
- [ ] Simulate permanent refresh error (`invalid_grant`), verify account marked broken with alert