### PR TITLE
Add global default model tier setting

### DIFF
--- a/backend/agents/engine.py
+++ b/backend/agents/engine.py
@@ -63,7 +63,7 @@ def build_agent_config(agent_row: dict) -> AgentConfig:
 
     google_accounts = agent_row.get("google_accounts") or {}
 
-    return AgentConfig(
+    config = AgentConfig(
         agent_id=agent_row["id"],
         agent_name=agent_row["agent_name"],
         slug=slug,
@@ -84,6 +84,14 @@ def build_agent_config(agent_row: dict) -> AgentConfig:
         onboarding_complete=bool(agent_row.get("onboarding_complete", 0)),
         training_topics=topics,
     )
+
+    if not config.model_override:
+        from setup.router import load_admin_settings
+        global_tier = load_admin_settings().get("default_model_tier", "auto")
+        if global_tier != "auto":
+            config.model_tier = global_tier
+
+    return config
 
 
 def get_context_manager(slug: str) -> ContextManager:

--- a/backend/core/agents/reminders/heartbeat.py
+++ b/backend/core/agents/reminders/heartbeat.py
@@ -170,6 +170,7 @@ def _process_self_reminder(reminder: dict) -> None:
             tool_defs=tool_defs,
             registry=registry,
             max_iterations=_MAX_TOOL_ITERATIONS,
+            model_tier=config.model_tier,
         )
         service.mark_fired(reminder["id"], f"processed: {result.text[:500]}")
         _schedule_next_if_recurring(reminder)

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -524,6 +524,7 @@ def _process_heartbeat(action: dict) -> None:
             provider_override=provider_override,
             model_override=model_override,
             on_iteration=on_iteration,
+            model_tier=_cfg.model_tier,
         )
         duration_ms = int((time.monotonic() - start_time) * 1000)
 
@@ -645,6 +646,7 @@ def _process_cron(action: dict) -> None:
             provider_override=provider_override,
             model_override=model_override,
             on_iteration=on_iteration,
+            model_tier=_cfg2.model_tier,
         )
         duration_ms = int((time.monotonic() - start_time) * 1000)
 

--- a/backend/setup/router.py
+++ b/backend/setup/router.py
@@ -25,9 +25,11 @@ ADMIN_SETTINGS_FILE = Path(__file__).resolve().parent.parent / "data" / "admin-s
 ADMIN_DEFAULTS = {
     "always_power_mode": False,
     "triage_mode": "always_cheap",
+    "default_model_tier": "auto",
 }
 
 VALID_TRIAGE_MODES = {"standard", "cheap", "always_cheap"}
+VALID_MODEL_TIERS = {"auto", "top", "mid", "light"}
 
 
 def load_admin_settings() -> dict:
@@ -36,6 +38,8 @@ def load_admin_settings() -> dict:
             result = {**ADMIN_DEFAULTS, **json.loads(ADMIN_SETTINGS_FILE.read_text(encoding="utf-8"))}
             if not isinstance(result.get("triage_mode"), str) or result["triage_mode"] not in VALID_TRIAGE_MODES:
                 result["triage_mode"] = ADMIN_DEFAULTS["triage_mode"]
+            if not isinstance(result.get("default_model_tier"), str) or result["default_model_tier"] not in VALID_MODEL_TIERS:
+                result["default_model_tier"] = ADMIN_DEFAULTS["default_model_tier"]
             return result
         except Exception:
             pass
@@ -116,5 +120,7 @@ async def update_admin_settings(body: dict, user=Depends(get_current_user)):
         settings["always_power_mode"] = bool(settings["always_power_mode"])
     if not isinstance(settings.get("triage_mode"), str) or settings["triage_mode"] not in VALID_TRIAGE_MODES:
         settings["triage_mode"] = ADMIN_DEFAULTS["triage_mode"]
+    if not isinstance(settings.get("default_model_tier"), str) or settings["default_model_tier"] not in VALID_MODEL_TIERS:
+        settings["default_model_tier"] = ADMIN_DEFAULTS["default_model_tier"]
     atomic_write_json(ADMIN_SETTINGS_FILE, settings)
     return settings

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -75,6 +75,7 @@ export function AgentPage() {
   const [activeProvider, setActiveProvider] = useState('');
   const [modelTier, setModelTier] = useState<ModelTier>('auto');
   const [tierLabels, setTierLabels] = useState<Record<string, string>>({});
+  const [globalModelTier, setGlobalModelTier] = useState<ModelTier>('auto');
   const isMobile = useIsMobile();
   const prevOnboardingComplete = useRef<boolean | null>(null);
 
@@ -154,10 +155,11 @@ export function AgentPage() {
   }, [agentId, modelTier]);
 
   useEffect(() => {
-    api<{ always_power_mode: boolean }>('/api/setup/admin-settings')
+    api<{ always_power_mode: boolean; default_model_tier: string }>('/api/setup/admin-settings')
       .then(s => {
         setAlwaysPowerMode(s.always_power_mode);
         if (s.always_power_mode) chat.setToolMode('power');
+        setGlobalModelTier((s.default_model_tier || 'auto') as ModelTier);
       })
       .catch(() => {});
   }, []);
@@ -627,9 +629,9 @@ export function AgentPage() {
               toolMode={chat.toolMode}
               onToolModeChange={handleToolModeChange}
               alwaysPowerMode={alwaysPowerMode}
-              modelTier={modelTier}
+              modelTier={globalModelTier !== 'auto' ? globalModelTier : modelTier}
               tierLabels={tierLabels}
-              onSwitchTier={handleSwitchTier}
+              onSwitchTier={globalModelTier === 'auto' ? handleSwitchTier : undefined}
               agentName={agent.agent_name}
               agentSlug={agent.slug}
               conversationSource={convs.conversations.find(c => c.id === convs.activeId)?.source}

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -39,14 +39,20 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
   );
   const [alwaysPowerMode, setAlwaysPowerMode] = useState(false);
   const [triageMode, setTriageMode] = useState<string>('always_cheap');
+  const [defaultModelTier, setDefaultModelTier] = useState<string>('auto');
+  const [tierLabels, setTierLabels] = useState<Record<string, string>>({});
 
   useEffect(() => {
     if (tab === 'chat') {
-      api<{ always_power_mode: boolean; triage_mode: string }>('/api/setup/admin-settings')
+      api<{ always_power_mode: boolean; triage_mode: string; default_model_tier: string }>('/api/setup/admin-settings')
         .then(s => {
           setAlwaysPowerMode(s.always_power_mode);
           setTriageMode(s.triage_mode);
+          setDefaultModelTier(s.default_model_tier || 'auto');
         })
+        .catch(() => {});
+      api<{ tier_labels: Record<string, Record<string, string>>; active_provider: string }>('/api/providers/tiers')
+        .then(d => setTierLabels(d.tier_labels[d.active_provider] || {}))
         .catch(() => {});
     }
   }, [tab]);
@@ -287,6 +293,44 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
                     left: alwaysPowerMode ? 22 : 2,
                   }} />
                 </button>
+              </div>
+
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <div>
+                  <p style={{ fontSize: 14, color: '#EDF0F4', margin: 0 }}>Default model</p>
+                  <p style={{ fontSize: 12, color: 'rgba(237,240,244,0.38)', marginTop: 2 }}>Auto selects the best model per message. Pin one to always use it.</p>
+                </div>
+                <select
+                  value={defaultModelTier}
+                  onChange={async (e) => {
+                    const next = e.target.value;
+                    const prev = defaultModelTier;
+                    setDefaultModelTier(next);
+                    try {
+                      await api('/api/setup/admin-settings', {
+                        method: 'PUT',
+                        body: JSON.stringify({ default_model_tier: next }),
+                      });
+                    } catch {
+                      setDefaultModelTier(prev);
+                    }
+                  }}
+                  style={{
+                    background: 'rgba(230,235,242,0.08)',
+                    border: '1px solid rgba(230,235,242,0.14)',
+                    color: '#EDF0F4',
+                    borderRadius: 4,
+                    padding: '6px 10px',
+                    fontSize: 13,
+                    outline: 'none',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <option value="auto">Auto (smart routing)</option>
+                  {(['top', 'mid', 'light'] as const).map(tier => (
+                    <option key={tier} value={tier}>{tierLabels[tier] || tier}</option>
+                  ))}
+                </select>
               </div>
 
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -52,7 +52,7 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
         })
         .catch(() => {});
       api<{ tier_labels: Record<string, Record<string, string>>; active_provider: string }>('/api/providers/tiers')
-        .then(d => setTierLabels(d.tier_labels[d.active_provider] || {}))
+        .then(d => setTierLabels(d.tier_labels?.[d.active_provider] || {}))
         .catch(() => {});
     }
   }, [tab]);


### PR DESCRIPTION
## Summary

- Adds a "Default model" dropdown to Dashboard > Settings > Chat tab (below "Always power mode") that pins all agents to a specific model tier globally
- When pinned (e.g., Opus/Sonnet/Haiku), per-agent tier buttons hide from the chat panel and the triage classifier is skipped entirely
- Applies across all channels: web chat, Telegram, WhatsApp, heartbeats, scheduled actions, and self-reminders

## Test plan

- [ ] Open Settings > Chat tab — confirm "Default model" dropdown appears below "Always power mode"
- [ ] Set to a non-Auto tier (e.g., Opus) — confirm it persists on reload
- [ ] Navigate to agent chat — confirm tier buttons are hidden
- [ ] Send a message — confirm response uses the pinned model
- [ ] Set back to Auto — confirm tier buttons reappear
- [ ] Test via Telegram/WhatsApp to confirm pinned tier applies