### PR TITLE
Fix cron scheduled actions never sending Telegram notifications

### DIFF
--- a/backend/core/agents/scheduled_actions/notifications.py
+++ b/backend/core/agents/scheduled_actions/notifications.py
@@ -45,7 +45,7 @@ def evaluate_and_notify(
         agent=agent_slug,
         title=f"{action.get('name', 'check')}",
         message=result_summary[:500],
-        source="heartbeat" if not is_cron else "cron",
+        source="cron" if is_cron else "heartbeat",
         source_id=action["id"],
     )
 

--- a/backend/core/agents/scheduled_actions/notifications.py
+++ b/backend/core/agents/scheduled_actions/notifications.py
@@ -24,39 +24,52 @@ def evaluate_and_notify(
 ) -> bool:
     """Create in-app alert and optionally send external notification.
 
-    Returns True if an alert was created.
+    For heartbeats, only notifies on "action_taken".
+    For cron jobs, notifies on any successful completion ("ok" or "action_taken")
+    since the whole point of a cron job is to produce output.
+
+    Returns True if an external notification was actually sent.
     """
-    if status != "action_taken":
-        return False
+    action_type = action.get("action_type", "heartbeat")
+    is_cron = action_type == "cron"
+
+    if is_cron:
+        if status not in ("ok", "action_taken"):
+            return False
+    else:
+        if status != "action_taken":
+            return False
 
     from core.agents.alerts.service import create_alert
     create_alert(
         agent=agent_slug,
-        title=f"Heartbeat: {action.get('name', 'check')}",
+        title=f"{action.get('name', 'check')}",
         message=result_summary[:500],
-        source="heartbeat",
+        source="heartbeat" if not is_cron else "cron",
         source_id=action["id"],
     )
 
-    if action.get("notify_on_action"):
-        _send_external(agent_slug, action, result_summary)
+    if not action.get("notify_on_action"):
+        return False
 
-    return True
+    return _send_external(agent_slug, action, result_summary)
 
 
-def _send_external(agent_slug: str, action: dict, result_summary: str) -> None:
-    """Try Telegram first, then WhatsApp. Fire-and-forget."""
+def _send_external(agent_slug: str, action: dict, result_summary: str) -> bool:
+    """Try Telegram first, then WhatsApp. Returns True if any channel succeeded."""
     try:
-        if _try_telegram(agent_slug, result_summary):
-            return
-        if _try_whatsapp(agent_slug, result_summary):
-            return
+        if _try_telegram(agent_slug, result_summary, action=action):
+            return True
+        if _try_whatsapp(agent_slug, result_summary, action=action):
+            return True
         logger.debug("No external notification channel configured for %s", agent_slug)
+        return False
     except Exception as e:
         logger.warning("External notification failed for %s: %s", agent_slug, e)
+        return False
 
 
-def _try_telegram(agent_slug: str, message: str) -> bool:
+def _try_telegram(agent_slug: str, message: str, action: dict | None = None) -> bool:
     try:
         from agents.db import list_agents
         from integrations.telegram.client import send_message
@@ -69,7 +82,6 @@ def _try_telegram(agent_slug: str, message: str) -> bool:
 
         bot_token = agent["telegram_bot_token"]
 
-        # Find the registered Telegram user for this agent
         tg_conn = get_tg_db()
         row = tg_conn.execute(
             "SELECT platform_user_id FROM user_mappings WHERE agent_id = ? AND platform = 'telegram' LIMIT 1",
@@ -79,12 +91,19 @@ def _try_telegram(agent_slug: str, message: str) -> bool:
             return False
 
         chat_id = row["platform_user_id"]
-        text = f"[Heartbeat] {agent['agent_name']}:\n{message[:300]}"
+        action_type = (action or {}).get("action_type", "heartbeat")
+        action_name = (action or {}).get("name", "")
+
+        if action_type == "cron" and action_name:
+            text = f"**{action_name}**\n\n{message[:3500]}"
+        else:
+            text = f"[Heartbeat] {agent['agent_name']}:\n{message[:3500]}"
+
         send_message(chat_id, text, bot_token)
-        logger.info("Heartbeat notification sent via Telegram for %s", agent_slug)
+        logger.info("Notification sent via Telegram for %s (%s)", agent_slug, action_type)
         return True
     except Exception as e:
-        logger.debug("Telegram notification skipped for %s: %s", agent_slug, e)
+        logger.warning("Telegram notification failed for %s: %s", agent_slug, e)
         return False
 
 
@@ -134,7 +153,7 @@ def evaluate_failure_alert(
     return True
 
 
-def _try_whatsapp(agent_slug: str, message: str) -> bool:
+def _try_whatsapp(agent_slug: str, message: str, action: dict | None = None) -> bool:
     try:
         from agents.db import list_agents
         from integrations.whatsapp.client import send_message

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -669,6 +669,8 @@ def _process_cron(action: dict) -> None:
                 )
             return
 
+        notified = notifications.evaluate_and_notify(action, status, result.text[:2000], agent_slug)
+
         if completed and execution_id:
             history.record_complete(
                 execution_id, status=status,
@@ -679,8 +681,9 @@ def _process_cron(action: dict) -> None:
                 input_tokens=result.input_tokens,
                 output_tokens=result.output_tokens,
                 duration_ms=duration_ms,
+                notification_sent=notified,
             )
-        logger.info("Cron %s/%s: %s (%dms)", agent_slug, action["id"][:8], status, duration_ms)
+        logger.info("Cron %s/%s: %s (%dms, notified=%s)", agent_slug, action["id"][:8], status, duration_ms, notified)
     except Exception as e:
         duration_ms = int((time.monotonic() - start_time) * 1000)
         logger.error("Cron %s failed: %s", agent_slug, e)

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -669,7 +669,7 @@ def _process_cron(action: dict) -> None:
                 )
             return
 
-        notified = notifications.evaluate_and_notify(action, status, result.text[:2000], agent_slug)
+        notified = notifications.evaluate_and_notify(action, status, result.text[:3500], agent_slug)
 
         if completed and execution_id:
             history.record_complete(


### PR DESCRIPTION
## Summary

- **Cron jobs (Morning Brief, Email Scan) had zero notification pathway** — `_process_cron()` never called `evaluate_and_notify()`, so Telegram messages were never sent regardless of `notify_on_action` setting
- **Notification gating fixed for cron vs heartbeat** — heartbeats still only notify on `action_taken`, but cron jobs now notify on any successful completion (`ok`) since a successful cron run IS the action
- **Improved delivery tracking and logging** — `notification_sent` now reflects actual Telegram/WhatsApp delivery (not just alert creation), message limit raised from 300→3500 chars, failure logging upgraded from debug→warning

## Test plan

- [ ] Deploy to Railway and verify next Morning Brief (5:15 AM CT) arrives on Telegram
- [ ] Verify next Email Scan (6 PM CT) arrives on Telegram
- [ ] Verify heartbeat `action_taken` notifications still send correctly
- [ ] Verify heartbeat `ok` / triage results do NOT send notifications (no regression)
- [ ] Check Railway logs for `Notification sent via Telegram` on next cron run
- [ ] 262 backend tests pass