### PR TITLE
Add mark-all-emails-as-read Gmail tool

### DIFF
--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -613,6 +613,22 @@ GMAIL_WRITE_TOOLS = [
         "kind": "gmail",
         "writes": True,
     },
+    {
+        "name": "mark_all_emails_as_read",
+        "description": "Mark all unread emails as read in Gmail. Searches for all unread messages, paginates through results, and marks them as read in batches. Optionally accepts a query to narrow scope (e.g., 'from:newsletters@example.com'). The query is always combined with 'is:unread'. Safety cap of 5000 messages per invocation.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Optional Gmail search query to narrow which unread emails to mark as read. Examples: 'from:bob@example.com', 'older_than:7d', 'label:promotions'. Always combined with 'is:unread'. If omitted, marks ALL unread emails as read.",
+                },
+            },
+            "required": [],
+        },
+        "kind": "gmail",
+        "writes": True,
+    },
 ]
 
 GMAIL_ATTACHMENT_READ_TOOLS = [

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -24,6 +24,7 @@ from integrations.google.tools import (
     get_email,
     get_email_thread,
     batch_mark_emails_as_read,
+    mark_all_emails_as_read,
     mark_email_as_read,
     reply_to_email,
     reply_to_email_with_attachment,
@@ -71,7 +72,8 @@ class ToolRegistry:
     _WRITE_TOOLS = {
         "gmail": {"send_email", "reply_to_email", "create_draft",
                   "send_email_with_attachment", "reply_to_email_with_attachment",
-                  "mark_email_as_read", "batch_mark_emails_as_read"},
+                  "mark_email_as_read", "batch_mark_emails_as_read",
+                  "mark_all_emails_as_read"},
         "calendar": {"create_calendar_event", "update_calendar_event", "delete_calendar_event"},
         "drive": {"create_drive_folder", "create_drive_file", "move_drive_file",
                   "rename_drive_file", "copy_drive_file"},
@@ -342,6 +344,8 @@ class ToolRegistry:
             return mark_email_as_read(aid, message_id=args["message_id"])
         elif tool_name == "batch_mark_emails_as_read":
             return batch_mark_emails_as_read(aid, message_ids=args["message_ids"])
+        elif tool_name == "mark_all_emails_as_read":
+            return mark_all_emails_as_read(aid, query=args.get("query", ""))
         elif tool_name == "download_email_attachment":
             return download_email_attachment(
                 aid, message_id=args["message_id"], filename=args["filename"],

--- a/backend/integrations/google/gmail_ops.py
+++ b/backend/integrations/google/gmail_ops.py
@@ -187,6 +187,70 @@ def batch_mark_as_read_op(service, message_ids: list[str]) -> dict:
     return {"ok": True, "count": len(message_ids)}
 
 
+_BATCH_MODIFY_CHUNK = 1000
+
+
+def mark_all_as_read_op(service, query: str = "", max_messages: int = 5000) -> dict:
+    """Paginate all unread messages and batch-mark them as read."""
+    search_query = f"is:unread {query}".strip() if query else "is:unread"
+
+    message_ids: list[str] = []
+    page_token: str | None = None
+    capped = False
+
+    while True:
+        remaining = max_messages - len(message_ids)
+        if remaining <= 0:
+            capped = True
+            break
+        kwargs = {"userId": "me", "q": search_query, "maxResults": min(500, remaining)}
+        if page_token:
+            kwargs["pageToken"] = page_token
+        results = service.users().messages().list(**kwargs).execute()
+        batch = results.get("messages", [])
+        if not batch:
+            break
+        message_ids.extend(m["id"] for m in batch)
+        page_token = results.get("nextPageToken")
+        if not page_token:
+            break
+
+    if not message_ids:
+        return {"ok": True, "count": 0, "message": "No unread emails found"}
+
+    if len(message_ids) > max_messages:
+        message_ids = message_ids[:max_messages]
+        capped = True
+
+    marked = 0
+    for i in range(0, len(message_ids), _BATCH_MODIFY_CHUNK):
+        chunk = message_ids[i : i + _BATCH_MODIFY_CHUNK]
+        try:
+            service.users().messages().batchModify(
+                userId="me",
+                body={"ids": chunk, "removeLabelIds": ["UNREAD"]},
+            ).execute()
+            marked += len(chunk)
+        except Exception as exc:
+            if marked:
+                return {
+                    "ok": False,
+                    "error": f"Partial failure: marked {marked} of {len(message_ids)} emails as read before error: {exc}",
+                    "count": marked,
+                    "total": len(message_ids),
+                }
+            raise
+
+    result: dict = {"ok": True, "count": marked}
+    if capped:
+        result["capped"] = True
+        result["message"] = (
+            f"Marked {marked} emails as read (safety cap reached). "
+            "There may be more unread emails remaining."
+        )
+    return result
+
+
 def get_attachment_content_op(service, message_id: str, attachment_id: str) -> bytes:
     """Download attachment content from a Gmail message. Returns raw bytes."""
     result = service.users().messages().attachments().get(

--- a/backend/integrations/google/tools.py
+++ b/backend/integrations/google/tools.py
@@ -84,6 +84,11 @@ def batch_mark_emails_as_read(account_id: str, message_ids: list[str]) -> dict:
                  message_ids=message_ids)
 
 
+def mark_all_emails_as_read(account_id: str, query: str = "") -> dict:
+    return _wrap(account_id, get_gmail_service, gmail_ops.mark_all_as_read_op,
+                 query=query)
+
+
 def download_email_attachment(account_id: str, message_id: str, filename: str, cache_dir: str | None = None) -> dict:
     """Download an email attachment, extract text, and cache for forwarding."""
     import base64 as b64


### PR DESCRIPTION
## Summary
- New `mark_all_emails_as_read` Gmail tool that paginates all unread messages and batch-marks them as read in a single agent call
- Accepts an optional `query` parameter to narrow scope (e.g., `from:newsletters`, `older_than:7d`)
- Includes a 5,000-message safety cap and partial-failure tracking with error diagnostics

## Test plan
- [ ] Start backend dev server, connect a Gmail account
- [ ] Ask agent to "mark all my email as read" — confirm it calls the new tool and returns a count
- [ ] Test with a query: "mark all emails from newsletters as read"
- [ ] Verify tool only appears when `gmail_send_enabled=True`
- [ ] Verify multi-account routing selects a write-capable account