### PR TITLE
Surface unassigned Google services in agent system prompt

### DIFF
--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -271,29 +271,29 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
             + "\n".join(f"- {email}" for email in broken_emails)
         )
 
-    # Detect connected Google accounts not assigned to this agent
-    assigned_ids: set[str] = set()
-    for svc in ("gmail", "calendar", "drive"):
-        assigned_ids.update(google_accounts.get(svc, []))
+    # Detect connected Google accounts with services not assigned to this agent.
+    # Compare per-service so partially-assigned accounts still surface
+    # their unassigned services (e.g. assigned for Gmail but not Calendar).
     unassigned = []
     for aid, info in account_info_map.items():
-        if aid in assigned_ids:
-            continue
         if info.get("connection_status") == "broken":
             continue
         email = info.get("email", aid)
         grants = info.get("scope_grants", {})
-        services = [s.title() for s in ("gmail", "calendar", "drive") if grants.get(s, "none") != "none"]
-        if services:
-            unassigned.append(f"- {email} (has {', '.join(services)} access)")
+        missing_services = []
+        for svc in ("gmail", "calendar", "drive"):
+            has_grant = grants.get(svc, "none") != "none"
+            is_assigned = aid in google_accounts.get(svc, [])
+            if has_grant and not is_assigned:
+                missing_services.append(svc.title())
+        if missing_services:
+            unassigned.append(f"- {email} ({', '.join(missing_services)} not assigned to you)")
     if unassigned:
         parts.append(
-            "## Google Accounts Not Assigned to You\n\n"
-            "The following Google accounts are connected but have NOT been assigned to you, "
-            "so you cannot use their Gmail, Calendar, or Drive tools yet. "
-            "If the user asks you to do something that requires Google access and you don't "
-            "have any assigned accounts, let them know about these unassigned accounts and "
-            "tell them how to fix it:\n\n"
+            "## Google Services Not Assigned to You\n\n"
+            "The following Google services are connected but not assigned to you. "
+            "If the user asks you to do something that requires a Google service you don't "
+            "have assigned, let them know it's available and how to assign it:\n\n"
             "**How to assign:** Go to Settings (gear icon) → Integrations tab → "
             "scroll down to the Google card → under \"Agent Assignments\" check the boxes "
             "next to your name for each service (Gmail, Calendar, Drive) they want you to have.\n\n"

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -271,6 +271,35 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
             + "\n".join(f"- {email}" for email in broken_emails)
         )
 
+    # Detect connected Google accounts not assigned to this agent
+    assigned_ids: set[str] = set()
+    for svc in ("gmail", "calendar", "drive"):
+        assigned_ids.update(google_accounts.get(svc, []))
+    unassigned = []
+    for aid, info in account_info_map.items():
+        if aid in assigned_ids:
+            continue
+        if info.get("connection_status") == "broken":
+            continue
+        email = info.get("email", aid)
+        grants = info.get("scope_grants", {})
+        services = [s.title() for s in ("gmail", "calendar", "drive") if grants.get(s, "none") != "none"]
+        if services:
+            unassigned.append(f"- {email} (has {', '.join(services)} access)")
+    if unassigned:
+        parts.append(
+            "## Google Accounts Not Assigned to You\n\n"
+            "The following Google accounts are connected but have NOT been assigned to you, "
+            "so you cannot use their Gmail, Calendar, or Drive tools yet. "
+            "If the user asks you to do something that requires Google access and you don't "
+            "have any assigned accounts, let them know about these unassigned accounts and "
+            "tell them how to fix it:\n\n"
+            "**How to assign:** Go to Settings (gear icon) → Integrations tab → "
+            "scroll down to the Google card → under \"Agent Assignments\" check the boxes "
+            "next to your name for each service (Gmail, Calendar, Drive) they want you to have.\n\n"
+            + "\n".join(unassigned)
+        )
+
     return "\n\n".join(parts)
 
 

--- a/backend/tests/test_google_accounts_context.py
+++ b/backend/tests/test_google_accounts_context.py
@@ -1,0 +1,64 @@
+"""Tests for _google_accounts_context system prompt builder."""
+
+from core.agents.ai_service import _google_accounts_context
+
+
+def _make_info(email, *, status="ok", gmail="send", calendar="full", drive="full"):
+    return {
+        "email": email,
+        "connection_status": status,
+        "scope_grants": {"gmail": gmail, "calendar": calendar, "drive": drive},
+    }
+
+
+class TestUnassignedAccounts:
+    def test_fully_unassigned_account_listed(self):
+        info_map = {"a1": _make_info("alice@example.com")}
+        result = _google_accounts_context(info_map, {})
+        assert "alice@example.com" in result
+        assert "Gmail, Calendar, Drive not assigned" in result
+
+    def test_fully_assigned_account_not_listed(self):
+        info_map = {"a1": _make_info("alice@example.com")}
+        ga = {"gmail": ["a1"], "calendar": ["a1"], "drive": ["a1"]}
+        result = _google_accounts_context(info_map, ga)
+        assert "Not Assigned" not in result
+
+    def test_partially_assigned_shows_missing_services(self):
+        info_map = {"a1": _make_info("alice@example.com")}
+        ga = {"gmail": ["a1"], "calendar": [], "drive": []}
+        result = _google_accounts_context(info_map, ga)
+        assert "Calendar, Drive not assigned" in result
+        alice_line = [l for l in result.splitlines() if "alice@example.com" in l][0]
+        assert "Gmail" not in alice_line
+
+    def test_broken_account_excluded(self):
+        info_map = {"a1": _make_info("broken@example.com", status="broken")}
+        result = _google_accounts_context(info_map, {})
+        assert "Not Assigned" not in result
+
+    def test_account_with_no_grants_excluded(self):
+        info_map = {"a1": _make_info("none@example.com", gmail="none", calendar="none", drive="none")}
+        result = _google_accounts_context(info_map, {})
+        assert "Not Assigned" not in result
+
+    def test_includes_assignment_instructions(self):
+        info_map = {"a1": _make_info("alice@example.com")}
+        result = _google_accounts_context(info_map, {})
+        assert "Settings (gear icon)" in result
+        assert "Integrations tab" in result
+        assert "Agent Assignments" in result
+
+    def test_mixed_assigned_and_unassigned(self):
+        info_map = {
+            "a1": _make_info("alice@example.com"),
+            "a2": _make_info("bob@example.com"),
+        }
+        ga = {"gmail": ["a1"], "calendar": ["a1"], "drive": ["a1"]}
+        result = _google_accounts_context(info_map, ga)
+        assert "alice@example.com" not in result
+        assert "bob@example.com" in result
+
+    def test_empty_account_info_map(self):
+        result = _google_accounts_context({}, {})
+        assert result == ""


### PR DESCRIPTION
## Summary

- When a Google account is connected but not assigned to an agent, the agent's system prompt now includes a section listing the unassigned services (Gmail, Calendar, Drive) with instructions for the user on how to assign them
- Compares per-service rather than per-account, so partially-assigned accounts (e.g. Gmail assigned but not Calendar) still surface the gap
- Fixes the confusing scenario where Google shows "connected" in integrations but agents can't use it because the account was never assigned after connecting

## Test plan

- [ ] 8 new unit tests covering: fully unassigned, fully assigned, partially assigned, broken excluded, no-grant excluded, mixed accounts, empty map, instruction text
- [ ] Full test suite passes (270 tests)
- [ ] Codex review passed (2 rounds, all findings addressed)
- [ ] Deploy and verify: connect a Google account without assigning it to an agent, then ask the agent to check email — it should tell the user about the unassigned account and how to fix it