### PR TITLE
Add avatar menu popover with upload, generate, and remove

### DIFF
--- a/.claude/coach-lessons.md
+++ b/.claude/coach-lessons.md
@@ -1,0 +1,8 @@
+# Coach Lessons
+
+> Instincts extracted from development sessions. Scores reflect real-world effectiveness.
+> Format: `[score]` **When** trigger → **do** action → **because** reason
+
+## Deploy & Infrastructure
+
+- `[0.70]` **When** running the backend from a git worktree → **do** use the absolute venv path (`/Users/willwilson/ai/chatty/.venv/bin/python`), not relative (`../../.venv/bin/python`) → **because** worktrees live under `.claude/worktrees/<name>/backend/` and the relative path resolves to a nonexistent location

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -420,6 +420,24 @@ async def avatar_upload(
     return {"ok": True, "avatar_url": f"/api/agents/{agent_id}/avatar"}
 
 
+@router.delete("/{agent_id}/avatar")
+async def avatar_delete(agent_id: str, user=Depends(get_current_user)):
+    """Remove the agent's avatar, reverting to the default letter badge."""
+    from core.storage import delete_config
+
+    agent = _get_agent_or_404(agent_id)
+    slug = agent["slug"]
+
+    avatar_path = DATA_DIR / slug / "avatar.png"
+    if avatar_path.exists():
+        avatar_path.unlink()
+
+    delete_config("avatar.png", prefix=f"agents/{slug}/")
+    agent_db.update_agent(agent_id, avatar_url="")
+
+    return {"ok": True}
+
+
 @router.get("/{agent_id}/avatar")
 async def get_avatar(agent_id: str, request: Request, token: str | None = None):
     """Serve the agent's avatar image.

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -12,6 +12,7 @@ import HeartbeatPanel from './components/HeartbeatPanel';
 import AgentRemindersPanel from './components/AgentRemindersPanel';
 import { ConversationSidebar } from './components/ConversationSidebar';
 import { AvatarPicker } from './components/AvatarPicker';
+import { AvatarMenu } from './components/AvatarMenu';
 import { AgentMark } from '../shared/AgentMark';
 import { useIsMobile } from '../shared/useIsMobile';
 import { MobileMenuDrawer } from '../shared/MobileMenuDrawer';
@@ -69,9 +70,11 @@ export function AgentPage() {
   const [agent, setAgent] = useState<AgentRow | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>(() => parseTab(searchParams.get('tab')) || 'chat');
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);
+  const [avatarMenuRect, setAvatarMenuRect] = useState<DOMRect | null>(null);
   const [showSidebar, setShowSidebar] = useState(false);
   const [openaiAvailable, setOpenaiAvailable] = useState(false);
   const [alwaysPowerMode, setAlwaysPowerMode] = useState(false);
+  const [avatarCacheBust, setAvatarCacheBust] = useState(0);
   const [activeProvider, setActiveProvider] = useState('');
   const [modelTier, setModelTier] = useState<ModelTier>('auto');
   const [tierLabels, setTierLabels] = useState<Record<string, string>>({});
@@ -315,7 +318,22 @@ export function AgentPage() {
 
   function handleAvatarComplete() {
     setShowAvatarPicker(false);
+    setAvatarMenuRect(null);
+    setAvatarCacheBust(Date.now());
     if (agentId) api<AgentRow>(`/api/agents/${agentId}`).then(setAgent).catch(() => {});
+  }
+
+  function buildAvatarUrl() {
+    if (!agent?.avatar_url) return undefined;
+    const token = sessionStorage.getItem('chatty_token') || '';
+    return `${agent.avatar_url}?token=${token}&t=${avatarCacheBust}`;
+  }
+
+  function handleAvatarClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!agent?.onboarding_complete) return;
+    const el = (e.currentTarget as HTMLElement);
+    setAvatarMenuRect(prev => prev ? null : el.getBoundingClientRect());
   }
 
   if (!agent) {
@@ -359,30 +377,24 @@ export function AgentPage() {
             </div>
           )}
 
-          <AgentMark
-            letter={letter}
-            size={28}
-            avatarUrl={agent.avatar_url ? `${agent.avatar_url}${agent.avatar_url.includes('?') ? '&' : '?'}token=${sessionStorage.getItem('chatty_token') || ''}` : undefined}
-          />
+          <div
+            onClick={handleAvatarClick}
+            style={{
+              cursor: agent.onboarding_complete ? 'pointer' : 'default',
+              borderRadius: 6, lineHeight: 0,
+            }}
+          >
+            <AgentMark
+              letter={letter}
+              size={28}
+              avatarUrl={buildAvatarUrl()}
+            />
+          </div>
 
           <span style={{
             fontFamily: "'Fraunces', Georgia, serif",
             fontSize: 16, letterSpacing: '-0.01em', color: '#EDF0F4',
           }}>{agent.agent_name}</span>
-
-          {!isMobile && agent.onboarding_complete && !agent.avatar_url && (
-            <button
-              onClick={() => setShowAvatarPicker(true)}
-              style={{
-                fontSize: 11, background: 'rgba(34,40,48,0.55)',
-                color: 'rgba(237,240,244,0.62)',
-                border: '1px solid rgba(230,235,242,0.07)',
-                borderRadius: 4, padding: '2px 8px', cursor: 'pointer',
-              }}
-            >
-              Set Avatar
-            </button>
-          )}
 
           {/* Tool mode selector — hidden on mobile */}
           {!isMobile && activeTab === 'chat' && (
@@ -582,10 +594,10 @@ export function AgentPage() {
                   display: 'flex', flexDirection: 'column', gap: 2,
                   padding: '8px 12px', borderBottom: '1px solid rgba(230,235,242,0.07)',
                 }}>
-                  {agent.onboarding_complete && !agent.avatar_url && (
+                  {agent.onboarding_complete && (
                     <div onClick={() => { setShowSidebar(false); setShowAvatarPicker(true); }}
                       style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 8px', borderRadius: 4, cursor: 'pointer', color: 'rgba(237,240,244,0.7)' }}>
-                      <span style={{ fontSize: 14 }}>Set Avatar</span>
+                      <span style={{ fontSize: 14 }}>{agent.avatar_url ? 'Change Avatar' : 'Set Avatar'}</span>
                     </div>
                   )}
                   <div onClick={() => { setShowSidebar(false); handleTogglePlanMode(); }}
@@ -605,6 +617,7 @@ export function AgentPage() {
                 <div style={{ flex: 1, overflow: 'auto' }}>
                   <ConversationSidebar
                     agentName={agent.agent_name}
+                    avatarUrl={buildAvatarUrl()}
                     conversations={convs.conversations}
                     activeId={convs.activeId}
                     searchQuery={convs.searchQuery}
@@ -622,6 +635,8 @@ export function AgentPage() {
             {!isMobile && (
               <ConversationSidebar
                 agentName={agent.agent_name}
+                avatarUrl={buildAvatarUrl()}
+                onAvatarClick={handleAvatarClick}
                 conversations={convs.conversations}
                 activeId={convs.activeId}
                 searchQuery={convs.searchQuery}
@@ -679,6 +694,19 @@ export function AgentPage() {
           </div>
         ) : null}
       </div>
+
+      {/* Avatar menu popover */}
+      {avatarMenuRect && (
+        <AvatarMenu
+          agentId={agentId!}
+          hasAvatar={!!agent.avatar_url}
+          openaiAvailable={openaiAvailable}
+          onGenerate={() => { setAvatarMenuRect(null); setShowAvatarPicker(true); }}
+          onAvatarChanged={handleAvatarComplete}
+          onClose={() => setAvatarMenuRect(null)}
+          anchorRect={avatarMenuRect}
+        />
+      )}
 
       {/* Avatar picker overlay */}
       {showAvatarPicker && (

--- a/frontend/src/agent/components/AvatarMenu.tsx
+++ b/frontend/src/agent/components/AvatarMenu.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../../core/api/client';
+
+interface Props {
+  agentId: string;
+  hasAvatar: boolean;
+  openaiAvailable: boolean;
+  onGenerate: () => void;
+  onAvatarChanged: () => void;
+  onClose: () => void;
+  anchorRect: DOMRect | null;
+}
+
+export function AvatarMenu({
+  agentId, hasAvatar, openaiAvailable,
+  onGenerate, onAvatarChanged, onClose, anchorRect,
+}: Props) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [removing, setRemoving] = useState(false);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose();
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose]);
+
+  async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const token = sessionStorage.getItem('chatty_token');
+      const res = await fetch(`/api/agents/${agentId}/avatar/upload`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: formData,
+      });
+      if (!res.ok) {
+        if (res.status === 401) { window.location.href = '/login'; return; }
+        const body = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(body.detail || 'Upload failed');
+      }
+      onAvatarChanged();
+    } catch {
+      setUploading(false);
+    }
+    if (fileRef.current) fileRef.current.value = '';
+  }
+
+  async function handleRemove() {
+    setRemoving(true);
+    try {
+      await api(`/api/agents/${agentId}/avatar`, { method: 'DELETE' });
+      onAvatarChanged();
+    } catch {
+      setRemoving(false);
+    }
+  }
+
+  const top = anchorRect ? anchorRect.bottom + 6 : 0;
+  const left = anchorRect ? anchorRect.left : 0;
+
+  const itemStyle: React.CSSProperties = {
+    display: 'flex', alignItems: 'center', gap: 10,
+    padding: '9px 14px', cursor: 'pointer',
+    fontSize: 13, color: 'rgba(237,240,244,0.78)',
+    fontFamily: "'Inter Tight', system-ui, sans-serif",
+    borderRadius: 4,
+    background: 'transparent',
+    border: 'none', width: '100%', textAlign: 'left',
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      style={{
+        position: 'fixed', top, left, zIndex: 100,
+        background: '#181C22',
+        border: '1px solid rgba(230,235,242,0.10)',
+        borderRadius: 8, padding: '4px 0',
+        minWidth: 180,
+        boxShadow: '0 8px 32px rgba(0,0,0,0.45)',
+      }}
+    >
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        onChange={handleUpload}
+        style={{ display: 'none' }}
+      />
+
+      <button
+        style={itemStyle}
+        onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(230,235,242,0.06)'; }}
+        onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+        onClick={() => fileRef.current?.click()}
+        disabled={uploading}
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+          <polyline points="17 8 12 3 7 8" />
+          <line x1="12" y1="3" x2="12" y2="15" />
+        </svg>
+        {uploading ? 'Uploading...' : 'Upload image'}
+      </button>
+
+      {openaiAvailable && (
+        <button
+          style={itemStyle}
+          onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(230,235,242,0.06)'; }}
+          onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+          onClick={() => { onClose(); onGenerate(); }}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 2L2 7l10 5 10-5-10-5z" />
+            <path d="M2 17l10 5 10-5" />
+            <path d="M2 12l10 5 10-5" />
+          </svg>
+          Generate with AI
+        </button>
+      )}
+
+      {hasAvatar && (
+        <>
+          <div style={{ height: 1, background: 'rgba(230,235,242,0.07)', margin: '4px 0' }} />
+          <button
+            style={{ ...itemStyle, color: 'rgba(217,119,87,0.85)' }}
+            onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(217,119,87,0.08)'; }}
+            onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+            onClick={handleRemove}
+            disabled={removing}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2" />
+            </svg>
+            {removing ? 'Removing...' : 'Remove avatar'}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/agent/components/AvatarMenu.tsx
+++ b/frontend/src/agent/components/AvatarMenu.tsx
@@ -27,10 +27,10 @@ export function AvatarMenu({
     function handleKey(e: KeyboardEvent) {
       if (e.key === 'Escape') onClose();
     }
-    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('click', handleClick);
     document.addEventListener('keydown', handleKey);
     return () => {
-      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('click', handleClick);
       document.removeEventListener('keydown', handleKey);
     };
   }, [onClose]);

--- a/frontend/src/agent/components/ConversationSidebar.tsx
+++ b/frontend/src/agent/components/ConversationSidebar.tsx
@@ -6,6 +6,8 @@ import { formatSidebarTime } from '../utils/dateFormat';
 
 interface Props {
   agentName: string;
+  avatarUrl?: string;
+  onAvatarClick?: (e: React.MouseEvent) => void;
   conversations: Conversation[];
   activeId: string | null;
   searchQuery: string;
@@ -19,7 +21,8 @@ interface Props {
 }
 
 export function ConversationSidebar({
-  agentName, conversations, activeId, searchQuery, searchResults, isSearching,
+  agentName, avatarUrl, onAvatarClick,
+  conversations, activeId, searchQuery, searchResults, isSearching,
   onNew, onSelect, onDelete, onSearch, onRename,
 }: Props) {
   const [collapsed, setCollapsed] = useState(false);
@@ -73,7 +76,12 @@ export function ConversationSidebar({
         padding: '14px 16px', display: 'flex', alignItems: 'center', gap: 12,
         borderBottom: '1px solid rgba(230,235,242,0.07)',
       }}>
-        <AgentMark letter={letter} size={36} />
+        <div
+          onClick={onAvatarClick}
+          style={{ cursor: onAvatarClick ? 'pointer' : 'default', borderRadius: 6, lineHeight: 0 }}
+        >
+          <AgentMark letter={letter} size={36} avatarUrl={avatarUrl} />
+        </div>
         <div style={{ flex: 1 }}>
           <div style={{
             fontFamily: "'Fraunces', Georgia, serif",


### PR DESCRIPTION
## Summary

- Replace the static "Set Avatar" button with a click-on-avatar popover menu offering three actions: upload image, generate with AI (when OpenAI available), and remove avatar
- Add `DELETE /api/agents/{id}/avatar` endpoint for avatar removal (deletes file, clears GCS, updates DB)
- Show the agent's actual avatar in the conversation sidebar with click-to-change support
- Mobile sidebar avatar option now shows "Change Avatar" / "Set Avatar" dynamically

## Test plan

- [ ] Click agent avatar in header bar → popover menu appears
- [ ] Click avatar again → menu toggles closed
- [ ] Click outside menu or press Escape → menu dismisses
- [ ] Upload an image via menu → avatar updates immediately
- [ ] "Generate with AI" opens the AI avatar picker (requires OpenAI key)
- [ ] "Remove avatar" deletes avatar, reverts to letter badge
- [ ] Sidebar shows actual avatar image (not just letter)
- [ ] Click sidebar avatar → popover menu appears (desktop only)
- [ ] Mobile: hamburger menu shows "Change Avatar" when avatar set, "Set Avatar" when not
- [ ] Avatar not clickable during onboarding (before agent setup complete)