### PR TITLE
Fix OpenAI API key validation rejecting valid keys

### DIFF
--- a/backend/core/providers/openai_provider.py
+++ b/backend/core/providers/openai_provider.py
@@ -227,8 +227,9 @@ class OpenAIProvider(AIProvider):
     async def validate(self) -> bool:
         try:
             client = openai.OpenAI(**self._build_client_kwargs())
+            model = "gpt-4o-mini"
             client.chat.completions.create(
-                model="gpt-5.4-mini",
+                model=model,
                 messages=[{"role": "user", "content": "hi"}],
                 max_tokens=1,
             )


### PR DESCRIPTION
## Summary

- The `validate()` method in `OpenAIProvider` hardcoded `gpt-5.4-mini` with the `max_tokens` parameter, but newer OpenAI models require `max_completion_tokens` and return a 400 error for `max_tokens`
- The blanket `except` caught this API error and returned `False`, making valid API keys appear invalid
- Switched the validation model to `gpt-4o-mini` which supports `max_tokens` and is cheap/stable — only used for the one-token key check

## Test plan

- [ ] Enter a valid OpenAI API key in the setup wizard — should accept and save
- [ ] Enter an invalid/revoked key — should still reject with "Invalid API key"
- [ ] Verify chat works after key is accepted (streaming path already handled `max_completion_tokens` correctly)