### PR TITLE
Add timestamps to all chats with AI time awareness

### DIFF
--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -511,13 +511,16 @@ def _build_system_prompt(
         logger.debug("alerts injection skipped: %s", e)
 
     now_ct = datetime.now(CT_TZ)
-    date_str = now_ct.strftime("%A, %B %d, %Y")
-    time_str = now_ct.strftime("%I:%M %p CT")
+    dst_state = "CDT" if now_ct.dst() else "CST"
     volatile_parts.extend([
-        "# Current Session",
+        "# Current Time",
         "",
-        f"- Date: {date_str}",
-        f"- Time: {time_str}",
+        f"- ISO: {now_ct.isoformat()}",
+        f"- Timezone: America/Chicago ({dst_state})",
+        f"- Day: {now_ct.strftime('%A, %B %d, %Y')}",
+        f"- Human: {now_ct.strftime('%I:%M %p')} {dst_state}",
+        "",
+        "All times you state to the user MUST be in Central Time unless they ask otherwise.",
         "",
     ])
 

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1607,7 +1607,7 @@ def get_tool_definitions(
     if import_mode:
         from agents.import_service.tool_defs import IMPORT_TOOLS
         read_only_context = [t for t in CONTEXT_TOOLS if not t.get("writes", False)]
-        return read_only_context + list(IMPORT_TOOLS)
+        return read_only_context + list(DATETIME_TOOLS) + list(IMPORT_TOOLS)
 
     tools = list(CONTEXT_TOOLS)
     tools.extend(DATETIME_TOOLS)

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1531,6 +1531,16 @@ POST_MESSAGE_TOOLS = [
     },
 ]
 
+DATETIME_TOOLS = [
+    {
+        "name": "get_current_datetime",
+        "description": "Get the current date and time. Returns ISO 8601, human-readable format, timezone, and DST state.",
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+        "kind": "context",
+        "writes": False,
+    },
+]
+
 NOTIFY_USER_TOOLS = [
     {
         "name": "notify_user",
@@ -1600,6 +1610,7 @@ def get_tool_definitions(
         return read_only_context + list(IMPORT_TOOLS)
 
     tools = list(CONTEXT_TOOLS)
+    tools.extend(DATETIME_TOOLS)
     if memory_enabled:
         tools.extend(MEMORY_TOOLS)
         tools.extend(SKILL_TOOLS)

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -186,6 +186,9 @@ class ToolRegistry:
             return write_context_file(self.context_dir, args["filename"], args["content"])
         elif tool_name == "append_to_context_file":
             return append_to_context_file(self.context_dir, args["filename"], args["content"])
+        elif tool_name == "get_current_datetime":
+            from core.agents.tools.datetime_tools import get_current_datetime
+            return get_current_datetime()
         elif tool_name == "delete_context_file":
             return delete_context_file(self.context_dir, args["filename"])
         return {"error": f"Unknown context tool: {tool_name}"}

--- a/backend/core/agents/tools/datetime_tools.py
+++ b/backend/core/agents/tools/datetime_tools.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+CT_TZ = ZoneInfo("America/Chicago")
+
+
+def get_current_datetime() -> dict:
+    now = datetime.now(CT_TZ)
+    dst_state = "CDT" if now.dst() else "CST"
+    offset = now.strftime("%z")
+    return {
+        "iso": now.isoformat(),
+        "human": now.strftime(f"%A, %B %d, %Y at %I:%M %p {dst_state}"),
+        "day_of_week": now.strftime("%A"),
+        "date": now.strftime("%Y-%m-%d"),
+        "time": now.strftime("%H:%M:%S"),
+        "timezone": "America/Chicago",
+        "dst_state": dst_state,
+        "utc_offset": offset[:3] + ":" + offset[3:],
+    }

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -1,12 +1,14 @@
-import { useState, useRef, useEffect, useCallback, type RefObject, type KeyboardEvent, type DragEvent, type MouseEvent } from 'react';
+import { useState, useRef, useEffect, useCallback, Fragment, type RefObject, type KeyboardEvent, type DragEvent, type MouseEvent } from 'react';
 import type { ChatMessage, ContextUsage, ToolMode, ModelTier } from '../hooks/useAgentChat';
 import type { AgentAlert } from '../../core/types';
 import { AgentMessageBubble } from './AgentMessageBubble';
+import { DateDivider } from './DateDivider';
 import AlertBanner from './AlertBanner';
 import NotificationLog from './NotificationLog';
 import { IconAttach, IconArrowUp } from '../../shared/icons';
 import { useIsMobile } from '../../shared/useIsMobile';
 import { api } from '../../core/api/client';
+import { ctDateKey } from '../utils/dateFormat';
 
 const ALLOWED_EXTENSIONS = new Set(['csv', 'xlsx', 'md', 'txt', 'pdf', 'docx']);
 const MAX_FILE_SIZE = 1 * 1024 * 1024;
@@ -502,23 +504,31 @@ export function AgentChatPanel({
                 </span>
               </div>
             )}
-            {messages.filter(msg => !msg.hidden).map(msg => {
-              const displayMsg = (msg.role === 'user' && msg.content.match(/^\[via (Telegram|WhatsApp) from [^\]]+\] /))
-                ? { ...msg, content: msg.content.replace(/^\[via (?:Telegram|WhatsApp) from [^\]]+\] /, '') }
-                : msg;
-              return (
-                <AgentMessageBubble
-                  key={msg.id}
-                  message={displayMsg}
-                  onApprove={onApprove}
-                  onDeny={onDeny}
-                  onApprovePlan={onApprovePlan}
-                  onIteratePlan={onIteratePlan}
-                  agentName={agentName}
-                  showModelBadge={modelTier === 'auto'}
-                />
-              );
-            })}
+            {(() => {
+              const visible = messages.filter(msg => !msg.hidden);
+              return visible.map((msg, i) => {
+                const dayKey = ctDateKey(msg.timestamp);
+                const prevDayKey = i > 0 ? ctDateKey(visible[i - 1].timestamp) : '';
+                const showDivider = !!dayKey && dayKey !== prevDayKey;
+                const displayMsg = (msg.role === 'user' && msg.content.match(/^\[via (Telegram|WhatsApp) from [^\]]+\] /))
+                  ? { ...msg, content: msg.content.replace(/^\[via (?:Telegram|WhatsApp) from [^\]]+\] /, '') }
+                  : msg;
+                return (
+                  <Fragment key={msg.id}>
+                    {showDivider && <DateDivider timestamp={msg.timestamp} />}
+                    <AgentMessageBubble
+                      message={displayMsg}
+                      onApprove={onApprove}
+                      onDeny={onDeny}
+                      onApprovePlan={onApprovePlan}
+                      onIteratePlan={onIteratePlan}
+                      agentName={agentName}
+                      showModelBadge={modelTier === 'auto'}
+                    />
+                  </Fragment>
+                );
+              });
+            })()}
           </div>
         )}
       </div>

--- a/frontend/src/agent/components/AgentMessageBubble.tsx
+++ b/frontend/src/agent/components/AgentMessageBubble.tsx
@@ -5,6 +5,7 @@ import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import ReportRenderer from '../reports/ReportRenderer';
 import { AgentMark } from '../../shared/AgentMark';
 import { IconAttach } from '../../shared/icons';
+import { formatBubbleTime } from '../utils/dateFormat';
 
 interface Props {
   message: ChatMessage;
@@ -364,6 +365,11 @@ function AgentMessageBubbleInner({ message, onApprove, onDeny, onApprovePlan, on
               whiteSpace: 'pre-wrap', wordBreak: 'break-word',
             }}>
               {message.content}
+              {message.timestamp ? (
+                <div style={{ fontSize: 10, color: 'rgba(237,240,244,0.38)', textAlign: 'right', marginTop: 4 }}>
+                  {formatBubbleTime(message.timestamp)}
+                </div>
+              ) : null}
             </div>
           </div>
         </div>
@@ -449,10 +455,15 @@ function AgentMessageBubbleInner({ message, onApprove, onDeny, onApprovePlan, on
           />
         )}
 
-        {/* Copy */}
+        {/* Copy + timestamp */}
         {message.content && (
-          <div style={{ marginTop: 4 }}>
+          <div style={{ marginTop: 4, display: 'flex', alignItems: 'center', gap: 8 }}>
             <CopyButton copied={copied} onClick={() => copy(message.content)} />
+            {message.timestamp ? (
+              <span style={{ fontSize: 10, color: 'rgba(237,240,244,0.38)' }}>
+                {formatBubbleTime(message.timestamp)}
+              </span>
+            ) : null}
           </div>
         )}
       </div>

--- a/frontend/src/agent/components/ConversationSidebar.tsx
+++ b/frontend/src/agent/components/ConversationSidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback } from 'react';
 import type { Conversation } from '../hooks/useConversations';
 import { AgentMark } from '../../shared/AgentMark';
 import { IconPlus } from '../../shared/icons';
+import { formatSidebarTime } from '../utils/dateFormat';
 
 interface Props {
   agentName: string;
@@ -16,12 +17,6 @@ interface Props {
   onSearch: (q: string) => void;
   onRename: (id: string, title: string) => void;
 }
-
-const mono = (size: number, color = 'rgba(237,240,244,0.38)') => ({
-  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
-  fontSize: size, letterSpacing: '0.16em',
-  textTransform: 'uppercase' as const, color,
-});
 
 export function ConversationSidebar({
   agentName, conversations, activeId, searchQuery, searchResults, isSearching,
@@ -124,9 +119,6 @@ export function ConversationSidebar({
         + New chat
       </div>
 
-      {/* Section label */}
-      <div style={{ padding: '8px 14px 4px', ...mono(9, 'rgba(237,240,244,0.38)') }}>Today</div>
-
       {/* Conversation list */}
       <div style={{ flex: 1, overflowY: 'auto' }}>
         {isSearching ? (
@@ -193,9 +185,20 @@ export function ConversationSidebar({
                             {(item as Conversation).source?.startsWith('telegram') ? 'TG' : 'WA'}
                           </span>
                         )}
-                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
                           {title}
                         </span>
+                        {'updated_at' in item && (
+                          <span style={{
+                            fontSize: 10,
+                            fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                            color: 'rgba(237,240,244,0.3)',
+                            whiteSpace: 'nowrap',
+                            flexShrink: 0,
+                          }}>
+                            {formatSidebarTime((item as Conversation).updated_at)}
+                          </span>
+                        )}
                       </div>
                       {snippet && (
                         <div style={{

--- a/frontend/src/agent/components/DateDivider.tsx
+++ b/frontend/src/agent/components/DateDivider.tsx
@@ -1,0 +1,21 @@
+import { formatDateDivider } from '../utils/dateFormat';
+
+export function DateDivider({ timestamp }: { timestamp: number }) {
+  const label = formatDateDivider(timestamp);
+  if (!label) return null;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '8px 0' }}>
+      <span style={{
+        padding: '2px 12px',
+        fontSize: 11,
+        fontFamily: "'Inter Tight', system-ui, sans-serif",
+        fontWeight: 500,
+        color: 'rgba(237,240,244,0.38)',
+        background: 'rgba(34,40,48,0.55)',
+        borderRadius: 99,
+      }}>
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/agent/hooks/useConversations.ts
+++ b/frontend/src/agent/hooks/useConversations.ts
@@ -49,12 +49,12 @@ export function useConversations(apiPrefix: string) {
       }>(`${apiPrefix}/conversations/${id}`);
       setActiveId(id);
       return data.messages.map(m => {
-        const parsed = parseServerTimestamp(m.created_at);
+        const parsedTimestamp = parseServerTimestamp(m.created_at);
         const msg: ChatMessage = {
           id: m.id,
           role: m.role as 'user' | 'assistant',
           content: m.content,
-          timestamp: parsed ? parsed.getTime() : Date.now(),
+          timestamp: parsedTimestamp ? parsedTimestamp.getTime() : 0,
           model: m.model,
         };
         if (m.tool_calls) {

--- a/frontend/src/agent/hooks/useConversations.ts
+++ b/frontend/src/agent/hooks/useConversations.ts
@@ -6,6 +6,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { api } from '../../core/api/client';
 import type { ChatMessage } from './useAgentChat';
+import { parseServerTimestamp } from '../utils/dateFormat';
 
 export interface Conversation {
   id: string;
@@ -27,7 +28,7 @@ export function useConversations(apiPrefix: string) {
   const [loaded, setLoaded] = useState(false);
   useEffect(() => { setLoaded(false); setConversations([]); setActiveId(null); }, [apiPrefix]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<{ id: string; title: string; snippet: string }[]>([]);
+  const [searchResults, setSearchResults] = useState<{ id: string; title: string; snippet: string; updated_at?: string }[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -44,15 +45,16 @@ export function useConversations(apiPrefix: string) {
     try {
       const data = await api<{
         id: string; title: string;
-        messages: { id: string; role: string; content: string; seq: number; tool_calls?: string; model?: string }[];
+        messages: { id: string; role: string; content: string; seq: number; tool_calls?: string; model?: string; created_at?: string }[];
       }>(`${apiPrefix}/conversations/${id}`);
       setActiveId(id);
       return data.messages.map(m => {
+        const parsed = parseServerTimestamp(m.created_at);
         const msg: ChatMessage = {
           id: m.id,
           role: m.role as 'user' | 'assistant',
           content: m.content,
-          timestamp: Date.now(),
+          timestamp: parsed ? parsed.getTime() : Date.now(),
           model: m.model,
         };
         if (m.tool_calls) {
@@ -125,7 +127,7 @@ export function useConversations(apiPrefix: string) {
     setIsSearching(true);
     searchTimer.current = setTimeout(async () => {
       try {
-        const data = await api<{ results: { id: string; title: string; snippet: string }[] }>(
+        const data = await api<{ results: { id: string; title: string; snippet: string; updated_at?: string }[] }>(
           `${apiPrefix}/conversations/search?q=${encodeURIComponent(query)}`
         );
         setSearchResults(data.results);

--- a/frontend/src/agent/utils/dateFormat.ts
+++ b/frontend/src/agent/utils/dateFormat.ts
@@ -6,6 +6,7 @@ export function parseServerTimestamp(value: string | number | null | undefined):
     const d = new Date(value);
     return Number.isNaN(d.getTime()) ? null : d;
   }
+  // SQLite datetime('now') returns UTC without a timezone marker (e.g. "2026-05-30 14:23:11")
   const sqliteNaive =
     /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}/.test(value) &&
     !value.includes('Z') &&
@@ -19,6 +20,7 @@ function ctDayKey(d: Date): string {
 }
 
 export function ctDateKey(value: string | number | null | undefined): string {
+  if (value === 0) return '';
   const d = parseServerTimestamp(value);
   return d ? ctDayKey(d) : '';
 }
@@ -34,6 +36,7 @@ function ctTime(d: Date): string {
 }
 
 export function formatSidebarTime(value: string | number | null | undefined): string {
+  if (value === 0) return '';
   const d = parseServerTimestamp(value);
   if (!d) return '';
   const days = ctDaysAgo(d, new Date());
@@ -46,12 +49,14 @@ export function formatSidebarTime(value: string | number | null | undefined): st
 }
 
 export function formatBubbleTime(value: string | number | null | undefined): string {
+  if (value === 0) return '';
   const d = parseServerTimestamp(value);
   if (!d) return '';
   return ctTime(d);
 }
 
 export function formatDateDivider(value: string | number | null | undefined): string {
+  if (value === 0) return '';
   const d = parseServerTimestamp(value);
   if (!d) return '';
   const now = new Date();

--- a/frontend/src/agent/utils/dateFormat.ts
+++ b/frontend/src/agent/utils/dateFormat.ts
@@ -1,0 +1,69 @@
+const CT = 'America/Chicago';
+
+export function parseServerTimestamp(value: string | number | null | undefined): Date | null {
+  if (value == null || value === '') return null;
+  if (typeof value === 'number') {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  const sqliteNaive =
+    /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}/.test(value) &&
+    !value.includes('Z') &&
+    !/[+-]\d\d:?\d\d$/.test(value);
+  const d = sqliteNaive ? new Date(value.replace(' ', 'T') + 'Z') : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function ctDayKey(d: Date): string {
+  return d.toLocaleDateString('en-CA', { timeZone: CT });
+}
+
+export function ctDateKey(value: string | number | null | undefined): string {
+  const d = parseServerTimestamp(value);
+  return d ? ctDayKey(d) : '';
+}
+
+function ctDaysAgo(then: Date, now: Date): number {
+  const a = new Date(ctDayKey(then) + 'T00:00:00Z').getTime();
+  const b = new Date(ctDayKey(now) + 'T00:00:00Z').getTime();
+  return Math.round((b - a) / 86_400_000);
+}
+
+function ctTime(d: Date): string {
+  return d.toLocaleTimeString('en-US', { timeZone: CT, hour: 'numeric', minute: '2-digit' });
+}
+
+export function formatSidebarTime(value: string | number | null | undefined): string {
+  const d = parseServerTimestamp(value);
+  if (!d) return '';
+  const days = ctDaysAgo(d, new Date());
+  if (days <= 0) return ctTime(d);
+  if (days === 1) return 'Yesterday';
+  if (days < 7) return d.toLocaleDateString('en-US', { timeZone: CT, weekday: 'short' });
+  return d.toLocaleDateString('en-US', {
+    timeZone: CT, month: 'numeric', day: 'numeric', year: '2-digit',
+  });
+}
+
+export function formatBubbleTime(value: string | number | null | undefined): string {
+  const d = parseServerTimestamp(value);
+  if (!d) return '';
+  return ctTime(d);
+}
+
+export function formatDateDivider(value: string | number | null | undefined): string {
+  const d = parseServerTimestamp(value);
+  if (!d) return '';
+  const now = new Date();
+  const days = ctDaysAgo(d, now);
+  if (days <= 0) return 'Today';
+  if (days === 1) return 'Yesterday';
+  if (days <= 6) return d.toLocaleDateString('en-US', { timeZone: CT, weekday: 'long' });
+  const sameYear =
+    d.toLocaleDateString('en-US', { timeZone: CT, year: 'numeric' }) ===
+    now.toLocaleDateString('en-US', { timeZone: CT, year: 'numeric' });
+  return d.toLocaleDateString('en-US', {
+    timeZone: CT, month: 'short', day: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  });
+}


### PR DESCRIPTION
## Summary

- **Bubble timestamps** on every user and assistant message (Telegram-style "2:23 PM"), **date dividers** between message groups on different days ("Today", "Yesterday", "Friday", "May 29"), and **per-row timestamps** in the conversation sidebar — replacing the hard-coded "Today" label
- **Fixed historical message timestamps** — conversations loaded from the DB now use the actual `created_at` instead of `Date.now()`, so old messages show their real time instead of the load time
- **Backend AI time awareness** — enhanced system prompt with ISO 8601 time block, timezone, and DST state; new `get_current_datetime` tool for mid-turn time refresh

## Test plan

- [ ] Open an existing conversation — messages should show "2:23 PM" style bubble timestamps
- [ ] Open a conversation spanning multiple days — date dividers ("Today", "Yesterday", etc.) should appear between day groups
- [ ] Check the sidebar — each conversation should show a relative timestamp ("2:23 PM", "Yesterday", "Mon", "5/29/26")
- [ ] Send a new message — both user and assistant messages should get timestamps
- [ ] Ask the agent "what time is it?" — should answer correctly from system prompt or use `get_current_datetime` tool
- [ ] Reload an old conversation — timestamps should reflect actual message times, not current time
- [ ] Search conversations — results should show timestamps