### PR TITLE
Add global heartbeat triage mode setting with cheap model support

### DIFF
--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -31,6 +31,12 @@ _AGENT_TURN_ERRORS = frozenset({
     "(max iterations reached)",
 })
 
+TRIAGE_MODELS = {
+    "anthropic": "claude-haiku-4-5-20251001",
+    "openai": "gpt-5.4-nano",
+    "google": "gemini-2.0-flash-lite",
+}
+
 # -- In-flight tracking --------------------------------------------------
 _in_flight_count = 0
 _in_flight_agents: set[str] = set()
@@ -313,6 +319,20 @@ def _process_action(action: dict) -> None:
         _mark_and_alert(action, "skipped", f"unknown action_type: {action_type}", 0, lease_id=action.get("lease_id"), agent_slug=action["agent"])
 
 
+def _resolve_triage_provider(agent: dict) -> str:
+    """Return provider type for triage model lookup, or '' if cheap triage is not applicable."""
+    from core.providers.credentials import CredentialStore
+    store = CredentialStore()
+    profile_name, profile = store.get_active_profile(
+        provider_override=agent.get("provider_override") or None
+    )
+    if not profile:
+        return ""
+    if profile.get("type") == "chatgpt_oauth":
+        return ""
+    return profile_name.split(":", 1)[0]
+
+
 def _resolve_agent(agent_slug: str) -> dict | None:
     """Resolve agent row from DB."""
     from agents import db as agent_db
@@ -374,7 +394,24 @@ def _process_heartbeat(action: dict) -> None:
     start_time = time.monotonic()
     try:
         triage_data = None
-        if action.get("triage_enabled", 1):
+
+        from setup.router import load_admin_settings
+        admin = load_admin_settings()
+        triage_mode = admin.get("triage_mode", "always_cheap")
+
+        triage_model_override = model_override
+        cheap_model = None
+        if triage_mode in ("cheap", "always_cheap"):
+            cheap_model = TRIAGE_MODELS.get(_resolve_triage_provider(agent))
+            if cheap_model:
+                triage_model_override = cheap_model
+
+        if triage_mode == "always_cheap" and cheap_model:
+            do_triage = True
+        else:
+            do_triage = bool(action.get("triage_enabled", 1))
+
+        if do_triage:
             triage_result = run_background_turn(
                 system_prompt=(
                     f"You are {agent['agent_name']}.\n\n"
@@ -391,7 +428,7 @@ def _process_heartbeat(action: dict) -> None:
                 registry=registry,
                 max_iterations=2,
                 provider_override=provider_override,
-                model_override=model_override,
+                model_override=triage_model_override,
                 on_iteration=on_iteration,
             )
 

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -31,9 +31,9 @@ _AGENT_TURN_ERRORS = frozenset({
     "(max iterations reached)",
 })
 
-TRIAGE_MODELS = {
+_TRIAGE_MODELS = {
     "anthropic": "claude-haiku-4-5-20251001",
-    "openai": "gpt-5.4-nano",
+    "openai": "gpt-4.1-nano",
     "google": "gemini-2.0-flash-lite",
 }
 
@@ -397,12 +397,12 @@ def _process_heartbeat(action: dict) -> None:
 
         from setup.router import load_admin_settings
         admin = load_admin_settings()
-        triage_mode = admin.get("triage_mode", "always_cheap")
+        triage_mode = admin["triage_mode"]
 
         triage_model_override = model_override
         cheap_model = None
         if triage_mode in ("cheap", "always_cheap"):
-            cheap_model = TRIAGE_MODELS.get(_resolve_triage_provider(agent))
+            cheap_model = _TRIAGE_MODELS.get(_resolve_triage_provider(agent))
             if cheap_model:
                 triage_model_override = cheap_model
 

--- a/backend/setup/router.py
+++ b/backend/setup/router.py
@@ -112,8 +112,9 @@ async def update_admin_settings(body: dict, user=Depends(get_current_user)):
     for key in ADMIN_DEFAULTS:
         if key in body:
             settings[key] = body[key]
+    if "always_power_mode" in settings:
+        settings["always_power_mode"] = bool(settings["always_power_mode"])
     if not isinstance(settings.get("triage_mode"), str) or settings["triage_mode"] not in VALID_TRIAGE_MODES:
-        prev = load_admin_settings()
-        settings["triage_mode"] = prev.get("triage_mode", ADMIN_DEFAULTS["triage_mode"])
+        settings["triage_mode"] = ADMIN_DEFAULTS["triage_mode"]
     atomic_write_json(ADMIN_SETTINGS_FILE, settings)
     return settings

--- a/backend/setup/router.py
+++ b/backend/setup/router.py
@@ -24,13 +24,19 @@ ADMIN_SETTINGS_FILE = Path(__file__).resolve().parent.parent / "data" / "admin-s
 
 ADMIN_DEFAULTS = {
     "always_power_mode": False,
+    "triage_mode": "always_cheap",
 }
+
+VALID_TRIAGE_MODES = {"standard", "cheap", "always_cheap"}
 
 
 def load_admin_settings() -> dict:
     if ADMIN_SETTINGS_FILE.exists():
         try:
-            return {**ADMIN_DEFAULTS, **json.loads(ADMIN_SETTINGS_FILE.read_text(encoding="utf-8"))}
+            result = {**ADMIN_DEFAULTS, **json.loads(ADMIN_SETTINGS_FILE.read_text(encoding="utf-8"))}
+            if not isinstance(result.get("triage_mode"), str) or result["triage_mode"] not in VALID_TRIAGE_MODES:
+                result["triage_mode"] = ADMIN_DEFAULTS["triage_mode"]
+            return result
         except Exception:
             pass
     return dict(ADMIN_DEFAULTS)
@@ -106,5 +112,8 @@ async def update_admin_settings(body: dict, user=Depends(get_current_user)):
     for key in ADMIN_DEFAULTS:
         if key in body:
             settings[key] = body[key]
+    if not isinstance(settings.get("triage_mode"), str) or settings["triage_mode"] not in VALID_TRIAGE_MODES:
+        prev = load_admin_settings()
+        settings["triage_mode"] = prev.get("triage_mode", ADMIN_DEFAULTS["triage_mode"])
     atomic_write_json(ADMIN_SETTINGS_FILE, settings)
     return settings

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -302,11 +302,16 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
                   value={triageMode}
                   onChange={async (e) => {
                     const next = e.target.value;
+                    const prev = triageMode;
                     setTriageMode(next);
-                    await api('/api/setup/admin-settings', {
-                      method: 'PUT',
-                      body: JSON.stringify({ triage_mode: next }),
-                    });
+                    try {
+                      await api('/api/setup/admin-settings', {
+                        method: 'PUT',
+                        body: JSON.stringify({ triage_mode: next }),
+                      });
+                    } catch {
+                      setTriageMode(prev);
+                    }
                   }}
                   style={{
                     background: 'rgba(230,235,242,0.08)',

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -38,11 +38,15 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
     localStorage.getItem('chatty_show_tool_calls') === 'true'
   );
   const [alwaysPowerMode, setAlwaysPowerMode] = useState(false);
+  const [triageMode, setTriageMode] = useState<string>('always_cheap');
 
   useEffect(() => {
     if (tab === 'chat') {
-      api<{ always_power_mode: boolean }>('/api/setup/admin-settings')
-        .then(s => setAlwaysPowerMode(s.always_power_mode))
+      api<{ always_power_mode: boolean; triage_mode: string }>('/api/setup/admin-settings')
+        .then(s => {
+          setAlwaysPowerMode(s.always_power_mode);
+          setTriageMode(s.triage_mode);
+        })
         .catch(() => {});
     }
   }, [tab]);
@@ -283,6 +287,42 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
                     left: alwaysPowerMode ? 22 : 2,
                   }} />
                 </button>
+              </div>
+
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <div>
+                  <p style={{ fontSize: 14, color: '#EDF0F4', margin: 0 }}>Heartbeat triage</p>
+                  <p style={{ fontSize: 12, color: 'rgba(237,240,244,0.38)', marginTop: 2 }}>
+                    {triageMode === 'standard' && 'Uses agent model for triage'}
+                    {triageMode === 'cheap' && 'Uses cheaper triage model when supported'}
+                    {triageMode === 'always_cheap' && 'Forces triage on with cheapest model (supported providers)'}
+                  </p>
+                </div>
+                <select
+                  value={triageMode}
+                  onChange={async (e) => {
+                    const next = e.target.value;
+                    setTriageMode(next);
+                    await api('/api/setup/admin-settings', {
+                      method: 'PUT',
+                      body: JSON.stringify({ triage_mode: next }),
+                    });
+                  }}
+                  style={{
+                    background: 'rgba(230,235,242,0.08)',
+                    border: '1px solid rgba(230,235,242,0.14)',
+                    color: '#EDF0F4',
+                    borderRadius: 4,
+                    padding: '6px 10px',
+                    fontSize: 13,
+                    outline: 'none',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <option value="standard">Standard</option>
+                  <option value="cheap">Cheap</option>
+                  <option value="always_cheap">Always Cheap</option>
+                </select>
               </div>
             </div>
           )}

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -329,6 +329,11 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
                   <option value="always_cheap">Always Cheap</option>
                 </select>
               </div>
+              {triageMode !== 'standard' && (
+                <p style={{ fontSize: 11, color: 'rgba(237,240,244,0.32)', margin: '4px 0 0' }}>
+                  Tip: Add an OpenAI API key for the best triage model (GPT-4.1 Nano)
+                </p>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- Adds a global **triage mode** setting (Standard / Cheap / Always Cheap) to control how heartbeat scheduled actions run triage passes
- **Cheap** mode swaps in a cheaper model (Haiku, GPT-4.1-nano, Gemini Flash Lite) for triage while respecting per-action triage flags
- **Always Cheap** forces triage on with the cheapest model regardless of per-action settings
- New dropdown in Settings > Chat panel, persisted to `admin-settings.json` with enum validation
- Includes review fixes: correct OpenAI model ID, private constant naming, redundant file read removal, `always_power_mode` type validation, UI error rollback on save failure

## Test plan

- [ ] Set triage mode to each option and verify heartbeat triage uses the correct model
- [ ] Verify unsupported providers (Ollama, Together AI) fall back gracefully
- [ ] Test settings panel dropdown persists and loads correctly on refresh
- [ ] Simulate API failure on settings save and verify dropdown rolls back