### PR TITLE
Add model tier system with auto-triage routing

### DIFF
--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -81,6 +81,7 @@ def _setup_connection() -> None:
         ("drive_enabled", "INTEGER NOT NULL DEFAULT 0"),
         ("drive_write_enabled", "INTEGER NOT NULL DEFAULT 0"),
         ("google_accounts", "TEXT NOT NULL DEFAULT '{}'"),
+        ("model_tier", "TEXT NOT NULL DEFAULT 'auto'"),
     ]:
         try:
             _connection.execute(f"ALTER TABLE agents ADD COLUMN {col} {typedef}")
@@ -194,6 +195,7 @@ UPDATABLE_FIELDS = {
     "whatsapp_session_id",
     "telegram_enabled", "telegram_bot_token", "telegram_bot_username",
     "telegram_group_enabled", "telegram_respond_to_bots", "telegram_max_bot_turns",
+    "model_tier",
 }
 
 

--- a/backend/agents/engine.py
+++ b/backend/agents/engine.py
@@ -70,6 +70,7 @@ def build_agent_config(agent_row: dict) -> AgentConfig:
         personality=personality,
         provider_override=agent_row.get("provider_override", ""),
         model_override=agent_row.get("model_override", ""),
+        model_tier=agent_row.get("model_tier", "auto"),
         gmail_enabled=bool(agent_row.get("gmail_enabled", 0)),
         gmail_send_enabled=bool(agent_row.get("gmail_send_enabled", 0)),
         calendar_enabled=bool(agent_row.get("calendar_enabled", 0)),

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -542,7 +542,10 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
                 if supports_auto_triage(provider_key):
                     from core.providers.triage import classify_tier, extract_classifier_credentials
                     last_user = next((m for m in reversed(messages) if m.get("role") == "user"), None)
-                    user_text = last_user.get("content", "") if last_user else ""
+                    raw_content = last_user.get("content", "") if last_user else ""
+                    user_text = raw_content if isinstance(raw_content, str) else " ".join(
+                        p.get("text", "") for p in raw_content if isinstance(p, dict) and p.get("type") == "text"
+                    )
                     creds = extract_classifier_credentials(provider_key, store)
                     tier, method = await classify_tier(
                         user_message=user_text,

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -237,6 +237,9 @@ async def update_agent(agent_id: str, body: UpdateAgentRequest, user=Depends(get
             raise HTTPException(status_code=400, detail="model_tier must be one of: auto, top, mid, light")
         updates["model_override"] = ""
 
+    if "model_override" in updates and updates["model_override"]:
+        updates["model_tier"] = "auto"
+
     if "google_accounts" in updates:
         ga = updates["google_accounts"]
         _ALLOWED_GA_KEYS = {"gmail", "calendar", "drive"}

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -127,6 +127,7 @@ class UpdateAgentRequest(BaseModel):
     drive_enabled: bool | None = None
     drive_write_enabled: bool | None = None
     google_accounts: dict | None = None
+    model_tier: str | None = None
     telegram_enabled: bool | None = None
     telegram_group_enabled: bool | None = None
     telegram_respond_to_bots: bool | None = None
@@ -230,6 +231,11 @@ async def update_agent(agent_id: str, body: UpdateAgentRequest, user=Depends(get
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
+
+    if "model_tier" in updates:
+        if updates["model_tier"] not in ("auto", "top", "mid", "light"):
+            raise HTTPException(status_code=400, detail="model_tier must be one of: auto, top, mid, light")
+        updates["model_override"] = ""
 
     if "google_accounts" in updates:
         ga = updates["google_accounts"]
@@ -445,7 +451,7 @@ async def get_avatar(agent_id: str, request: Request, token: str | None = None):
 def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_id: str | None,
                   training_type: str | None = None, plan_mode: bool = False,
                   tool_mode: str = "normal", approved_tool: dict | None = None,
-                  import_mode: bool = False):
+                  import_mode: bool = False, has_attachments: bool = False):
     """Build provider, registry, and return a StreamingResponse for agent chat."""
     config = build_agent_config(agent)
     ctx_manager = get_context_manager(agent["slug"])
@@ -458,9 +464,22 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
         pass  # Non-critical — search will degrade gracefully
 
     store = CredentialStore()
+
+    # ── Tier resolution ──────────────────────────────────────────────
+    # model_override takes absolute precedence — skip all tier logic
+    triage_info: dict | None = None
+    resolved_model = config.model_override or None
+
+    if not resolved_model and config.model_tier != "auto":
+        from core.providers.tiers import resolve_tier_model
+        provider_key = config.provider_override or store.data.get("active_provider", "")
+        resolved_model = resolve_tier_model(provider_key, config.model_tier)
+        triage_info = {"tier": config.model_tier, "method": "manual"}
+
     provider = get_ai_provider(
         agent_provider=config.provider_override or None,
-        agent_model=config.model_override or None,
+        agent_model=resolved_model,
+        agent_model_tier=config.model_tier if not resolved_model else None,
     )
     if not provider:
         raise HTTPException(status_code=400, detail="No AI provider configured")
@@ -512,6 +531,38 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
     anthropic_api_key = (anthropic_profile or {}).get("key", "")
 
     async def event_generator():
+        nonlocal triage_info, provider
+
+        # Run auto-triage if tier is "auto" and we haven't resolved yet
+        if not triage_info and config.model_tier == "auto" and not config.model_override:
+            skip_triage = training_mode or plan_mode or approved_tool is not None
+            if not skip_triage:
+                from core.providers.tiers import supports_auto_triage
+                provider_key = config.provider_override or store.data.get("active_provider", "")
+                if supports_auto_triage(provider_key):
+                    from core.providers.triage import classify_tier, extract_classifier_credentials
+                    last_user = next((m for m in reversed(messages) if m.get("role") == "user"), None)
+                    user_text = (last_user.get("content", "") if last_user else "") if last_user else ""
+                    creds = extract_classifier_credentials(provider_key, store)
+                    tier, method = await classify_tier(
+                        user_message=user_text,
+                        provider=provider_key,
+                        credentials=creds,
+                        conversation_id=conversation_id,
+                        has_attachments=has_attachments,
+                    )
+                    triage_info = {"tier": tier, "method": method}
+                    if tier != "top":
+                        from core.providers.tiers import resolve_tier_model
+                        resolved = resolve_tier_model(provider_key, tier)
+                        if resolved:
+                            new_provider = get_ai_provider(
+                                agent_provider=config.provider_override or None,
+                                agent_model=resolved,
+                            )
+                            if new_provider:
+                                provider = new_provider
+
         async for event in ai_service.chat(
             config=config,
             provider=provider,
@@ -529,6 +580,7 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
             tool_mode=tool_mode,
             approved_tool=approved_tool,
             integration_tool_modes=integration_tool_modes,
+            triage_info=triage_info,
         ):
             yield event
 
@@ -887,7 +939,7 @@ async def agent_chat_upload(
         agent, messages, body.get("training_mode", False), body.get("conversation_id"),
         training_type=body.get("training_type"), plan_mode=body.get("plan_mode", False),
         tool_mode=body.get("tool_mode", "normal"), approved_tool=body.get("approved_tool"),
-        import_mode=import_mode,
+        import_mode=import_mode, has_attachments=bool(files),
     )
 
 

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -542,7 +542,7 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
                 if supports_auto_triage(provider_key):
                     from core.providers.triage import classify_tier, extract_classifier_credentials
                     last_user = next((m for m in reversed(messages) if m.get("role") == "user"), None)
-                    user_text = (last_user.get("content", "") if last_user else "") if last_user else ""
+                    user_text = last_user.get("content", "") if last_user else ""
                     creds = extract_classifier_credentials(provider_key, store)
                     tier, method = await classify_tier(
                         user_message=user_text,

--- a/backend/cli/session.py
+++ b/backend/cli/session.py
@@ -65,6 +65,7 @@ def create_session(slug: str, tool_mode: str = "normal",
     provider = get_ai_provider(
         agent_provider=config.provider_override or None,
         agent_model=config.model_override or None,
+        agent_model_tier=config.model_tier,
     )
     if not provider:
         raise SystemExit("No AI provider configured. Set one up in the web UI first.")

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -636,6 +636,7 @@ async def chat(
     tool_mode: str = "normal",
     approved_tool: dict | None = None,
     integration_tool_modes: dict[str, str] | None = None,
+    triage_info: dict | None = None,
 ) -> AsyncGenerator[str, None]:
     """Stream a chat response as SSE events.
 
@@ -978,6 +979,7 @@ async def chat(
                             role="assistant",
                             content=turn_text,
                             tool_calls=tc_json,
+                            model=model_used,
                         )
                     except Exception as e:
                         logger.warning("Chat history save (assistant) failed: %s", e)
@@ -996,7 +998,10 @@ async def chat(
                     _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                         accumulated_text, all_tool_calls, model_used,
                                         total_input_tokens, total_output_tokens, chat_start_time)
-                    yield _sse({"type": "done"})
+                    done_event = {"type": "done", "model": model_used}
+                    if triage_info:
+                        done_event["tier"] = triage_info.get("tier")
+                    yield _sse(done_event)
                     return
 
             elif etype == "error":
@@ -1011,7 +1016,10 @@ async def chat(
             _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                 accumulated_text, all_tool_calls, model_used,
                                 total_input_tokens, total_output_tokens, chat_start_time)
-            yield _sse({"type": "done"})
+            done_event = {"type": "done", "model": model_used}
+            if triage_info:
+                done_event["tier"] = triage_info.get("tier")
+            yield _sse(done_event)
             return
 
         results = []
@@ -1084,7 +1092,10 @@ async def chat(
                 _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                     accumulated_text, all_tool_calls, model_used,
                                     total_input_tokens, total_output_tokens, chat_start_time)
-                yield _sse({"type": "done"})
+                done_event = {"type": "done", "model": model_used}
+                if triage_info:
+                    done_event["tier"] = triage_info.get("tier")
+                yield _sse(done_event)
                 return
 
             # ── Intercept write tools that need approval ──
@@ -1165,7 +1176,10 @@ async def chat(
             _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                 accumulated_text, all_tool_calls, model_used,
                                 total_input_tokens, total_output_tokens, chat_start_time)
-            yield _sse({"type": "done"})
+            done_event = {"type": "done", "model": model_used}
+            if triage_info:
+                done_event["tier"] = triage_info.get("tier")
+            yield _sse(done_event)
             return
 
     # Exceeded max iterations
@@ -1355,6 +1369,7 @@ async def run_sync(
                     role="assistant",
                     content=turn_text,
                     tool_calls=tc_json,
+                    model=model_used,
                 )
             except Exception as e:
                 logger.warning("run_sync: chat history save (assistant) failed: %s", e)

--- a/backend/core/agents/background_runner.py
+++ b/backend/core/agents/background_runner.py
@@ -42,6 +42,7 @@ async def _run_turn(
     model_override: str | None = None,
     provider_override: str | None = None,
     on_iteration: Callable[[int], bool] | None = None,
+    model_tier: str | None = None,
 ) -> BackgroundResult:
     """Run a single AI turn asynchronously, executing tools as needed.
 
@@ -52,6 +53,7 @@ async def _run_turn(
     provider = get_ai_provider(
         agent_provider=provider_override,
         agent_model=model_override,
+        agent_model_tier=model_tier,
     )
     if not provider:
         return BackgroundResult(text="No AI provider configured", error=True)
@@ -215,6 +217,7 @@ def run_background_turn(
     provider_override: str | None = None,
     on_iteration: Callable[[int], bool] | None = None,
     source: str | None = None,
+    model_tier: str | None = None,
 ) -> BackgroundResult:
     """Synchronous wrapper for running a background AI turn.
 
@@ -238,14 +241,14 @@ def run_background_turn(
                     asyncio.run,
                     _run_turn(system_prompt, user_message, tool_defs, registry,
                               max_iterations, model_override, provider_override,
-                              on_iteration)
+                              on_iteration, model_tier=model_tier)
                 )
                 result = future.result(timeout=300)
         else:
             result = asyncio.run(
                 _run_turn(system_prompt, user_message, tool_defs, registry,
                           max_iterations, model_override, provider_override,
-                          on_iteration)
+                          on_iteration, model_tier=model_tier)
             )
     except Exception as exc:
         if source:

--- a/backend/core/agents/chat_history/db.py
+++ b/backend/core/agents/chat_history/db.py
@@ -107,4 +107,8 @@ class ChatHistoryDB:
         if "mode" not in conv_cols:
             conn.execute("ALTER TABLE conversations ADD COLUMN mode TEXT NOT NULL DEFAULT 'normal'")
 
+        msg_cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+        if "model" not in msg_cols:
+            conn.execute("ALTER TABLE messages ADD COLUMN model TEXT NOT NULL DEFAULT ''")
+
         conn.commit()

--- a/backend/core/agents/chat_history/service.py
+++ b/backend/core/agents/chat_history/service.py
@@ -111,7 +111,7 @@ class ChatHistoryService:
         If seq is None, atomically computes the next sequence number under
         the write lock so concurrent callers never collide.
         tool_calls is an optional JSON string of tool call data for assistant messages.
-        model is the AI model used for assistant messages (for "via Model" badge).
+        model is the AI model ID that generated this message.
         """
         db = self._db.get_db()
         with self._db.write_lock():

--- a/backend/core/agents/chat_history/service.py
+++ b/backend/core/agents/chat_history/service.py
@@ -104,12 +104,14 @@ class ChatHistoryService:
         content: str,
         seq: int | None = None,
         tool_calls: str | None = None,
+        model: str = "",
     ) -> None:
         """Insert or replace a message and bump conversation updated_at.
 
         If seq is None, atomically computes the next sequence number under
         the write lock so concurrent callers never collide.
         tool_calls is an optional JSON string of tool call data for assistant messages.
+        model is the AI model used for assistant messages (for "via Model" badge).
         """
         db = self._db.get_db()
         with self._db.write_lock():
@@ -121,9 +123,9 @@ class ChatHistoryService:
                 seq = row["next_seq"]
             db.execute(
                 """INSERT OR REPLACE INTO messages
-                   (id, conversation_id, role, content, seq, tool_calls)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
-                (msg_id, conversation_id, role, content, seq, tool_calls),
+                   (id, conversation_id, role, content, seq, tool_calls, model)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (msg_id, conversation_id, role, content, seq, tool_calls, model),
             )
             db.execute(
                 "UPDATE conversations SET updated_at = datetime('now') WHERE id = ?",

--- a/backend/core/agents/config.py
+++ b/backend/core/agents/config.py
@@ -22,6 +22,7 @@ class AgentConfig:
     # Provider override — if empty, uses the globally active provider
     provider_override: str = ""
     model_override: str = ""
+    model_tier: str = "auto"
 
     # Feature flags (per-agent capability toggles). Agent can only use a
     # capability if the global Google connection has also granted the

--- a/backend/core/agents/router_factory.py
+++ b/backend/core/agents/router_factory.py
@@ -76,6 +76,7 @@ def create_agent_router(
         provider = get_ai_provider(
             agent_provider=config.provider_override or None,
             agent_model=config.model_override or None,
+            agent_model_tier=config.model_tier,
         )
         if not provider:
             raise HTTPException(status_code=400, detail="No AI provider configured")

--- a/backend/core/providers/__init__.py
+++ b/backend/core/providers/__init__.py
@@ -8,13 +8,19 @@ from core.providers.base import AIProvider
 from core.providers.credentials import CredentialStore
 
 
-def get_ai_provider(agent_provider: str | None = None, agent_model: str | None = None) -> AIProvider | None:
+def get_ai_provider(
+    agent_provider: str | None = None,
+    agent_model: str | None = None,
+    agent_model_tier: str | None = None,
+) -> AIProvider | None:
     """
     Return an initialized AIProvider for the active (or specified) provider.
 
     Args:
         agent_provider: Optional per-agent provider override ("anthropic", "openai", "google").
-        agent_model: Optional per-agent model override.
+        agent_model: Optional per-agent model override (takes precedence over tier).
+        agent_model_tier: Optional tier ("auto", "top", "mid", "light").
+            For "auto", resolves to "top" here (triage runs separately in _stream_chat).
 
     Returns None if no provider is configured.
     """
@@ -25,7 +31,20 @@ def get_ai_provider(agent_provider: str | None = None, agent_model: str | None =
         return None
 
     provider_type = profile.get("type")
-    raw_model = agent_model or store.data.get("active_model", "")
+
+    # Resolve model: agent_model > tier > global active_model
+    if agent_model:
+        raw_model = agent_model
+    elif agent_model_tier and agent_model_tier != "auto":
+        from core.providers.tiers import resolve_tier_model
+        provider_key = agent_provider or store.data.get("active_provider", "")
+        raw_model = resolve_tier_model(provider_key, agent_model_tier) or ""
+    elif agent_model_tier == "auto":
+        from core.providers.tiers import resolve_tier_model
+        provider_key = agent_provider or store.data.get("active_provider", "")
+        raw_model = resolve_tier_model(provider_key, "top") or ""
+    else:
+        raw_model = store.data.get("active_model", "")
     model = raw_model if raw_model and raw_model != "default" else ""
 
     if profile_name.startswith("anthropic:"):

--- a/backend/core/providers/router.py
+++ b/backend/core/providers/router.py
@@ -37,6 +37,19 @@ async def get_providers(user=Depends(get_current_user)):
     return result
 
 
+@router.get("/tiers")
+async def get_tiers(user=Depends(get_current_user)):
+    """Return tier configuration for all providers."""
+    from core.providers.tiers import TIER_MODELS, TIER_LABELS, supports_auto_triage
+    store = CredentialStore()
+    return {
+        "active_provider": store.data.get("active_provider", ""),
+        "tier_models": TIER_MODELS,
+        "tier_labels": TIER_LABELS,
+        "auto_triage_providers": [p for p in TIER_MODELS if supports_auto_triage(p)],
+    }
+
+
 # ── Connect Anthropic (API key) ───────────────────────────────────────────────
 
 class AnthropicConnectRequest(BaseModel):

--- a/backend/core/providers/tiers.py
+++ b/backend/core/providers/tiers.py
@@ -1,0 +1,82 @@
+"""Chatty — Model tier definitions and resolution.
+
+Maps tier labels (top/mid/light) to concrete model IDs per provider.
+Hardcoded, updated occasionally when new models are released.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.agents.config import AgentConfig
+
+TIER_MODELS: dict[str, dict[str, str]] = {
+    "anthropic": {
+        "top":   "claude-opus-4-6",
+        "mid":   "claude-sonnet-4-6",
+        "light": "claude-haiku-4-5-20251001",
+    },
+    "openai": {
+        "top":   "gpt-5.4",
+        "mid":   "gpt-5.4-mini",
+        "light": "gpt-5.4-nano",
+    },
+    "google": {
+        "top":   "gemini-2.5-pro",
+        "mid":   "gemini-2.5-flash",
+        "light": "gemini-2.0-flash-lite",
+    },
+    "together": {
+        "top":   "Qwen/Qwen3.5-32B",
+        "mid":   "Qwen/Qwen3.5-14B",
+        "light": "Qwen/Qwen3.5-7B",
+    },
+}
+
+TIER_LABELS: dict[str, dict[str, str]] = {
+    "anthropic": {"top": "Opus", "mid": "Sonnet", "light": "Haiku"},
+    "openai":    {"top": "GPT-5.4", "mid": "Mini", "light": "Nano"},
+    "google":    {"top": "Pro", "mid": "Flash", "light": "Lite"},
+    "together":  {"top": "32B", "mid": "14B", "light": "7B"},
+}
+
+TRIAGE_CLASSIFIERS: dict[str, str] = {
+    "anthropic": "claude-haiku-4-5-20251001",
+    "openai":    "gpt-5.4-nano",
+    "google":    "gemini-2.0-flash-lite",
+}
+
+
+def resolve_tier_model(provider: str, tier: str) -> str | None:
+    return TIER_MODELS.get(provider, {}).get(tier)
+
+
+def get_tier_info(provider: str) -> dict | None:
+    models = TIER_MODELS.get(provider)
+    labels = TIER_LABELS.get(provider)
+    if not models or not labels:
+        return None
+    return {"models": models, "labels": labels}
+
+
+def supports_auto_triage(provider: str) -> bool:
+    return provider in TRIAGE_CLASSIFIERS
+
+
+def get_triage_classifier(provider: str) -> str | None:
+    return TRIAGE_CLASSIFIERS.get(provider)
+
+
+def resolve_model_for_agent(config: AgentConfig, provider: str) -> str | None:
+    """Full resolution: model_override > model_tier > None.
+
+    Returns None if the tier/provider combination has no mapping,
+    letting the caller fall back to the global active_model.
+    """
+    if config.model_override:
+        return config.model_override
+    tier = config.model_tier or "auto"
+    if tier == "auto":
+        tier = "top"
+    return resolve_tier_model(provider, tier)

--- a/backend/core/providers/tiers.py
+++ b/backend/core/providers/tiers.py
@@ -6,10 +6,6 @@ Hardcoded, updated occasionally when new models are released.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from core.agents.config import AgentConfig
 
 TIER_MODELS: dict[str, dict[str, str]] = {
     "anthropic": {
@@ -66,17 +62,3 @@ def supports_auto_triage(provider: str) -> bool:
 
 def get_triage_classifier(provider: str) -> str | None:
     return TRIAGE_CLASSIFIERS.get(provider)
-
-
-def resolve_model_for_agent(config: AgentConfig, provider: str) -> str | None:
-    """Full resolution: model_override > model_tier > None.
-
-    Returns None if the tier/provider combination has no mapping,
-    letting the caller fall back to the global active_model.
-    """
-    if config.model_override:
-        return config.model_override
-    tier = config.model_tier or "auto"
-    if tier == "auto":
-        tier = "top"
-    return resolve_tier_model(provider, tier)

--- a/backend/core/providers/triage.py
+++ b/backend/core/providers/triage.py
@@ -102,9 +102,12 @@ def extract_classifier_credentials(provider: str, store: CredentialStore) -> dic
     return {}
 
 
+_CLASSIFIER_TIMEOUT = 5
+
+
 async def _classify_anthropic(text: str, creds: dict) -> str:
     import anthropic
-    client = anthropic.AsyncAnthropic(api_key=creds["api_key"])
+    client = anthropic.AsyncAnthropic(api_key=creds["api_key"], timeout=_CLASSIFIER_TIMEOUT)
     response = await client.messages.create(
         model=TRIAGE_CLASSIFIERS["anthropic"],
         max_tokens=5,
@@ -116,7 +119,7 @@ async def _classify_anthropic(text: str, creds: dict) -> str:
 
 async def _classify_openai(text: str, creds: dict) -> str:
     import openai
-    kwargs: dict = {"api_key": creds["api_key"]}
+    kwargs: dict = {"api_key": creds["api_key"], "timeout": _CLASSIFIER_TIMEOUT}
     if creds.get("use_chatgpt_api"):
         kwargs["base_url"] = "http://127.0.0.1:9877/v1"
     client = openai.AsyncOpenAI(**kwargs)
@@ -132,6 +135,7 @@ async def _classify_openai(text: str, creds: dict) -> str:
 
 
 async def _classify_google(text: str, creds: dict) -> str:
+    import asyncio
     import google.generativeai as genai
     if creds.get("api_key"):
         genai.configure(api_key=creds["api_key"])
@@ -141,9 +145,12 @@ async def _classify_google(text: str, creds: dict) -> str:
         TRIAGE_CLASSIFIERS["google"],
         system_instruction=_TRIAGE_SYSTEM_PROMPT,
     )
-    response = await model.generate_content_async(
-        text[:_MAX_INPUT_CHARS],
-        generation_config=genai.types.GenerationConfig(max_output_tokens=5),
+    response = await asyncio.wait_for(
+        model.generate_content_async(
+            text[:_MAX_INPUT_CHARS],
+            generation_config=genai.types.GenerationConfig(max_output_tokens=5),
+        ),
+        timeout=_CLASSIFIER_TIMEOUT,
     )
     return response.text or ""
 
@@ -190,7 +197,7 @@ async def classify_tier(
 
     # If cached, promote upward only
     classify_fn = _CLASSIFY_DISPATCH.get(provider)
-    if not classify_fn or not credentials.get("api_key") and not credentials.get("access_token"):
+    if not classify_fn or (not credentials.get("api_key") and not credentials.get("access_token")):
         return ("top", "skip")
 
     try:

--- a/backend/core/providers/triage.py
+++ b/backend/core/providers/triage.py
@@ -1,0 +1,206 @@
+"""Chatty — Auto-triage classifier.
+
+Routes messages to the appropriate model tier using:
+1. Heuristic fast-path (greetings/acks -> light)
+2. Provider-specific classifier (three-way top/mid/light, biased toward top)
+3. Per-conversation upward-only cache
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+
+from core.providers.credentials import CredentialStore
+from core.providers.tiers import TRIAGE_CLASSIFIERS
+
+logger = logging.getLogger(__name__)
+
+_TRIAGE_GREETINGS = frozenset({
+    "hi", "hey", "hello", "good morning", "good afternoon", "good evening",
+    "morning", "afternoon", "evening", "howdy", "sup", "yo", "hiya",
+    "whats up", "what's up", "greetings",
+})
+
+_TRIAGE_ACKS = frozenset({
+    "thanks", "thank you", "thx", "ty", "great", "perfect", "awesome",
+    "got it", "ok", "okay", "cool", "sounds good", "nice", "sweet",
+})
+
+_TIER_RANK = {"light": 0, "mid": 1, "top": 2}
+
+_MAX_CACHE_SIZE = 500
+_conversation_tier_cache: OrderedDict[str, str] = OrderedDict()
+
+_TRIAGE_SYSTEM_PROMPT = (
+    "Classify this message. Reply with ONLY one word: TOP, MID, or LIGHT.\n\n"
+    "TOP — complex reasoning, analysis, planning, creative work, code generation, "
+    "multi-step tasks, anything requiring deep understanding or nuance. "
+    "When in doubt, choose TOP.\n"
+    "MID — summarization, simple explanations, Q&A with context, formatting, translation.\n"
+    "LIGHT — simple greetings, acknowledgments, yes/no questions, trivial lookups."
+)
+
+_MAX_INPUT_CHARS = 500
+
+
+def _should_fast_path_light(text: str) -> bool:
+    normalized = text.strip().lower().rstrip("!.?,;:")
+    return normalized in _TRIAGE_GREETINGS or normalized in _TRIAGE_ACKS
+
+
+def _cache_get(conversation_id: str) -> str | None:
+    tier = _conversation_tier_cache.get(conversation_id)
+    if tier is not None:
+        _conversation_tier_cache.move_to_end(conversation_id)
+    return tier
+
+
+def _cache_set(conversation_id: str, tier: str) -> None:
+    _conversation_tier_cache[conversation_id] = tier
+    _conversation_tier_cache.move_to_end(conversation_id)
+    while len(_conversation_tier_cache) > _MAX_CACHE_SIZE:
+        _conversation_tier_cache.popitem(last=False)
+
+
+def _max_tier(a: str, b: str) -> str:
+    return a if _TIER_RANK.get(a, 2) >= _TIER_RANK.get(b, 2) else b
+
+
+def _parse_tier(raw: str) -> str:
+    upper = raw.strip().upper()
+    if "LIGHT" in upper:
+        return "light"
+    if "MID" in upper:
+        return "mid"
+    return "top"
+
+
+def extract_classifier_credentials(provider: str, store: CredentialStore) -> dict:
+    """Extract the right credentials for the triage classifier, matching get_ai_provider() logic."""
+    _, profile = store.get_active_profile(provider_override=provider)
+    if not profile:
+        return {}
+
+    if provider == "anthropic":
+        if profile.get("type") == "setup_token":
+            return {"api_key": profile.get("token", "")}
+        return {"api_key": profile.get("key", "")}
+
+    elif provider == "openai":
+        if profile.get("type") == "api_key":
+            return {"api_key": profile.get("key", "")}
+        if profile.get("type") == "chatgpt_oauth":
+            return {"api_key": profile.get("access", ""), "use_chatgpt_api": True}
+        return {"api_key": profile.get("access", "")}
+
+    elif provider == "google":
+        if profile.get("type") == "api_key":
+            return {"api_key": profile.get("key", "")}
+        return {"access_token": profile.get("access", "")}
+
+    return {}
+
+
+async def _classify_anthropic(text: str, creds: dict) -> str:
+    import anthropic
+    client = anthropic.AsyncAnthropic(api_key=creds["api_key"])
+    response = await client.messages.create(
+        model=TRIAGE_CLASSIFIERS["anthropic"],
+        max_tokens=5,
+        system=_TRIAGE_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": text[:_MAX_INPUT_CHARS]}],
+    )
+    return response.content[0].text
+
+
+async def _classify_openai(text: str, creds: dict) -> str:
+    import openai
+    kwargs: dict = {"api_key": creds["api_key"]}
+    if creds.get("use_chatgpt_api"):
+        kwargs["base_url"] = "http://127.0.0.1:9877/v1"
+    client = openai.AsyncOpenAI(**kwargs)
+    response = await client.chat.completions.create(
+        model=TRIAGE_CLASSIFIERS["openai"],
+        max_completion_tokens=20,
+        messages=[
+            {"role": "system", "content": _TRIAGE_SYSTEM_PROMPT},
+            {"role": "user", "content": text[:_MAX_INPUT_CHARS]},
+        ],
+    )
+    return response.choices[0].message.content or ""
+
+
+async def _classify_google(text: str, creds: dict) -> str:
+    import google.generativeai as genai
+    if creds.get("api_key"):
+        genai.configure(api_key=creds["api_key"])
+    elif creds.get("access_token"):
+        genai.configure(credentials=_google_oauth_creds(creds["access_token"]))
+    model = genai.GenerativeModel(
+        TRIAGE_CLASSIFIERS["google"],
+        system_instruction=_TRIAGE_SYSTEM_PROMPT,
+    )
+    response = await model.generate_content_async(
+        text[:_MAX_INPUT_CHARS],
+        generation_config=genai.types.GenerationConfig(max_output_tokens=5),
+    )
+    return response.text or ""
+
+
+def _google_oauth_creds(access_token: str):
+    from google.oauth2.credentials import Credentials
+    return Credentials(token=access_token)
+
+
+_CLASSIFY_DISPATCH = {
+    "anthropic": _classify_anthropic,
+    "openai":    _classify_openai,
+    "google":    _classify_google,
+}
+
+
+async def classify_tier(
+    user_message: str,
+    provider: str,
+    credentials: dict,
+    conversation_id: str | None = None,
+    has_attachments: bool = False,
+) -> tuple[str, str]:
+    """Classify a message into a model tier.
+
+    Returns (tier, method) where tier is "top"/"mid"/"light"
+    and method is "heuristic"/"classifier"/"cached"/"skip".
+    """
+    if has_attachments:
+        return ("top", "skip")
+
+    # Upward-only cache check
+    cached_tier = None
+    if conversation_id:
+        cached_tier = _cache_get(conversation_id)
+
+    if _should_fast_path_light(user_message):
+        tier = "light"
+        if cached_tier:
+            tier = _max_tier(cached_tier, tier)
+        if conversation_id:
+            _cache_set(conversation_id, tier)
+        return (tier, "heuristic")
+
+    # If cached, promote upward only
+    classify_fn = _CLASSIFY_DISPATCH.get(provider)
+    if not classify_fn or not credentials.get("api_key") and not credentials.get("access_token"):
+        return ("top", "skip")
+
+    try:
+        raw = await classify_fn(user_message, credentials)
+        tier = _parse_tier(raw)
+        if cached_tier:
+            tier = _max_tier(cached_tier, tier)
+        if conversation_id:
+            _cache_set(conversation_id, tier)
+        return (tier, "classifier")
+    except Exception as e:
+        logger.warning("Triage classifier failed for %s, defaulting to top: %s", provider, e)
+        return ("top", "skip")

--- a/backend/core/providers/triage.py
+++ b/backend/core/providers/triage.py
@@ -121,7 +121,8 @@ async def _classify_openai(text: str, creds: dict) -> str:
     import openai
     kwargs: dict = {"api_key": creds["api_key"], "timeout": _CLASSIFIER_TIMEOUT}
     if creds.get("use_chatgpt_api"):
-        kwargs["base_url"] = "http://127.0.0.1:9877/v1"
+        from core.providers.openai_provider import CHATGPT_PROXY_URL
+        kwargs["base_url"] = CHATGPT_PROXY_URL
     client = openai.AsyncOpenAI(**kwargs)
     response = await client.chat.completions.create(
         model=TRIAGE_CLASSIFIERS["openai"],

--- a/backend/core/providers/triage.py
+++ b/backend/core/providers/triage.py
@@ -64,7 +64,7 @@ def _cache_set(conversation_id: str, tier: str) -> None:
 
 
 def _max_tier(a: str, b: str) -> str:
-    return a if _TIER_RANK.get(a, 2) >= _TIER_RANK.get(b, 2) else b
+    return a if _TIER_RANK.get(a, -1) >= _TIER_RANK.get(b, -1) else b
 
 
 def _parse_tier(raw: str) -> str:

--- a/backend/integrations/paperclip/webhook.py
+++ b/backend/integrations/paperclip/webhook.py
@@ -158,6 +158,7 @@ async def handle_heartbeat(request: Request):
         provider = get_ai_provider(
             agent_provider=config.provider_override or None,
             agent_model=config.model_override or None,
+            agent_model_tier=config.model_tier,
         )
         if not provider:
             return JSONResponse(

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -170,6 +170,7 @@ async def process_message(
     provider = get_ai_provider(
         agent_provider=config.provider_override or None,
         agent_model=config.model_override or None,
+        agent_model_tier=config.model_tier,
     )
     if not provider:
         return "No AI provider is configured. Please set up an AI provider in Settings."
@@ -274,6 +275,7 @@ async def process_group_message(
     provider = get_ai_provider(
         agent_provider=config.provider_override or None,
         agent_model=config.model_override or None,
+        agent_model_tier=config.model_tier,
     )
     if not provider:
         return "No AI provider is configured. Please set up an AI provider in Settings."

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -265,6 +265,7 @@ def _process_message_locked(
         max_iterations=5,
         model_override=config.model_override or None,
         source="whatsapp",
+        model_tier=config.model_tier,
     )
 
     response_text = result.text
@@ -277,6 +278,7 @@ def _process_message_locked(
                 msg_id=str(uuid.uuid4()),
                 role="assistant",
                 content=response_text,
+                model=result.model_used,
             )
         except Exception as e:
             logger.warning("Failed to save assistant message to chat history: %s", e)

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { api } from '../core/api/client';
 import type { ProviderStatus } from '../core/types';
-import { useAgentChat, type ToolMode } from './hooks/useAgentChat';
+import { useAgentChat, type ToolMode, type ModelTier } from './hooks/useAgentChat';
 import { useConversations } from './hooks/useConversations';
 import { useScrollDirection } from './hooks/useScrollDirection';
 import { AgentChatPanel } from './components/AgentChatPanel';
@@ -34,6 +34,8 @@ interface AgentRow {
   telegram_group_enabled: boolean;
   telegram_respond_to_bots: boolean;
   telegram_max_bot_turns: number;
+  model_tier?: string;
+  provider_override?: string;
 }
 
 type Tab = 'chat' | 'knowledge' | 'reports' | 'reminders' | 'heartbeat';
@@ -72,6 +74,8 @@ export function AgentPage() {
   const [alwaysPowerMode, setAlwaysPowerMode] = useState(false);
   const [activeProvider, setActiveProvider] = useState('');
   const [activeModel, setActiveModel] = useState('');
+  const [modelTier, setModelTier] = useState<ModelTier>('auto');
+  const [tierLabels, setTierLabels] = useState<Record<string, string>>({});
   const isMobile = useIsMobile();
   const prevOnboardingComplete = useRef<boolean | null>(null);
 
@@ -121,6 +125,35 @@ export function AgentPage() {
       .then(p => { setActiveProvider(p.active_provider); setActiveModel(p.active_model); })
       .catch(() => {});
   }, []);
+
+  // Fetch tier labels and resolve for the agent's provider
+  useEffect(() => {
+    if (!agent) return;
+    const providerKey = agent.provider_override || activeProvider;
+    if (!providerKey) return;
+    api<{ tier_labels: Record<string, Record<string, string>> }>('/api/providers/tiers')
+      .then(d => setTierLabels(d.tier_labels[providerKey] || {}))
+      .catch(() => {});
+  }, [agent, activeProvider]);
+
+  // Load model_tier from agent data
+  useEffect(() => {
+    if (agent?.model_tier) setModelTier(agent.model_tier as ModelTier);
+  }, [agent]);
+
+  const handleSwitchTier = useCallback(async (tier: ModelTier) => {
+    if (!agentId) return;
+    const prev = modelTier;
+    setModelTier(tier);
+    try {
+      await api(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ model_tier: tier }),
+      });
+    } catch {
+      setModelTier(prev);
+    }
+  }, [agentId, modelTier]);
 
   const handleSwitchModel = useCallback(async (model: string) => {
     if (!activeProvider) return;
@@ -614,6 +647,9 @@ export function AgentPage() {
               activeProvider={activeProvider}
               activeModel={activeModel}
               onSwitchModel={handleSwitchModel}
+              modelTier={modelTier}
+              tierLabels={tierLabels}
+              onSwitchTier={handleSwitchTier}
               agentName={agent.agent_name}
               agentSlug={agent.slug}
               conversationSource={convs.conversations.find(c => c.id === convs.activeId)?.source}

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -73,7 +73,6 @@ export function AgentPage() {
   const [openaiAvailable, setOpenaiAvailable] = useState(false);
   const [alwaysPowerMode, setAlwaysPowerMode] = useState(false);
   const [activeProvider, setActiveProvider] = useState('');
-  const [activeModel, setActiveModel] = useState('');
   const [modelTier, setModelTier] = useState<ModelTier>('auto');
   const [tierLabels, setTierLabels] = useState<Record<string, string>>({});
   const isMobile = useIsMobile();
@@ -109,7 +108,10 @@ export function AgentPage() {
     if (!agentId) return;
     localStorage.setItem('chatty_last_agent', agentId);
     api<AgentRow>(`/api/agents/${agentId}`)
-      .then(setAgent)
+      .then(a => {
+        setAgent(a);
+        if (a.model_tier) setModelTier(a.model_tier as ModelTier);
+      })
       .catch(() => navigate('/'));
   }, [agentId, navigate]);
 
@@ -122,7 +124,7 @@ export function AgentPage() {
 
   useEffect(() => {
     api<ProviderStatus>('/api/providers')
-      .then(p => { setActiveProvider(p.active_provider); setActiveModel(p.active_model); })
+      .then(p => { setActiveProvider(p.active_provider); })
       .catch(() => {});
   }, []);
 
@@ -136,10 +138,6 @@ export function AgentPage() {
       .catch(() => {});
   }, [agent, activeProvider]);
 
-  // Load model_tier from agent data
-  useEffect(() => {
-    if (agent?.model_tier) setModelTier(agent.model_tier as ModelTier);
-  }, [agent]);
 
   const handleSwitchTier = useCallback(async (tier: ModelTier) => {
     if (!agentId) return;
@@ -154,21 +152,6 @@ export function AgentPage() {
       setModelTier(prev);
     }
   }, [agentId, modelTier]);
-
-  const handleSwitchModel = useCallback(async (model: string) => {
-    if (!activeProvider) return;
-    const prev = activeModel;
-    setActiveModel(model);
-    try {
-      await api('/api/providers/active', {
-        method: 'PUT',
-        body: JSON.stringify({ provider: activeProvider, model }),
-      });
-    } catch (e) {
-      setActiveModel(prev);
-      alert(`Failed to switch model: ${e instanceof Error ? e.message : 'unknown error'}`);
-    }
-  }, [activeProvider, activeModel]);
 
   useEffect(() => {
     api<{ always_power_mode: boolean }>('/api/setup/admin-settings')
@@ -644,9 +627,6 @@ export function AgentPage() {
               toolMode={chat.toolMode}
               onToolModeChange={handleToolModeChange}
               alwaysPowerMode={alwaysPowerMode}
-              activeProvider={activeProvider}
-              activeModel={activeModel}
-              onSwitchModel={handleSwitchModel}
               modelTier={modelTier}
               tierLabels={tierLabels}
               onSwitchTier={handleSwitchTier}

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { api } from '../core/api/client';
+import type { ProviderStatus } from '../core/types';
 import { useAgentChat, type ToolMode } from './hooks/useAgentChat';
 import { useConversations } from './hooks/useConversations';
 import { useScrollDirection } from './hooks/useScrollDirection';
@@ -69,6 +70,8 @@ export function AgentPage() {
   const [showSidebar, setShowSidebar] = useState(false);
   const [openaiAvailable, setOpenaiAvailable] = useState(false);
   const [alwaysPowerMode, setAlwaysPowerMode] = useState(false);
+  const [activeProvider, setActiveProvider] = useState('');
+  const [activeModel, setActiveModel] = useState('');
   const isMobile = useIsMobile();
   const prevOnboardingComplete = useRef<boolean | null>(null);
 
@@ -112,6 +115,27 @@ export function AgentPage() {
       .then(d => setOpenaiAvailable(d.generate_available))
       .catch(() => {});
   }, [agentId]);
+
+  useEffect(() => {
+    api<ProviderStatus>('/api/providers')
+      .then(p => { setActiveProvider(p.active_provider); setActiveModel(p.active_model); })
+      .catch(() => {});
+  }, []);
+
+  const handleSwitchModel = useCallback(async (model: string) => {
+    if (!activeProvider) return;
+    const prev = activeModel;
+    setActiveModel(model);
+    try {
+      await api('/api/providers/active', {
+        method: 'PUT',
+        body: JSON.stringify({ provider: activeProvider, model }),
+      });
+    } catch (e) {
+      setActiveModel(prev);
+      alert(`Failed to switch model: ${e instanceof Error ? e.message : 'unknown error'}`);
+    }
+  }, [activeProvider, activeModel]);
 
   useEffect(() => {
     api<{ always_power_mode: boolean }>('/api/setup/admin-settings')
@@ -587,6 +611,9 @@ export function AgentPage() {
               toolMode={chat.toolMode}
               onToolModeChange={handleToolModeChange}
               alwaysPowerMode={alwaysPowerMode}
+              activeProvider={activeProvider}
+              activeModel={activeModel}
+              onSwitchModel={handleSwitchModel}
               agentName={agent.agent_name}
               agentSlug={agent.slug}
               conversationSource={convs.conversations.find(c => c.id === convs.activeId)?.source}

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -36,6 +36,9 @@ interface Props {
   importMode?: boolean;
   onCancelImport?: () => void;
   greetingPending?: boolean;
+  activeProvider?: string;
+  activeModel?: string;
+  onSwitchModel?: (model: string) => void;
 }
 
 const TOOL_MODES: { key: ToolMode; label: string }[] = [
@@ -44,11 +47,16 @@ const TOOL_MODES: { key: ToolMode; label: string }[] = [
   { key: 'power', label: 'Power' },
 ];
 
+const ANTHROPIC_MODEL_TABS: { id: string; label: string }[] = [
+  { id: 'claude-opus-4-6', label: 'Opus' },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet' },
+];
+
 export function AgentChatPanel({
   messages, isStreaming, onSend, onStop, onApprove, onDeny,
   onApprovePlan, onIteratePlan, scrollRef: externalScrollRef,
   contextUsage, toolMode, onToolModeChange, alwaysPowerMode, agentName, agentSlug, conversationSource, importMode, onCancelImport,
-  greetingPending,
+  greetingPending, activeProvider, activeModel, onSwitchModel,
 }: Props) {
   const [input, setInput] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -263,6 +271,38 @@ export function AgentChatPanel({
                       {m.label}
                     </div>
                   ))}
+                </div>
+              )}
+
+              {/* Anthropic model switcher (Opus / Sonnet) */}
+              {activeProvider === 'anthropic' && onSwitchModel && (
+                <div
+                  title="Switch Anthropic model"
+                  style={{
+                    display: 'flex', border: '1px solid rgba(230,235,242,0.07)',
+                    borderRadius: 3, overflow: 'hidden',
+                    opacity: isStreaming ? 0.5 : 1,
+                  }}
+                >
+                  {ANTHROPIC_MODEL_TABS.map(m => {
+                    const isActive = activeModel === m.id;
+                    return (
+                      <div
+                        key={m.id}
+                        onClick={() => !isStreaming && !isActive && onSwitchModel(m.id)}
+                        style={{
+                          padding: '3px 10px',
+                          fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                          fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase',
+                          color: isActive ? '#0E1013' : 'rgba(237,240,244,0.62)',
+                          background: isActive ? 'var(--color-ch-accent, #C8D1D9)' : 'transparent',
+                          cursor: isStreaming || isActive ? 'default' : 'pointer',
+                        }}
+                      >
+                        {m.label}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, type RefObject, type KeyboardEvent, type DragEvent, type MouseEvent } from 'react';
-import type { ChatMessage, ContextUsage, ToolMode } from '../hooks/useAgentChat';
+import type { ChatMessage, ContextUsage, ToolMode, ModelTier } from '../hooks/useAgentChat';
 import type { AgentAlert } from '../../core/types';
 import { AgentMessageBubble } from './AgentMessageBubble';
 import AlertBanner from './AlertBanner';
@@ -39,6 +39,9 @@ interface Props {
   activeProvider?: string;
   activeModel?: string;
   onSwitchModel?: (model: string) => void;
+  modelTier?: ModelTier;
+  tierLabels?: Record<string, string>;
+  onSwitchTier?: (tier: ModelTier) => void;
 }
 
 const TOOL_MODES: { key: ToolMode; label: string }[] = [
@@ -47,16 +50,14 @@ const TOOL_MODES: { key: ToolMode; label: string }[] = [
   { key: 'power', label: 'Power' },
 ];
 
-const ANTHROPIC_MODEL_TABS: { id: string; label: string }[] = [
-  { id: 'claude-opus-4-6', label: 'Opus' },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet' },
-];
+const TIER_KEYS: ModelTier[] = ['auto', 'top', 'mid', 'light'];
 
 export function AgentChatPanel({
   messages, isStreaming, onSend, onStop, onApprove, onDeny,
   onApprovePlan, onIteratePlan, scrollRef: externalScrollRef,
   contextUsage, toolMode, onToolModeChange, alwaysPowerMode, agentName, agentSlug, conversationSource, importMode, onCancelImport,
   greetingPending, activeProvider, activeModel, onSwitchModel,
+  modelTier, tierLabels, onSwitchTier,
 }: Props) {
   const [input, setInput] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -274,22 +275,23 @@ export function AgentChatPanel({
                 </div>
               )}
 
-              {/* Anthropic model switcher (Opus / Sonnet) */}
-              {activeProvider === 'anthropic' && onSwitchModel && (
+              {/* Model tier toggle */}
+              {tierLabels && Object.keys(tierLabels).length > 0 && onSwitchTier && !isMobile && (
                 <div
-                  title="Switch Anthropic model"
+                  title="Model tier"
                   style={{
                     display: 'flex', border: '1px solid rgba(230,235,242,0.07)',
                     borderRadius: 3, overflow: 'hidden',
                     opacity: isStreaming ? 0.5 : 1,
                   }}
                 >
-                  {ANTHROPIC_MODEL_TABS.map(m => {
-                    const isActive = activeModel === m.id;
+                  {TIER_KEYS.map(tier => {
+                    const isActive = modelTier === tier;
+                    const label = tier === 'auto' ? 'Auto' : tierLabels[tier] || tier;
                     return (
                       <div
-                        key={m.id}
-                        onClick={() => !isStreaming && !isActive && onSwitchModel(m.id)}
+                        key={tier}
+                        onClick={() => !isStreaming && !isActive && onSwitchTier(tier)}
                         style={{
                           padding: '3px 10px',
                           fontFamily: "'JetBrains Mono', ui-monospace, monospace",
@@ -299,11 +301,34 @@ export function AgentChatPanel({
                           cursor: isStreaming || isActive ? 'default' : 'pointer',
                         }}
                       >
-                        {m.label}
+                        {label}
                       </div>
                     );
                   })}
                 </div>
+              )}
+              {/* Mobile tier dropdown */}
+              {tierLabels && Object.keys(tierLabels).length > 0 && onSwitchTier && isMobile && (
+                <select
+                  value={modelTier}
+                  onChange={e => !isStreaming && onSwitchTier(e.target.value as ModelTier)}
+                  disabled={isStreaming}
+                  style={{
+                    fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                    fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase',
+                    color: 'rgba(237,240,244,0.62)',
+                    background: 'transparent',
+                    border: '1px solid rgba(230,235,242,0.07)',
+                    borderRadius: 3, padding: '3px 6px',
+                    opacity: isStreaming ? 0.5 : 1,
+                  }}
+                >
+                  {TIER_KEYS.map(tier => (
+                    <option key={tier} value={tier}>
+                      {tier === 'auto' ? 'Auto' : tierLabels[tier] || tier}
+                    </option>
+                  ))}
+                </select>
               )}
             </div>
 
@@ -491,6 +516,7 @@ export function AgentChatPanel({
                   onApprovePlan={onApprovePlan}
                   onIteratePlan={onIteratePlan}
                   agentName={agentName}
+                  showModelBadge={modelTier === 'auto'}
                 />
               );
             })}

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -36,9 +36,6 @@ interface Props {
   importMode?: boolean;
   onCancelImport?: () => void;
   greetingPending?: boolean;
-  activeProvider?: string;
-  activeModel?: string;
-  onSwitchModel?: (model: string) => void;
   modelTier?: ModelTier;
   tierLabels?: Record<string, string>;
   onSwitchTier?: (tier: ModelTier) => void;
@@ -56,7 +53,7 @@ export function AgentChatPanel({
   messages, isStreaming, onSend, onStop, onApprove, onDeny,
   onApprovePlan, onIteratePlan, scrollRef: externalScrollRef,
   contextUsage, toolMode, onToolModeChange, alwaysPowerMode, agentName, agentSlug, conversationSource, importMode, onCancelImport,
-  greetingPending, activeProvider, activeModel, onSwitchModel,
+  greetingPending,
   modelTier, tierLabels, onSwitchTier,
 }: Props) {
   const [input, setInput] = useState('');

--- a/frontend/src/agent/components/AgentMessageBubble.tsx
+++ b/frontend/src/agent/components/AgentMessageBubble.tsx
@@ -13,6 +13,23 @@ interface Props {
   onApprovePlan?: (msgId: string) => void;
   onIteratePlan?: (msgId: string) => void;
   agentName?: string;
+  showModelBadge?: boolean;
+}
+
+const FRIENDLY_MODEL_NAMES: Record<string, string> = {
+  'claude-opus-4-6': 'Opus',
+  'claude-sonnet-4-6': 'Sonnet',
+  'claude-haiku-4-5-20251001': 'Haiku',
+  'gpt-5.4': 'GPT-5.4',
+  'gpt-5.4-mini': 'Mini',
+  'gpt-5.4-nano': 'Nano',
+  'gemini-2.5-pro': 'Pro',
+  'gemini-2.5-flash': 'Flash',
+  'gemini-2.0-flash-lite': 'Lite',
+};
+
+function friendlyModelName(model: string): string {
+  return FRIENDLY_MODEL_NAMES[model] || model.split('/').pop() || model;
 }
 
 const HUNG_THRESHOLD_SEC = 30;
@@ -296,7 +313,7 @@ function TypingDots() {
   );
 }
 
-function AgentMessageBubbleInner({ message, onApprove, onDeny, onApprovePlan, onIteratePlan, agentName }: Props) {
+function AgentMessageBubbleInner({ message, onApprove, onDeny, onApprovePlan, onIteratePlan, agentName, showModelBadge }: Props) {
   const isUser = message.role === 'user';
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const { copied, copy } = useCopyToClipboard();
@@ -365,12 +382,21 @@ function AgentMessageBubbleInner({ message, onApprove, onDeny, onApprovePlan, on
     <div style={{ display: 'flex', gap: 12 }}>
       <AgentMark letter={letter} size={30} />
       <div style={{ flex: 1, maxWidth: '85%' }}>
-        {/* Agent name + timestamp */}
+        {/* Agent name + model badge */}
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: 6 }}>
           <div style={{
             fontFamily: "'Fraunces', Georgia, serif",
             fontSize: 14, color: '#D4A85A',
           }}>{agentName || 'Agent'}</div>
+          {message.model && showModelBadge && (
+            <span style={{
+              fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+              fontSize: 9, letterSpacing: '0.1em',
+              color: 'rgba(237,240,244,0.3)',
+            }}>
+              via {friendlyModelName(message.model)}
+            </span>
+          )}
         </div>
 
         {/* Tool calls */}

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -72,6 +72,7 @@ export interface ChatMessage {
   pendingPlan?: PendingPlan;
   reports?: InlineReport[];
   model?: string;
+  tier?: string;
 }
 
 export interface ContextUsage {
@@ -327,8 +328,12 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
               options?.onTitleUpdate?.(event.conversation_id, event.title);
             } else if (event.type === 'done') {
               flushPendingText();
-              if (event.model) {
-                updateLastAssistant(last => ({ ...last, model: event.model }));
+              if (event.model || event.tier) {
+                updateLastAssistant(last => ({
+                  ...last,
+                  ...(event.model && { model: event.model }),
+                  ...(event.tier && { tier: event.tier }),
+                }));
               }
             } else if (event.type === 'error') {
               flushPendingText();

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -23,6 +23,7 @@ function uuid(): string {
 }
 
 export type ToolMode = 'read-only' | 'normal' | 'power';
+export type ModelTier = 'auto' | 'top' | 'mid' | 'light';
 export type TrainingType = 'topic' | 'improve' | null;
 
 export interface ToolCallInfo {
@@ -70,6 +71,7 @@ export interface ChatMessage {
   pendingConfirm?: PendingConfirmation;
   pendingPlan?: PendingPlan;
   reports?: InlineReport[];
+  model?: string;
 }
 
 export interface ContextUsage {
@@ -323,6 +325,11 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
               setConversationId(event.id);
             } else if (event.type === 'title_update' && event.title && event.conversation_id) {
               options?.onTitleUpdate?.(event.conversation_id, event.title);
+            } else if (event.type === 'done') {
+              flushPendingText();
+              if (event.model) {
+                updateLastAssistant(last => ({ ...last, model: event.model }));
+              }
             } else if (event.type === 'error') {
               flushPendingText();
               updateLastAssistant(last => ({

--- a/frontend/src/agent/hooks/useConversations.ts
+++ b/frontend/src/agent/hooks/useConversations.ts
@@ -44,7 +44,7 @@ export function useConversations(apiPrefix: string) {
     try {
       const data = await api<{
         id: string; title: string;
-        messages: { id: string; role: string; content: string; seq: number; tool_calls?: string }[];
+        messages: { id: string; role: string; content: string; seq: number; tool_calls?: string; model?: string }[];
       }>(`${apiPrefix}/conversations/${id}`);
       setActiveId(id);
       return data.messages.map(m => {
@@ -53,6 +53,7 @@ export function useConversations(apiPrefix: string) {
           role: m.role as 'user' | 'assistant',
           content: m.content,
           timestamp: Date.now(),
+          model: m.model,
         };
         if (m.tool_calls) {
           try {

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -238,5 +238,5 @@ export type SSEEvent =
   | { type: 'usage'; input_tokens: number; context_window: number }
   | { type: 'report'; report: { id: string; title: string; subtitle?: string; sections: unknown[]; created_at: string } }
   | { type: 'title_update'; title: string; conversation_id: string }
-  | { type: 'done' }
+  | { type: 'done'; model?: string; tier?: string }
   | { type: 'error'; error: string };


### PR DESCRIPTION
## Summary

- **4-position tier toggle** (Auto / Top / Mid / Light) in the chat composer, replacing the prototype Opus/Sonnet switcher. Desktop renders pills, mobile renders a dropdown. Labels update per-provider (Opus/Sonnet/Haiku, GPT-5.4/Mini/Nano, Pro/Flash/Lite, etc.)
- **Auto-triage classifier** routes messages to the right model tier using each provider's cheapest model (Haiku, GPT-5.4-nano, Flash Lite). Heuristic fast-path for greetings/acks skips the API call entirely. Upward-only per-conversation cache prevents downgrade mid-conversation. Works for Anthropic, OpenAI, and Google; Together/Ollama default to top.
- **"via Model" badge** on assistant messages in Auto mode shows which model was actually used (e.g., "via Opus", "via Haiku"). Persists in chat history via new `model` column on messages table.
- **Per-agent persistence** — `model_tier` column on agents table, wired through all call sites (web chat, CLI, Telegram, WhatsApp, Paperclip, background runner, scheduled actions). Resolution precedence: model_override > model_tier > global active_model.

## Test plan

- [ ] Auto mode: send "hi" → badge shows cheapest model; send complex question → badge shows top model
- [ ] Manual tiers: switch to each tier, verify correct model used (check backend logs)
- [ ] Provider switching: change provider in settings, verify tier labels update correctly
- [ ] Mobile: verify toggle collapses to dropdown on narrow viewports
- [ ] Per-agent persistence: set agent A to "mid", switch to agent B, switch back — agent A should still be "mid"
- [ ] Streaming: verify toggle is disabled during streaming and re-enables after
- [ ] Badge persistence: reload page, verify badges survive on historical messages
- [ ] Together AI: Auto mode silently uses top (no classifier call)