### PR TITLE
Fix heartbeat Telegram notifications and add post_message tool

### DIFF
--- a/backend/core/agents/scheduled_actions/notifications.py
+++ b/backend/core/agents/scheduled_actions/notifications.py
@@ -69,7 +69,26 @@ def _send_external(agent_slug: str, action: dict, result_summary: str) -> bool:
         return False
 
 
-def _try_telegram(agent_slug: str, message: str, action: dict | None = None) -> bool:
+def send_external_for_agent(agent_slug: str, message: str, title: str = "") -> bool:
+    """Send an external notification on behalf of an agent.
+
+    Used by the post_message tool. Bypasses notify_on_action checks
+    since the agent is explicitly requesting delivery.
+    """
+    formatted = f"**{title}**\n\n{message[:3500]}" if title else message[:3500]
+    try:
+        if _try_telegram(agent_slug, message, formatted_text=formatted):
+            return True
+        if _try_whatsapp(agent_slug, message, formatted_text=formatted):
+            return True
+        logger.debug("No external channel configured for %s", agent_slug)
+        return False
+    except Exception as e:
+        logger.warning("External send for %s failed: %s", agent_slug, e)
+        return False
+
+
+def _try_telegram(agent_slug: str, message: str, action: dict | None = None, formatted_text: str | None = None) -> bool:
     try:
         from agents.db import list_agents
         from integrations.telegram.client import send_message
@@ -94,7 +113,9 @@ def _try_telegram(agent_slug: str, message: str, action: dict | None = None) -> 
         action_type = (action or {}).get("action_type", "heartbeat")
         action_name = (action or {}).get("name", "")
 
-        if action_type == "cron" and action_name:
+        if formatted_text:
+            text = formatted_text
+        elif action_type == "cron" and action_name:
             text = f"**{action_name}**\n\n{message[:3500]}"
         else:
             text = f"[Heartbeat] {agent['agent_name']}:\n{message[:3500]}"
@@ -153,7 +174,7 @@ def evaluate_failure_alert(
     return True
 
 
-def _try_whatsapp(agent_slug: str, message: str, action: dict | None = None) -> bool:
+def _try_whatsapp(agent_slug: str, message: str, action: dict | None = None, formatted_text: str | None = None) -> bool:
     try:
         from agents.db import list_agents
         from integrations.whatsapp.client import send_message
@@ -164,9 +185,9 @@ def _try_whatsapp(agent_slug: str, message: str, action: dict | None = None) -> 
             return False
 
         phone = agent["whatsapp_phone"]
-        text = f"[Heartbeat] {agent['agent_name']}:\n{message[:300]}"
+        text = formatted_text if formatted_text else f"[Heartbeat] {agent['agent_name']}:\n{message[:3500]}"
         send_message(phone, text)
-        logger.info("Heartbeat notification sent via WhatsApp for %s", agent_slug)
+        logger.info("Notification sent via WhatsApp for %s", agent_slug)
         return True
     except Exception as e:
         logger.debug("WhatsApp notification skipped for %s: %s", agent_slug, e)

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -418,15 +418,19 @@ def _process_heartbeat(action: dict) -> None:
                 system_prompt=(
                     f"You are {agent['agent_name']}.\n\n"
                     + (f"{ga_ctx}\n\n" if ga_ctx else "")
-                    + f"# Quick Heartbeat Triage — {date_str}, {time_str}\n\n"
-                    f"Quickly check the following items using your tools. "
+                    + f"# Heartbeat Triage — {date_str}, {time_str}\n\n"
+                    f"Look at the checklist items below and their time conditions. "
+                    f"Based on the current date and time ({date_str}, {time_str}), "
+                    f"determine if any items are due now.\n\n"
+                    f"If an item has no explicit time condition, assume it NEEDS_ACTION.\n\n"
+                    f"Do NOT use tools — just assess the time conditions.\n\n"
                     f"Respond with ONLY one of:\n"
                     f"- NEEDS_ACTION: <brief reason>\n"
                     f"- ALL_CLEAR\n\n"
                     f"## Checklist\n\n{checklist}\n"
                 ),
                 user_message="Quick triage check — anything need attention?",
-                tool_defs=tool_defs,
+                tool_defs=[],
                 registry=registry,
                 max_iterations=2,
                 provider_override=provider_override,
@@ -509,7 +513,9 @@ def _process_heartbeat(action: dict) -> None:
                 f"- Time: {time_str}\n\n"
                 f"## Rules\n\n"
                 f"- If everything is normal and no action is needed, respond with exactly: HEARTBEAT_OK\n"
-                f"- If something needs attention, take action and respond with: ACTION_TAKEN: <brief description>\n"
+                f"- If something needs attention, take action using your tools.\n"
+                f"- Use `post_message` to communicate findings or alerts to the user — this sends via Telegram/WhatsApp and creates an in-app notification.\n"
+                f"- After completing your checks, respond with: ACTION_TAKEN: <brief description of what you found/did>\n"
                 f"- Be concise. This is an automated check, not a conversation.\n"
                 f"{error_context}"
             ),
@@ -556,7 +562,11 @@ def _process_heartbeat(action: dict) -> None:
                 )
             return
 
-        notified = notifications.evaluate_and_notify(action, status, result.text[:300], agent_slug)
+        post_message_used = any(tc.get("tool") == "post_message" for tc in result.tool_log)
+        if post_message_used:
+            notified = True
+        else:
+            notified = notifications.evaluate_and_notify(action, status, result.text[:3500], agent_slug)
 
         if execution_id:
             history.record_complete(

--- a/backend/core/agents/scheduled_actions/service.py
+++ b/backend/core/agents/scheduled_actions/service.py
@@ -605,7 +605,7 @@ def ensure_default_actions(agent_slug: str) -> None:
                 update_action(action["id"], always_on=True)
         return
 
-    create_action(
+    result = create_action(
         agent=agent_slug,
         schedule_type="interval",
         name="Heartbeat",
@@ -618,6 +618,8 @@ def ensure_default_actions(agent_slug: str) -> None:
         action_type="heartbeat",
         always_on=True,
     )
+    if result.get("ok") and result.get("id"):
+        update_action(result["id"], notify_on_action=True)
     logger.info("Created default heartbeat for agent %s", agent_slug)
 
 

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -16,6 +16,7 @@ TOOL_KIND_LABELS: dict[str, str] = {
     "report": "Reports",
     "setup": "Setup & Integrations",
     "activity_log": "Activity Log",
+    "post_message": "Messaging",
 }
 
 
@@ -1336,6 +1337,9 @@ Use `create_scheduled_action` only when you need a task with its own independent
 - For 24/7 operation, set `always_on=true` — this bypasses active hours entirely.
 - Your heartbeat runs 24/7 by default (`always_on`). Time-gating belongs in your HEARTBEAT.md checklist items (e.g., "Only on weekdays before 10 AM: ..."), not on the heartbeat's active hours.
 
+### Posting Messages
+Use `post_message` to communicate findings, alerts, or updates to the user. This creates an in-app alert and sends via Telegram/WhatsApp if configured. During heartbeat checks, use `post_message` whenever you find something noteworthy — don't rely on the heartbeat response text alone to reach the user.
+
 ### Guidelines
 - Always confirm with the user before creating scheduled actions
 - Use descriptive names for scheduled actions
@@ -1500,6 +1504,33 @@ ACTIVITY_LOG_TOOLS = [
     },
 ]
 
+POST_MESSAGE_TOOLS = [
+    {
+        "name": "post_message",
+        "description": (
+            "Post a message to the user. Creates an in-app alert and sends "
+            "via Telegram/WhatsApp if configured. Use this to proactively "
+            "communicate findings, alerts, or updates."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "The message content to send to the user",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Short title for the alert (e.g. 'Weather Alert', 'Email Summary'). Defaults to agent name.",
+                },
+            },
+            "required": ["message"],
+        },
+        "kind": "post_message",
+        "writes": True,
+    },
+]
+
 
 def get_tool_definitions(
     gmail_enabled: bool = False,
@@ -1581,6 +1612,7 @@ def get_tool_definitions(
         tools.extend(integration_tools)
     tools.extend(SETUP_TOOLS)
     tools.extend(ACTIVITY_LOG_TOOLS)
+    tools.extend(POST_MESSAGE_TOOLS)
     # Append agent-created real tools (loaded from filesystem)
     if dynamic_real_tools:
         tools.extend(dynamic_real_tools)

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -164,6 +164,8 @@ class ToolRegistry:
                 return self._execute_import(tool_name, tool_args)
             elif kind == "activity_log":
                 return self._execute_activity_log(tool_name, tool_args)
+            elif kind == "post_message":
+                return self._execute_post_message(tool_name, tool_args)
             elif kind == "meta":
                 return {"error": "Meta tools are handled by ai_service directly"}
             else:
@@ -590,6 +592,35 @@ class ToolRegistry:
                     for tc in r["tool_calls"]
                 ]
         return {"entries": records, "count": len(records)}
+
+    def _execute_post_message(self, tool_name: str, args: dict) -> dict:
+        message = args.get("message", "")
+        if not message:
+            return {"error": "message is required"}
+
+        title = (args.get("title", "") or self.agent_name or "Agent Message")[:200]
+
+        from core.agents.alerts.service import create_alert
+        create_alert(
+            agent=self.agent_slug,
+            title=title,
+            message=message[:500],
+            source="post_message",
+        )
+
+        external_sent = False
+        try:
+            from core.agents.scheduled_actions.notifications import send_external_for_agent
+            external_sent = send_external_for_agent(self.agent_slug, message, title=title)
+        except Exception as e:
+            logger.warning("post_message external delivery failed for %s: %s", self.agent_slug, e)
+
+        return {
+            "ok": True,
+            "alert_created": True,
+            "external_sent": external_sent,
+            "message": f"Message posted{' and sent via Telegram/WhatsApp' if external_sent else ''}.",
+        }
 
     def _mark_setup_complete(self, integration_name: str) -> None:
         """Auto-update _pending-setup.md to check off a completed integration."""

--- a/backend/integrations/telegram/state.py
+++ b/backend/integrations/telegram/state.py
@@ -30,6 +30,10 @@ def _get_db() -> sqlite3.Connection:
     return _connection
 
 
+def get_db() -> sqlite3.Connection:
+    return _get_db()
+
+
 def _migrate_user_mappings_v2(conn: sqlite3.Connection) -> None:
     """Migrate user_mappings from UNIQUE(platform, platform_user_id) to
     UNIQUE(platform, platform_user_id, agent_id) so one Telegram user

--- a/frontend/src/agent/components/heartbeat/HeartbeatConfig.tsx
+++ b/frontend/src/agent/components/heartbeat/HeartbeatConfig.tsx
@@ -16,6 +16,7 @@ export function HeartbeatConfig({ action, onUpdateConfig }: Props) {
   const [hoursEnd, setHoursEnd] = useState(action.active_hours_end || '23:59');
   const [modelOverride, setModelOverride] = useState(action.model_override || '');
   const [maxIterations, setMaxIterations] = useState(action.max_tool_iterations || 10);
+  const [notifyOnAction, setNotifyOnAction] = useState(action.notify_on_action);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
@@ -28,6 +29,7 @@ export function HeartbeatConfig({ action, onUpdateConfig }: Props) {
     setHoursEnd(action.active_hours_end || '23:59');
     setModelOverride(action.model_override || '');
     setMaxIterations(action.max_tool_iterations || 10);
+    setNotifyOnAction(action.notify_on_action);
     setDirty(false);
   }, [action]);
 
@@ -43,6 +45,7 @@ export function HeartbeatConfig({ action, onUpdateConfig }: Props) {
         active_hours_start: hoursStart,
         active_hours_end: hoursEnd,
         max_tool_iterations: maxIterations,
+        notify_on_action: notifyOnAction,
       };
       fields.model_override = modelOverride.trim() || '';
       await onUpdateConfig(fields);
@@ -87,6 +90,7 @@ export function HeartbeatConfig({ action, onUpdateConfig }: Props) {
           />
         </div>
 
+        <Toggle on={notifyOnAction} onChange={setNotifyOnAction} label="Notify on action (Telegram / WhatsApp)" />
         <Toggle on={triage} onChange={setTriage} label="Triage (quick check before full run)" />
       </div>
 


### PR DESCRIPTION
## Summary

- Fix broken Telegram notification delivery — `notifications.py` imported `get_db` from `telegram/state.py` but the function was `_get_db` (private). Zero notifications had ever been sent across 317 heartbeat and 14 cron runs.
- Add `post_message` tool so agents can explicitly send messages to users during heartbeat/cron execution. Creates in-app alert + sends via Telegram/WhatsApp if configured. Lays groundwork for future internal reporting when no external channel is connected.
- Fix triage reliability — remove tool access from triage step (was causing failures when Haiku tried to use tools with only 2 iterations) and use pure time-condition assessment.
- Fix notification truncation (300 → 3500 chars), add `notify_on_action` UI toggle to HeartbeatConfig, and prevent double notifications when agent uses `post_message`.

## Test plan

- [ ] Deploy to Railway
- [ ] Trigger heartbeat manually — verify triage passes, full heartbeat runs, `post_message` sends to Telegram, alert created in dashboard
- [ ] Verify cron jobs (morning brief, email scan) also deliver to Telegram
- [ ] Test HeartbeatConfig UI — notify toggle visible, saves and persists correctly
- [ ] Create a new agent and verify `notify_on_action` defaults to enabled