### PR TITLE
Add Telegram message debounce with response hold

### DIFF
--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -26,6 +26,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
+from collections.abc import Callable
 from typing import AsyncGenerator
 from zoneinfo import ZoneInfo
 
@@ -1277,6 +1278,8 @@ async def run_sync(
     integration_tool_defs: list[dict] | None = None,
     integration_tool_modes: dict[str, str] | None = None,
     source: str = "chat",
+    on_iteration: Callable[[int], bool] | None = None,
+    skip_user_save: bool = False,
 ) -> str:
     """Run an agent synchronously, returning the final text response.
 
@@ -1383,7 +1386,7 @@ async def run_sync(
 
     # Chat history — save user message
     persist = chat_service is not None
-    if persist:
+    if persist and not skip_user_save:
         try:
             if not conversation_id:
                 conv = chat_service.create_conversation()
@@ -1408,6 +1411,10 @@ async def run_sync(
     max_iterations = 20
 
     for iteration in range(max_iterations):
+        if on_iteration is not None and iteration > 0:
+            if not on_iteration(iteration):
+                return ""
+
         tool_calls_this_turn: list[dict] = []
         turn_text = ""
         stop_reason = "stop"

--- a/backend/integrations/telegram/client.py
+++ b/backend/integrations/telegram/client.py
@@ -119,6 +119,20 @@ def delete_webhook(bot_token: str) -> dict:
         return {"ok": False, "error": str(e)}
 
 
+def send_chat_action(chat_id: int | str, action: str, bot_token: str) -> None:
+    """Send a chat action indicator (e.g. 'typing'). Silent on failure."""
+    if not bot_token:
+        return
+    try:
+        httpx.post(
+            f"{_base_url(bot_token)}/sendChatAction",
+            json={"chat_id": chat_id, "action": action},
+            timeout=5,
+        )
+    except httpx.HTTPError:
+        pass
+
+
 def get_me(bot_token: str) -> dict:
     """Get bot info (username, name) for status display."""
     if not bot_token:

--- a/backend/integrations/telegram/debounce.py
+++ b/backend/integrations/telegram/debounce.py
@@ -1,0 +1,409 @@
+"""Telegram message debounce — response hold system.
+
+Batches rapid-fire messages into a single AI turn. When a message arrives:
+1. Save it to chat history immediately
+2. Start AI processing immediately (no delay on first message)
+3. Hold the AI response for a configurable window before sending
+4. If a new message arrives during the hold, discard the response and restart
+
+Thread-based: uses threading.Timer for hold windows, threading.Event for
+cancellation, threading.Lock for state protection.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from .client import send_chat_action, send_message
+from . import group, service, state
+
+logger = logging.getLogger(__name__)
+
+_STALE_TTL = 300  # 5 minutes — same as old busy TTL
+_MAX_RESTARTS = 3
+_TYPING_INTERVAL = 4.0  # Telegram typing expires after ~5s
+
+
+@dataclass
+class _ChatState:
+    messages: list[str] = field(default_factory=list)
+    held_response: str | None = None
+    timer: threading.Timer | None = None
+    cancelled: threading.Event = field(default_factory=threading.Event)
+    restart_count: int = 0
+    processing: bool = False
+    generation: int = 0
+    bot_token: str = ""
+    agent_id: str = ""
+    agent_slug: str = ""
+    sender_id: str = ""
+    sender_name: str = ""
+    chat_id: int = 0
+    is_group: bool = False
+    group_meta: dict | None = None
+    typing_timer: threading.Timer | None = None
+    started_at: float = 0.0
+
+
+_states: dict[tuple[str, int], _ChatState] = {}
+_lock = threading.Lock()
+
+# Use the router's executor for AI processing
+_executor = None
+
+
+def _get_executor():
+    global _executor
+    if _executor is None:
+        from .router import _executor as router_executor
+        _executor = router_executor
+    return _executor
+
+
+def _get_hold_delay_seconds() -> float:
+    from setup.router import load_admin_settings
+    settings = load_admin_settings()
+    return settings.get("message_hold_delay_ms", 2000) / 1000.0
+
+
+def make_on_iteration(key: tuple[str, int]) -> Callable[[int], bool]:
+    """Build an on_iteration callback that checks the cancellation Event."""
+    def check(_iteration: int) -> bool:
+        with _lock:
+            st = _states.get(key)
+            if st is None:
+                return True
+            return not st.cancelled.is_set()
+    return check
+
+
+def enqueue_message(
+    agent_slug: str,
+    chat_id: int,
+    message_text: str,
+    prefix: str,
+    bot_token: str,
+    agent_id: str,
+    sender_id: str,
+    sender_name: str,
+    is_group: bool = False,
+    group_meta: dict | None = None,
+) -> None:
+    """Enqueue a message for debounced processing.
+
+    Called from the router's _safe_process_telegram(). This is the main
+    entry point for the debounce system.
+    """
+    key = (agent_slug, chat_id)
+    prefixed_text = prefix + message_text
+
+    # Save to chat history immediately (fire-and-forget)
+    _save_message_async(agent_id, agent_slug, sender_id, prefixed_text,
+                        source="telegram-group" if is_group else "telegram")
+
+    # Send typing indicator
+    send_chat_action(chat_id, "typing", bot_token)
+
+    with _lock:
+        st = _states.get(key)
+
+        if st is None:
+            # First message for this chat — create state and start processing
+            st = _ChatState(
+                messages=[prefixed_text],
+                bot_token=bot_token,
+                agent_id=agent_id,
+                agent_slug=agent_slug,
+                sender_id=sender_id,
+                sender_name=sender_name,
+                chat_id=chat_id,
+                is_group=is_group,
+                group_meta=group_meta,
+                processing=True,
+                started_at=time.monotonic(),
+            )
+            _states[key] = st
+            _start_typing_refresh(key, st)
+            generation = st.generation
+            # Release lock before submitting to executor
+            _get_executor().submit(_run_ai, key, generation)
+            return
+
+        # Stale state detection
+        if st.processing and (time.monotonic() - st.started_at) > _STALE_TTL:
+            logger.warning("Debounce: stale state for %s, resetting", key)
+            _cancel_timers(st)
+            st.messages = [prefixed_text]
+            st.held_response = None
+            st.cancelled.clear()
+            st.restart_count = 0
+            st.processing = True
+            st.generation += 1
+            st.started_at = time.monotonic()
+            st.bot_token = bot_token
+            st.agent_id = agent_id
+            st.sender_id = sender_id
+            st.sender_name = sender_name
+            st.is_group = is_group
+            st.group_meta = group_meta
+            _start_typing_refresh(key, st)
+            generation = st.generation
+            _get_executor().submit(_run_ai, key, generation)
+            return
+
+        # Update group_meta with latest message's sender info
+        if is_group and group_meta:
+            st.group_meta = group_meta
+        st.sender_name = sender_name
+
+        if st.held_response is not None:
+            # AI finished, response is being held — cancel timer, discard, restart
+            if st.timer is not None:
+                st.timer.cancel()
+                st.timer = None
+            st.held_response = None
+            st.messages.append(prefixed_text)
+            st.processing = True
+            st.cancelled.clear()
+            st.generation += 1
+            st.started_at = time.monotonic()
+            generation = st.generation
+            _get_executor().submit(_run_ai, key, generation)
+            return
+
+        if st.processing:
+            # AI is still running — accumulate and signal cancellation if allowed
+            st.messages.append(prefixed_text)
+            if st.restart_count < _MAX_RESTARTS:
+                st.cancelled.set()
+            return
+
+        # Shouldn't reach here, but handle gracefully
+        st.messages.append(prefixed_text)
+        st.processing = True
+        st.cancelled.clear()
+        st.generation += 1
+        st.started_at = time.monotonic()
+        generation = st.generation
+        _get_executor().submit(_run_ai, key, generation)
+
+
+def _run_ai(key: tuple[str, int], generation: int) -> None:
+    """Run AI processing in a thread. Handles completion, cancellation, and restart."""
+    with _lock:
+        st = _states.get(key)
+        if st is None or st.generation != generation:
+            return
+        combined = "\n".join(st.messages)
+        is_group = st.is_group
+        agent_id = st.agent_id
+        sender_id = st.sender_id
+        sender_name = st.sender_name
+
+    # Run the AI call (blocking, with its own event loop)
+    loop = asyncio.new_event_loop()
+    try:
+        on_iter = make_on_iteration(key)
+        if is_group:
+            chat_id = key[1]
+            response = loop.run_until_complete(
+                service.process_group_message_batched(
+                    chat_id=chat_id,
+                    agent_id=agent_id,
+                    combined_message=combined,
+                    on_iteration=on_iter,
+                )
+            )
+        else:
+            response = loop.run_until_complete(
+                service.process_message_batched(
+                    sender_id=sender_id,
+                    sender_name=sender_name,
+                    combined_message=combined,
+                    agent_id=agent_id,
+                    on_iteration=on_iter,
+                )
+            )
+    except Exception:
+        logger.exception("Debounce: AI processing failed for %s", key)
+        response = ""
+    finally:
+        loop.close()
+
+    # Handle completion
+    with _lock:
+        st = _states.get(key)
+        if st is None or st.generation != generation:
+            return  # Stale — a newer run superseded us
+
+        if st.cancelled.is_set():
+            # Cancelled — restart with accumulated messages
+            st.cancelled.clear()
+            st.restart_count += 1
+            st.generation += 1
+            st.started_at = time.monotonic()
+            new_generation = st.generation
+            _get_executor().submit(_run_ai, key, new_generation)
+            return
+
+        st.processing = False
+
+        if not response:
+            # AI returned empty (error) — send error message and cleanup
+            _stop_typing_refresh(st)
+            del _states[key]
+            send_message(st.chat_id, "I had trouble processing that. Please try again.", st.bot_token)
+            return
+
+        # Normal completion — check hold delay
+        hold_delay = _get_hold_delay_seconds()
+        if hold_delay <= 0:
+            # Disabled — send immediately
+            chat_id = st.chat_id
+            bot_token = st.bot_token
+            is_group = st.is_group
+            agent_id = st.agent_id
+            agent_slug = st.agent_slug
+            sender_id = st.sender_id
+            _stop_typing_refresh(st)
+            del _states[key]
+            send_message(chat_id, response, bot_token)
+            if is_group:
+                group.record_response(chat_id, agent_id)
+            _save_response_async(agent_slug, sender_id, agent_id, response,
+                                 source="telegram-group" if is_group else "telegram")
+            return
+
+        # Start hold timer
+        st.held_response = response
+        st.timer = threading.Timer(hold_delay, _on_hold_expired, args=[key, generation])
+        st.timer.daemon = True
+        st.timer.start()
+
+
+def _on_hold_expired(key: tuple[str, int], generation: int) -> None:
+    """Hold window expired — send the response."""
+    with _lock:
+        st = _states.get(key)
+        if st is None or st.generation != generation:
+            return
+        if st.held_response is None:
+            return  # Already cancelled by a new message
+
+        response = st.held_response
+        chat_id = st.chat_id
+        bot_token = st.bot_token
+        agent_slug = st.agent_slug
+        sender_id = st.sender_id
+        agent_id = st.agent_id
+        is_group = st.is_group
+
+        _stop_typing_refresh(st)
+        del _states[key]
+
+    send_message(chat_id, response, bot_token)
+    if is_group:
+        group.record_response(chat_id, agent_id)
+    _save_response_async(agent_slug, sender_id, agent_id, response,
+                         source="telegram-group" if is_group else "telegram")
+
+
+# ---------------------------------------------------------------------------
+# Typing indicator refresh
+# ---------------------------------------------------------------------------
+
+def _start_typing_refresh(key: tuple[str, int], st: _ChatState) -> None:
+    """Start a repeating timer to refresh the typing indicator."""
+    _stop_typing_refresh(st)
+    t = threading.Timer(_TYPING_INTERVAL, _typing_tick, args=[key])
+    t.daemon = True
+    t.start()
+    st.typing_timer = t
+
+
+def _typing_tick(key: tuple[str, int]) -> None:
+    """Send typing indicator and schedule next tick."""
+    with _lock:
+        st = _states.get(key)
+        if st is None:
+            return
+        chat_id = st.chat_id
+        bot_token = st.bot_token
+
+    send_chat_action(chat_id, "typing", bot_token)
+
+    with _lock:
+        st = _states.get(key)
+        if st is None:
+            return
+        t = threading.Timer(_TYPING_INTERVAL, _typing_tick, args=[key])
+        t.daemon = True
+        t.start()
+        st.typing_timer = t
+
+
+def _stop_typing_refresh(st: _ChatState) -> None:
+    """Cancel the typing refresh timer."""
+    if st.typing_timer is not None:
+        st.typing_timer.cancel()
+        st.typing_timer = None
+
+
+def _cancel_timers(st: _ChatState) -> None:
+    """Cancel all timers on a state."""
+    if st.timer is not None:
+        st.timer.cancel()
+        st.timer = None
+    _stop_typing_refresh(st)
+
+
+# ---------------------------------------------------------------------------
+# Chat history helpers (fire-and-forget, non-blocking)
+# ---------------------------------------------------------------------------
+
+def _save_message_async(
+    agent_id: str, agent_slug: str, sender_id: str, content: str, source: str = "telegram",
+) -> None:
+    """Save a user message to chat history without blocking."""
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(service.save_message_only(
+            agent_id=agent_id,
+            agent_slug=agent_slug,
+            sender_id=sender_id,
+            content=content,
+            source=source,
+        ))
+    except Exception:
+        logger.warning("Debounce: failed to save message for %s/%s", agent_slug, sender_id, exc_info=True)
+    finally:
+        loop.close()
+
+
+def _save_response_async(
+    agent_slug: str, sender_id: str, agent_id: str, response: str, source: str = "telegram",
+) -> None:
+    """Save the assistant response to chat history."""
+    try:
+        from agents.engine import get_chat_service
+        chat_service = get_chat_service(agent_slug)
+        if not chat_service:
+            return
+
+        conv = state.get_or_create_conversation(sender_id, agent_id)
+        chatty_conv_id = conv.get("chatty_conversation_id")
+        if not chatty_conv_id:
+            return
+
+        chat_service.save_message(
+            conversation_id=chatty_conv_id,
+            msg_id=str(uuid.uuid4()),
+            role="assistant",
+            content=response,
+        )
+    except Exception:
+        logger.warning("Debounce: failed to save response for %s", agent_slug, exc_info=True)

--- a/backend/integrations/telegram/debounce.py
+++ b/backend/integrations/telegram/debounce.py
@@ -52,22 +52,21 @@ class _ChatState:
 _states: dict[tuple[str, int], _ChatState] = {}
 _lock = threading.Lock()
 
-# Use the router's executor for AI processing
-_executor = None
+_MAX_MESSAGES = 50
 
 
 def _get_executor():
-    global _executor
-    if _executor is None:
-        from .router import _executor as router_executor
-        _executor = router_executor
+    from .router import _executor
     return _executor
 
 
 def _get_hold_delay_seconds() -> float:
-    from setup.router import load_admin_settings
-    settings = load_admin_settings()
-    return settings.get("message_hold_delay_ms", 2000) / 1000.0
+    try:
+        from setup.router import load_admin_settings
+        settings = load_admin_settings()
+        return max(0.0, float(settings.get("message_hold_delay_ms", 2000)) / 1000.0)
+    except Exception:
+        return 2.0
 
 
 def make_on_iteration(key: tuple[str, int]) -> Callable[[int], bool]:
@@ -166,7 +165,8 @@ def enqueue_message(
                 st.timer.cancel()
                 st.timer = None
             st.held_response = None
-            st.messages.append(prefixed_text)
+            if len(st.messages) < _MAX_MESSAGES:
+                st.messages.append(prefixed_text)
             st.processing = True
             st.cancelled.clear()
             st.generation += 1
@@ -177,13 +177,15 @@ def enqueue_message(
 
         if st.processing:
             # AI is still running — accumulate and signal cancellation if allowed
-            st.messages.append(prefixed_text)
+            if len(st.messages) < _MAX_MESSAGES:
+                st.messages.append(prefixed_text)
             if st.restart_count < _MAX_RESTARTS:
                 st.cancelled.set()
             return
 
         # Shouldn't reach here, but handle gracefully
-        st.messages.append(prefixed_text)
+        if len(st.messages) < _MAX_MESSAGES:
+            st.messages.append(prefixed_text)
         st.processing = True
         st.cancelled.clear()
         st.generation += 1
@@ -234,55 +236,51 @@ def _run_ai(key: tuple[str, int], generation: int) -> None:
     finally:
         loop.close()
 
-    # Handle completion
+    # Handle completion — determine action under lock, execute I/O outside
+    action = None
     with _lock:
         st = _states.get(key)
         if st is None or st.generation != generation:
-            return  # Stale — a newer run superseded us
+            return
 
         if st.cancelled.is_set():
-            # Cancelled — restart with accumulated messages
             st.cancelled.clear()
             st.restart_count += 1
             st.generation += 1
             st.started_at = time.monotonic()
-            new_generation = st.generation
-            _get_executor().submit(_run_ai, key, new_generation)
+            _get_executor().submit(_run_ai, key, st.generation)
             return
 
         st.processing = False
 
         if not response:
-            # AI returned empty (error) — send error message and cleanup
+            action = ("error", st.chat_id, st.bot_token, st.is_group, st.agent_id, st.agent_slug, st.sender_id)
             _stop_typing_refresh(st)
             del _states[key]
-            send_message(st.chat_id, "I had trouble processing that. Please try again.", st.bot_token)
-            return
+        else:
+            hold_delay = _get_hold_delay_seconds()
+            if hold_delay <= 0:
+                action = ("send", st.chat_id, st.bot_token, st.is_group, st.agent_id, st.agent_slug, st.sender_id)
+                _stop_typing_refresh(st)
+                del _states[key]
+            else:
+                st.held_response = response
+                st.timer = threading.Timer(hold_delay, _on_hold_expired, args=[key, generation])
+                st.timer.daemon = True
+                st.timer.start()
 
-        # Normal completion — check hold delay
-        hold_delay = _get_hold_delay_seconds()
-        if hold_delay <= 0:
-            # Disabled — send immediately
-            chat_id = st.chat_id
-            bot_token = st.bot_token
-            is_group = st.is_group
-            agent_id = st.agent_id
-            agent_slug = st.agent_slug
-            sender_id = st.sender_id
-            _stop_typing_refresh(st)
-            del _states[key]
-            send_message(chat_id, response, bot_token)
-            if is_group:
-                group.record_response(chat_id, agent_id)
-            _save_response_async(agent_slug, sender_id, agent_id, response,
-                                 source="telegram-group" if is_group else "telegram")
-            return
-
-        # Start hold timer
-        st.held_response = response
-        st.timer = threading.Timer(hold_delay, _on_hold_expired, args=[key, generation])
-        st.timer.daemon = True
-        st.timer.start()
+    # I/O outside the lock
+    if action is None:
+        return
+    kind, chat_id, bot_token, is_group, agent_id, agent_slug, sender_id = action
+    if kind == "error":
+        send_message(chat_id, "I had trouble processing that. Please try again.", bot_token)
+    elif kind == "send":
+        send_message(chat_id, response, bot_token)
+        if is_group:
+            group.record_response(chat_id, agent_id)
+        _save_response_async(agent_slug, sender_id, agent_id, response,
+                             source="telegram-group" if is_group else "telegram")
 
 
 def _on_hold_expired(key: tuple[str, int], generation: int) -> None:
@@ -339,6 +337,8 @@ def _typing_tick(key: tuple[str, int]) -> None:
     with _lock:
         st = _states.get(key)
         if st is None:
+            return
+        if not st.processing and st.held_response is None:
             return
         t = threading.Timer(_TYPING_INTERVAL, _typing_tick, args=[key])
         t.daemon = True

--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -4,11 +4,8 @@ Handles inbound Telegram webhooks (unauthenticated, routed by agent slug)
 and JWT-protected admin endpoints for bot token management and registration.
 """
 
-import asyncio
 import hmac
 import logging
-import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -16,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from core.auth import get_current_user
 from agents import db as agent_db
 
-from . import state, lifecycle, service
+from . import state, lifecycle, service, debounce
 from .client import send_message
 from .models import SetBotTokenRequest, ResetRegistrationRequest
 
@@ -25,12 +22,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["telegram"])
 
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="telegram-webhook")
-
-# Per-chat busy tracking: maps (agent_slug, chat_id) → start timestamp.
-# Entries older than _BUSY_TTL are treated as stale (hung request).
-_busy_chats: dict[tuple[str, int], float] = {}
-_busy_lock = threading.Lock()
-_BUSY_TTL = 300  # 5 minutes
 
 from pathlib import Path as _Path
 _AGENTS_DIR = _Path(__file__).resolve().parent.parent.parent / "data" / "agents"
@@ -119,12 +110,14 @@ def _safe_process_telegram(
     from_username: str = "", group_name: str = "",
     entities: list | None = None, reply_to_bot_username: str = "",
 ) -> None:
-    """Process a Telegram message in a background thread."""
+    """Process a Telegram message in a background thread.
+
+    Routes through the debounce module which handles message batching,
+    AI cancellation/restart, and response hold timing.
+    """
     from . import group
 
-    bot_token = ""
     try:
-        # Resolve slug → agent
         agent = agent_db.get_agent_by_slug(agent_slug)
         if not agent:
             logger.warning("Telegram webhook: unknown slug %s", agent_slug)
@@ -134,7 +127,6 @@ def _safe_process_telegram(
         if not bot_token:
             return
 
-        # Check Telegram is enabled before any processing
         if not agent.get("telegram_enabled"):
             return
 
@@ -155,57 +147,19 @@ def _safe_process_telegram(
             if is_bot:
                 group.record_bot_message(chat_id)
 
-            # Busy check — save message to history but skip AI if already processing
-            busy_key = (agent_slug, chat_id)
-            busy_started = time.monotonic()
-            with _busy_lock:
-                existing = _busy_chats.get(busy_key)
-                if existing is not None and (busy_started - existing) < _BUSY_TTL:
-                    is_busy = True
-                else:
-                    _busy_chats[busy_key] = busy_started
-                    is_busy = False
-
-            if is_busy:
-                logger.info("Telegram busy (group): agent=%s chat=%s — saving without reply", agent_slug, chat_id)
-                prefix = group.build_group_prefix(group_name, sender_name, is_bot)
-                loop = asyncio.new_event_loop()
-                try:
-                    loop.run_until_complete(service.save_message_only(
-                        agent_id=agent["id"],
-                        agent_slug=agent_slug,
-                        sender_id=f"group:{chat_id}",
-                        content=prefix + message,
-                        source="telegram-group",
-                    ))
-                except Exception:
-                    logger.warning("Failed to save busy-skipped group message for chat=%s", chat_id, exc_info=True)
-                finally:
-                    loop.close()
-                return
-
-            try:
-                loop = asyncio.new_event_loop()
-                try:
-                    response = loop.run_until_complete(
-                        service.process_group_message(
-                            chat_id=chat_id,
-                            agent_id=agent["id"],
-                            sender_name=sender_name,
-                            sender_is_bot=is_bot,
-                            group_name=group_name,
-                            message_text=message,
-                        )
-                    )
-                finally:
-                    loop.close()
-
-                send_message(chat_id, response, bot_token)
-                group.record_response(chat_id, agent["id"])
-            finally:
-                with _busy_lock:
-                    if _busy_chats.get(busy_key) == busy_started:
-                        del _busy_chats[busy_key]
+            prefix = group.build_group_prefix(group_name, sender_name, is_bot)
+            debounce.enqueue_message(
+                agent_slug=agent_slug,
+                chat_id=chat_id,
+                message_text=message,
+                prefix=prefix,
+                bot_token=bot_token,
+                agent_id=agent["id"],
+                sender_id=f"group:{chat_id}",
+                sender_name=sender_name,
+                is_group=True,
+                group_meta={"group_name": group_name, "sender_name": sender_name, "sender_is_bot": is_bot},
+            )
             return
 
         # ── Private chat path ────────────────────────────────────────
@@ -223,58 +177,20 @@ def _safe_process_telegram(
                 )
                 return
 
-        # Busy check — save message to history but skip AI if already processing
-        busy_key = (agent_slug, chat_id)
-        busy_started = time.monotonic()
-        with _busy_lock:
-            existing = _busy_chats.get(busy_key)
-            if existing is not None and (busy_started - existing) < _BUSY_TTL:
-                is_busy = True
-            else:
-                _busy_chats[busy_key] = busy_started
-                is_busy = False
-
-        if is_busy:
-            logger.info("Telegram busy (private): agent=%s chat=%s — saving without reply", agent_slug, chat_id)
-            prefix = f"[via Telegram from {sender_name}] "
-            loop = asyncio.new_event_loop()
-            try:
-                loop.run_until_complete(service.save_message_only(
-                    agent_id=agent_id,
-                    agent_slug=agent_slug,
-                    sender_id=user_id,
-                    content=prefix + message,
-                ))
-            except Exception:
-                logger.warning("Failed to save busy-skipped message for chat=%s", chat_id, exc_info=True)
-            finally:
-                loop.close()
-            return
-
-        # Process the message via async service
-        try:
-            loop = asyncio.new_event_loop()
-            try:
-                response = loop.run_until_complete(
-                    service.process_message(user_id, sender_name, message, agent_id)
-                )
-            finally:
-                loop.close()
-
-            send_message(chat_id, response, bot_token)
-        finally:
-            with _busy_lock:
-                if _busy_chats.get(busy_key) == busy_started:
-                    del _busy_chats[busy_key]
+        prefix = f"[via Telegram from {sender_name}] "
+        debounce.enqueue_message(
+            agent_slug=agent_slug,
+            chat_id=chat_id,
+            message_text=message,
+            prefix=prefix,
+            bot_token=bot_token,
+            agent_id=agent_id,
+            sender_id=user_id,
+            sender_name=sender_name,
+            is_group=False,
+        )
     except Exception:
         logger.exception("Telegram processing failed (slug=%s, user_id=%s)", agent_slug, user_id)
-        try:
-            if bot_token:
-                send_message(
-                    chat_id, "I had trouble processing that. Please try again.", bot_token,
-                )
-        except Exception:
-            pass
 
 
 # ---------------------------------------------------------------------------

--- a/backend/integrations/telegram/router.py
+++ b/backend/integrations/telegram/router.py
@@ -191,6 +191,11 @@ def _safe_process_telegram(
         )
     except Exception:
         logger.exception("Telegram processing failed (slug=%s, user_id=%s)", agent_slug, user_id)
+        try:
+            if bot_token:
+                send_message(chat_id, "I had trouble processing that. Please try again.", bot_token)
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -8,6 +8,7 @@ The router handles sending the response back via the Telegram client.
 import importlib
 import logging
 import uuid
+from collections.abc import Callable
 
 from agents import db as agent_db
 from agents.engine import (
@@ -349,6 +350,213 @@ async def process_group_message(
     )
 
     return response or "I had trouble generating a response. Please try again."
+
+
+async def process_message_batched(
+    sender_id: str,
+    sender_name: str,
+    combined_message: str,
+    agent_id: str,
+    on_iteration: Callable[[int], bool] | None = None,
+) -> str:
+    """Process a batched (combined) private Telegram message.
+
+    Like process_message() but takes pre-combined text (already prefixed),
+    passes on_iteration for cancellation support, and skips user message save
+    (messages already saved individually by the debounce module).
+
+    Returns response text. Empty string means the run was aborted.
+    """
+    agent = agent_db.get_agent(agent_id)
+    if not agent:
+        return "This agent is no longer available."
+    if not agent.get("telegram_enabled"):
+        return "Telegram messaging is currently disabled for this agent."
+
+    slug = agent["slug"]
+    config = build_agent_config(agent)
+    ctx_manager = get_context_manager(slug)
+    chat_service = get_chat_service(slug)
+
+    provider = get_ai_provider(
+        agent_provider=config.provider_override or None,
+        agent_model=config.model_override or None,
+        agent_model_tier=config.model_tier,
+    )
+    if not provider:
+        return "No AI provider is configured. Please set up an AI provider in Settings."
+
+    ga = config.google_accounts
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    from integrations.registry import list_google_accounts as _list_ga
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
+
+    integration_tool_defs, integration_executors = _load_integration_tools()
+
+    from integrations.registry import get_tool_mode, get_credentials
+    integration_tool_modes = {
+        name: get_tool_mode(name)
+        for name in _INTEGRATION_MODULES
+        if "tool_mode" in get_credentials(name)
+    }
+
+    reminder_handlers, sa_handlers = _build_agent_handlers(slug)
+    registry = ToolRegistry(
+        context_dir=config.context_dir,
+        google_connected=google_connected,
+        integration_executors=integration_executors,
+        agent_slug=slug,
+        reminder_handlers=reminder_handlers,
+        scheduled_action_handlers=sa_handlers,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
+    )
+
+    conv = state.get_or_create_conversation(sender_id, agent_id)
+    chatty_conv_id = conv.get("chatty_conversation_id")
+    if not chatty_conv_id and chat_service:
+        try:
+            new_conv = chat_service.create_conversation(source="telegram")
+            chatty_conv_id = new_conv["id"]
+            state.set_chatty_conversation_id(conv["id"], chatty_conv_id)
+        except Exception as e:
+            logger.warning("Failed to create chat history conversation: %s", e)
+
+    messages = _load_recent_messages(chat_service, chatty_conv_id)
+    if not messages:
+        messages = [{"role": "user", "content": combined_message}]
+    else:
+        messages.append({"role": "user", "content": combined_message})
+
+    response = await ai_service.run_sync(
+        config=config,
+        provider=provider,
+        registry=registry,
+        ctx_manager=ctx_manager,
+        messages=messages,
+        chat_service=chat_service,
+        conversation_id=chatty_conv_id,
+        integration_tool_defs=integration_tool_defs or None,
+        integration_tool_modes=integration_tool_modes,
+        source="telegram",
+        on_iteration=on_iteration,
+        skip_user_save=True,
+    )
+
+    return response or ""
+
+
+async def process_group_message_batched(
+    chat_id: int,
+    agent_id: str,
+    combined_message: str,
+    on_iteration: Callable[[int], bool] | None = None,
+) -> str:
+    """Process a batched (combined) group Telegram message.
+
+    Like process_group_message() but takes pre-combined text (already prefixed),
+    passes on_iteration for cancellation support, and skips user message save.
+
+    Returns response text. Empty string means the run was aborted.
+    """
+    agent = agent_db.get_agent(agent_id)
+    if not agent:
+        return "This agent is no longer available."
+    if not agent.get("telegram_enabled"):
+        return "Telegram messaging is currently disabled for this agent."
+
+    slug = agent["slug"]
+    config = build_agent_config(agent)
+    ctx_manager = get_context_manager(slug)
+    chat_service = get_chat_service(slug)
+
+    provider = get_ai_provider(
+        agent_provider=config.provider_override or None,
+        agent_model=config.model_override or None,
+        agent_model_tier=config.model_tier,
+    )
+    if not provider:
+        return "No AI provider is configured. Please set up an AI provider in Settings."
+
+    ga = config.google_accounts
+    gmail_ids = ga.get("gmail", [])
+    calendar_ids = ga.get("calendar", [])
+    drive_ids = ga.get("drive", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+
+    from integrations.registry import list_google_accounts as _list_ga
+    all_ga = _list_ga()
+    account_info_map = {
+        aid: {"email": a.get("email", ""), "scope_grants": a.get("scope_grants", {}), "connection_status": a.get("connection_status", "ok")}
+        for aid, a in all_ga.items()
+    }
+
+    integration_tool_defs, integration_executors = _load_integration_tools()
+
+    from integrations.registry import get_tool_mode, get_credentials
+    integration_tool_modes = {
+        name: get_tool_mode(name)
+        for name in _INTEGRATION_MODULES
+        if "tool_mode" in get_credentials(name)
+    }
+
+    reminder_handlers, sa_handlers = _build_agent_handlers(slug)
+    registry = ToolRegistry(
+        context_dir=config.context_dir,
+        google_connected=google_connected,
+        integration_executors=integration_executors,
+        agent_slug=slug,
+        reminder_handlers=reminder_handlers,
+        scheduled_action_handlers=sa_handlers,
+        gmail_account_ids=gmail_ids,
+        calendar_account_ids=calendar_ids,
+        drive_account_ids=drive_ids,
+        account_info_map=account_info_map,
+    )
+
+    group_sender_id = f"group:{chat_id}"
+    conv = state.get_or_create_conversation(group_sender_id, agent_id)
+    chatty_conv_id = conv.get("chatty_conversation_id")
+    if not chatty_conv_id and chat_service:
+        try:
+            new_conv = chat_service.create_conversation(source="telegram-group")
+            chatty_conv_id = new_conv["id"]
+            state.set_chatty_conversation_id(conv["id"], chatty_conv_id)
+        except Exception as e:
+            logger.warning("Failed to create group chat conversation: %s", e)
+
+    messages = _load_recent_messages(chat_service, chatty_conv_id)
+    if not messages:
+        messages = [{"role": "user", "content": combined_message}]
+    else:
+        messages.append({"role": "user", "content": combined_message})
+
+    response = await ai_service.run_sync(
+        config=config,
+        provider=provider,
+        registry=registry,
+        ctx_manager=ctx_manager,
+        messages=messages,
+        chat_service=chat_service,
+        conversation_id=chatty_conv_id,
+        integration_tool_defs=integration_tool_defs or None,
+        integration_tool_modes=integration_tool_modes,
+        source="telegram-group",
+        on_iteration=on_iteration,
+        skip_user_save=True,
+    )
+
+    return response or ""
 
 
 def _load_recent_messages(chat_service, conversation_id: str | None) -> list[dict]:

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -365,13 +365,13 @@ async def process_message_batched(
     passes on_iteration for cancellation support, and skips user message save
     (messages already saved individually by the debounce module).
 
-    Returns response text. Empty string means the run was aborted.
+    Returns response text. Empty string means aborted or error.
     """
     agent = agent_db.get_agent(agent_id)
     if not agent:
-        return "This agent is no longer available."
+        return ""
     if not agent.get("telegram_enabled"):
-        return "Telegram messaging is currently disabled for this agent."
+        return ""
 
     slug = agent["slug"]
     config = build_agent_config(agent)
@@ -384,7 +384,7 @@ async def process_message_batched(
         agent_model_tier=config.model_tier,
     )
     if not provider:
-        return "No AI provider is configured. Please set up an AI provider in Settings."
+        return ""
 
     ga = config.google_accounts
     gmail_ids = ga.get("gmail", [])
@@ -467,13 +467,13 @@ async def process_group_message_batched(
     Like process_group_message() but takes pre-combined text (already prefixed),
     passes on_iteration for cancellation support, and skips user message save.
 
-    Returns response text. Empty string means the run was aborted.
+    Returns response text. Empty string means aborted or error.
     """
     agent = agent_db.get_agent(agent_id)
     if not agent:
-        return "This agent is no longer available."
+        return ""
     if not agent.get("telegram_enabled"):
-        return "Telegram messaging is currently disabled for this agent."
+        return ""
 
     slug = agent["slug"]
     config = build_agent_config(agent)
@@ -486,7 +486,7 @@ async def process_group_message_batched(
         agent_model_tier=config.model_tier,
     )
     if not provider:
-        return "No AI provider is configured. Please set up an AI provider in Settings."
+        return ""
 
     ga = config.google_accounts
     gmail_ids = ga.get("gmail", [])

--- a/backend/setup/router.py
+++ b/backend/setup/router.py
@@ -29,6 +29,7 @@ ADMIN_DEFAULTS = {
     "notifications_web_push": True,
     "notifications_telegram": True,
     "notifications_whatsapp": True,
+    "message_hold_delay_ms": 2000,
 }
 
 VALID_TRIAGE_MODES = {"standard", "cheap", "always_cheap"}
@@ -125,5 +126,9 @@ async def update_admin_settings(body: dict, user=Depends(get_current_user)):
         settings["triage_mode"] = ADMIN_DEFAULTS["triage_mode"]
     if not isinstance(settings.get("default_model_tier"), str) or settings["default_model_tier"] not in VALID_MODEL_TIERS:
         settings["default_model_tier"] = ADMIN_DEFAULTS["default_model_tier"]
+    try:
+        settings["message_hold_delay_ms"] = max(0, min(10000, int(settings.get("message_hold_delay_ms", 2000))))
+    except (TypeError, ValueError):
+        settings["message_hold_delay_ms"] = ADMIN_DEFAULTS["message_hold_delay_ms"]
     atomic_write_json(ADMIN_SETTINGS_FILE, settings)
     return settings

--- a/backend/tests/test_telegram_debounce.py
+++ b/backend/tests/test_telegram_debounce.py
@@ -1,0 +1,535 @@
+"""Tests for the Telegram message debounce system."""
+
+import threading
+import time
+from unittest.mock import patch, MagicMock, call
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from integrations.telegram import debounce
+from integrations.telegram.debounce import (
+    enqueue_message,
+    make_on_iteration,
+    _ChatState,
+    _states,
+    _lock,
+    _STALE_TTL,
+    _MAX_RESTARTS,
+    _get_hold_delay_seconds,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    """Reset debounce state between tests."""
+    with _lock:
+        _states.clear()
+    # Ensure executor is available
+    debounce._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="test-debounce")
+    yield
+    with _lock:
+        # Cancel any lingering timers
+        for st in _states.values():
+            if st.timer:
+                st.timer.cancel()
+            if st.typing_timer:
+                st.typing_timer.cancel()
+        _states.clear()
+    debounce._executor.shutdown(wait=False)
+    debounce._executor = None
+
+
+@pytest.fixture
+def mock_services():
+    """Mock out all external services (AI, Telegram API, chat history)."""
+    with patch("integrations.telegram.debounce.service") as mock_svc, \
+         patch("integrations.telegram.debounce.send_message") as mock_send, \
+         patch("integrations.telegram.debounce.send_chat_action") as mock_typing, \
+         patch("integrations.telegram.debounce.state") as mock_state, \
+         patch("integrations.telegram.debounce.group") as mock_group, \
+         patch("integrations.telegram.debounce._get_hold_delay_seconds", return_value=0.1):
+
+        # Mock save_message_only as a coroutine
+        async def noop_save(*args, **kwargs):
+            pass
+        mock_svc.save_message_only = MagicMock(side_effect=lambda *a, **kw: noop_save(*a, **kw))
+
+        # Mock process_message_batched
+        async def fake_process_private(**kwargs):
+            return "AI response"
+        mock_svc.process_message_batched = MagicMock(side_effect=fake_process_private)
+
+        # Mock process_group_message_batched
+        async def fake_process_group(**kwargs):
+            return "Group AI response"
+        mock_svc.process_group_message_batched = MagicMock(side_effect=fake_process_group)
+
+        # Mock state.get_or_create_conversation
+        mock_state.get_or_create_conversation.return_value = {"chatty_conversation_id": "conv-123"}
+
+        yield {
+            "service": mock_svc,
+            "send_message": mock_send,
+            "send_chat_action": mock_typing,
+            "state": mock_state,
+            "group": mock_group,
+        }
+
+
+class TestSingleMessage:
+    """Single message with no follow-up."""
+
+    def test_single_message_produces_response(self, mock_services):
+        """A single message should process and eventually send a response."""
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="hello",
+            prefix="[via Telegram from John] ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        # Wait for processing + hold timer
+        time.sleep(0.5)
+
+        mock_services["send_message"].assert_called_once()
+        args = mock_services["send_message"].call_args
+        assert args[0][0] == 123  # chat_id
+        assert "AI response" in args[0][1]  # response text
+        assert args[0][2] == "bot:token"  # bot_token
+
+    def test_typing_indicator_sent_immediately(self, mock_services):
+        """Typing indicator should be sent on first message."""
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="hello",
+            prefix="[via Telegram from John] ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        mock_services["send_chat_action"].assert_called_with(123, "typing", "bot:token")
+
+    def test_state_cleaned_up_after_response(self, mock_services):
+        """State should be removed after response is sent."""
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="hello",
+            prefix="[via Telegram from John] ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        time.sleep(0.5)
+
+        with _lock:
+            assert ("test-agent", 123) not in _states
+
+
+class TestBurstDuringHold:
+    """Messages arriving during the hold window (after AI finishes)."""
+
+    def test_second_message_during_hold_restarts(self, mock_services):
+        """A second message during hold discards response and restarts AI."""
+        # Slow down AI to ensure we can send second message during hold
+        call_count = [0]
+
+        async def slow_process(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return "first response"
+            return "combined response"
+
+        mock_services["service"].process_message_batched = MagicMock(side_effect=slow_process)
+
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="hello",
+            prefix="[via Telegram from John] ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        # Wait for AI to finish and hold timer to start, then send second message
+        time.sleep(0.05)
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="what's the weather?",
+            prefix="[via Telegram from John] ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        # Wait for second processing + hold
+        time.sleep(0.5)
+
+        # Should have been called twice (first + restart)
+        assert call_count[0] == 2
+        # Only one message should be sent (the combined response)
+        assert mock_services["send_message"].call_count == 1
+        sent_text = mock_services["send_message"].call_args[0][1]
+        assert sent_text == "combined response"
+
+
+class TestBurstDuringProcessing:
+    """Messages arriving while AI is still processing."""
+
+    def test_message_during_processing_sets_cancelled(self, mock_services):
+        """A message during AI processing should set the cancelled Event."""
+        processing_started = threading.Event()
+        hold_processing = threading.Event()
+
+        async def slow_process(**kwargs):
+            processing_started.set()
+            # Block until we release
+            while not hold_processing.is_set():
+                time.sleep(0.01)
+            # Check if we should return based on on_iteration
+            on_iter = kwargs.get("on_iteration")
+            if on_iter and not on_iter(1):
+                return ""
+            return "response"
+
+        mock_services["service"].process_message_batched = MagicMock(side_effect=slow_process)
+
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="hello",
+            prefix="[via Telegram from John] ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        # Wait for processing to start
+        processing_started.wait(timeout=2)
+
+        # Verify state shows processing
+        with _lock:
+            st = _states.get(("test-agent", 123))
+            assert st is not None
+            assert st.processing is True
+
+        # Send second message during processing
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="follow up",
+            prefix="[via Telegram from John] ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        # Verify cancelled is set
+        with _lock:
+            st = _states.get(("test-agent", 123))
+            assert st.cancelled.is_set()
+            assert len(st.messages) == 2
+
+        # Release the processing
+        hold_processing.set()
+        time.sleep(0.5)
+
+        # Should eventually send a response (from the restart)
+        assert mock_services["send_message"].call_count >= 1
+
+
+class TestMaxRestarts:
+    """After 3 restarts, stop cancelling."""
+
+    def test_max_restarts_stops_cancellation(self, mock_services):
+        """After MAX_RESTARTS, new messages accumulate without cancelling."""
+        call_count = [0]
+
+        async def counting_process(**kwargs):
+            call_count[0] += 1
+            return f"response-{call_count[0]}"
+
+        mock_services["service"].process_message_batched = MagicMock(side_effect=counting_process)
+
+        # Enqueue first message
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="msg1",
+            prefix="P ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        # Wait a tiny bit for processing to start
+        time.sleep(0.02)
+
+        # Simulate the state having 3 restarts already
+        with _lock:
+            st = _states.get(("test-agent", 123))
+            if st:
+                st.restart_count = _MAX_RESTARTS
+
+        # Send another message — should NOT set cancelled
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="msg after max",
+            prefix="P ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        with _lock:
+            st = _states.get(("test-agent", 123))
+            if st:
+                # Should NOT be cancelled since we're past max restarts
+                assert not st.cancelled.is_set()
+
+
+class TestOnIteration:
+    """Test the on_iteration callback mechanism."""
+
+    def test_make_on_iteration_returns_true_when_not_cancelled(self, mock_services):
+        """on_iteration should return True when not cancelled."""
+        key = ("test-agent", 456)
+        with _lock:
+            _states[key] = _ChatState(
+                messages=["test"],
+                bot_token="t",
+                agent_id="a",
+                agent_slug="test-agent",
+                sender_id="u",
+                sender_name="J",
+                chat_id=456,
+            )
+
+        checker = make_on_iteration(key)
+        assert checker(1) is True
+
+    def test_make_on_iteration_returns_false_when_cancelled(self, mock_services):
+        """on_iteration should return False when cancelled Event is set."""
+        key = ("test-agent", 456)
+        with _lock:
+            st = _ChatState(
+                messages=["test"],
+                bot_token="t",
+                agent_id="a",
+                agent_slug="test-agent",
+                sender_id="u",
+                sender_name="J",
+                chat_id=456,
+            )
+            st.cancelled.set()
+            _states[key] = st
+
+        checker = make_on_iteration(key)
+        assert checker(1) is False
+
+    def test_make_on_iteration_returns_true_when_state_gone(self, mock_services):
+        """on_iteration should return True if state was cleaned up."""
+        key = ("test-agent", 789)
+        # Don't create state — simulates cleanup
+        checker = make_on_iteration(key)
+        assert checker(1) is True
+
+
+class TestGroupChat:
+    """Group chat debounce behavior."""
+
+    def test_group_message_calls_group_service(self, mock_services):
+        """Group messages should use process_group_message_batched."""
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=999,
+            message_text="hey everyone",
+            prefix="[Group: Team] Alice: ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="group:999",
+            sender_name="Alice",
+            is_group=True,
+            group_meta={"group_name": "Team", "sender_name": "Alice", "sender_is_bot": False},
+        )
+
+        time.sleep(0.5)
+
+        mock_services["service"].process_group_message_batched.assert_called_once()
+        mock_services["send_message"].assert_called_once()
+
+    def test_group_response_records_response(self, mock_services):
+        """Group responses should call group.record_response."""
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=999,
+            message_text="hey",
+            prefix="[Group: Team] Alice: ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="group:999",
+            sender_name="Alice",
+            is_group=True,
+            group_meta={"group_name": "Team", "sender_name": "Alice", "sender_is_bot": False},
+        )
+
+        time.sleep(0.5)
+
+        mock_services["group"].record_response.assert_called_once_with(999, "agent-1")
+
+
+class TestDisabledFeature:
+    """Behavior when hold delay is 0 (disabled)."""
+
+    def test_delay_zero_sends_immediately(self, mock_services):
+        """With delay=0, response should be sent as soon as AI finishes."""
+        with patch("integrations.telegram.debounce._get_hold_delay_seconds", return_value=0.0):
+            enqueue_message(
+                agent_slug="test-agent",
+                chat_id=123,
+                message_text="hello",
+                prefix="[via Telegram from John] ",
+                bot_token="bot:token",
+                agent_id="agent-1",
+                sender_id="user-1",
+                sender_name="John",
+            )
+
+            # Should send almost immediately (no hold timer)
+            time.sleep(0.2)
+
+            mock_services["send_message"].assert_called_once()
+
+
+class TestStaleState:
+    """Stale state detection and recovery."""
+
+    def test_stale_state_resets(self, mock_services):
+        """State older than STALE_TTL should be reset on next enqueue."""
+        key = ("test-agent", 123)
+
+        with _lock:
+            st = _ChatState(
+                messages=["old message"],
+                bot_token="old_token",
+                agent_id="agent-1",
+                agent_slug="test-agent",
+                sender_id="user-1",
+                sender_name="John",
+                chat_id=123,
+                processing=True,
+                started_at=time.monotonic() - _STALE_TTL - 10,  # Well past TTL
+            )
+            _states[key] = st
+
+        enqueue_message(
+            agent_slug="test-agent",
+            chat_id=123,
+            message_text="fresh message",
+            prefix="[via Telegram from John] ",
+            bot_token="bot:token",
+            agent_id="agent-1",
+            sender_id="user-1",
+            sender_name="John",
+        )
+
+        time.sleep(0.3)
+
+        # State should have been reset and new processing started
+        mock_services["send_message"].assert_called()
+
+
+class TestMessageCombination:
+    """Verify messages are combined correctly."""
+
+    def test_messages_joined_with_newline(self, mock_services):
+        """Combined messages should be newline-separated."""
+        captured_messages = []
+
+        async def capture_process(**kwargs):
+            captured_messages.append(kwargs.get("combined_message", ""))
+            return "response"
+
+        mock_services["service"].process_message_batched = MagicMock(side_effect=capture_process)
+
+        # Use delay=0 so we can see the combined message without timing issues
+        with patch("integrations.telegram.debounce._get_hold_delay_seconds", return_value=0.0):
+            enqueue_message(
+                agent_slug="test-agent",
+                chat_id=123,
+                message_text="hello",
+                prefix="[via Telegram from John] ",
+                bot_token="bot:token",
+                agent_id="agent-1",
+                sender_id="user-1",
+                sender_name="John",
+            )
+
+            time.sleep(0.3)
+
+        # First call should have the single prefixed message
+        assert len(captured_messages) >= 1
+        assert captured_messages[0] == "[via Telegram from John] hello"
+
+
+class TestAdminSettings:
+    """Verify admin settings integration."""
+
+    def test_get_hold_delay_reads_settings(self):
+        """_get_hold_delay_seconds should read from admin settings."""
+        with patch("setup.router.load_admin_settings", return_value={"message_hold_delay_ms": 3000}):
+            delay = _get_hold_delay_seconds()
+            assert delay == 3.0
+
+    def test_get_hold_delay_default(self):
+        """Should default to 2.0s if setting is missing."""
+        with patch("setup.router.load_admin_settings", return_value={}):
+            delay = _get_hold_delay_seconds()
+            assert delay == 2.0
+
+
+class TestChatHistoryPersistence:
+    """Verify messages are saved to chat history correctly."""
+
+    def test_each_message_saved_individually(self, mock_services):
+        """Each arriving message should be saved to history immediately."""
+        save_calls = []
+
+        async def track_save(*args, **kwargs):
+            save_calls.append(kwargs)
+
+        mock_services["service"].save_message_only = MagicMock(side_effect=track_save)
+
+        with patch("integrations.telegram.debounce._get_hold_delay_seconds", return_value=0.0):
+            enqueue_message(
+                agent_slug="test-agent",
+                chat_id=123,
+                message_text="first",
+                prefix="[via Telegram from John] ",
+                bot_token="bot:token",
+                agent_id="agent-1",
+                sender_id="user-1",
+                sender_name="John",
+            )
+
+        # First save should happen before processing starts
+        mock_services["service"].save_message_only.assert_called()

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -42,14 +42,16 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
   const [triageMode, setTriageMode] = useState<string>('always_cheap');
   const [defaultModelTier, setDefaultModelTier] = useState<string>('auto');
   const [tierLabels, setTierLabels] = useState<Record<string, string>>({});
+  const [messageHoldDelay, setMessageHoldDelay] = useState<number>(2000);
 
   useEffect(() => {
     if (tab === 'chat') {
-      api<{ always_power_mode: boolean; triage_mode: string; default_model_tier: string }>('/api/setup/admin-settings')
+      api<{ always_power_mode: boolean; triage_mode: string; default_model_tier: string; message_hold_delay_ms: number }>('/api/setup/admin-settings')
         .then(s => {
           setAlwaysPowerMode(s.always_power_mode);
           setTriageMode(s.triage_mode);
           setDefaultModelTier(s.default_model_tier || 'auto');
+          setMessageHoldDelay(s.message_hold_delay_ms ?? 2000);
         })
         .catch(() => {});
       api<{ tier_labels: Record<string, Record<string, string>>; active_provider: string }>('/api/providers/tiers')
@@ -379,6 +381,43 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
                   Tip: Add an OpenAI API key for the best triage model (GPT-4.1 Nano)
                 </p>
               )}
+
+              {/* Message batching delay slider */}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 8 }}>
+                <div>
+                  <p style={{ fontSize: 14, color: '#EDF0F4', margin: 0 }}>Message batching delay</p>
+                  <p style={{ fontSize: 12, color: 'rgba(237,240,244,0.38)', marginTop: 2 }}>
+                    Hold Telegram responses to batch rapid messages
+                  </p>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <input
+                    type="range"
+                    min={0}
+                    max={10000}
+                    step={500}
+                    value={messageHoldDelay}
+                    onChange={async (e) => {
+                      const next = Number(e.target.value);
+                      const prev = messageHoldDelay;
+                      setMessageHoldDelay(next);
+                      try {
+                        await api('/api/setup/admin-settings', {
+                          method: 'PUT',
+                          body: JSON.stringify({ message_hold_delay_ms: next }),
+                        });
+                      } catch {
+                        setMessageHoldDelay(prev);
+                      }
+                    }}
+                    style={{ width: 120, accentColor: 'var(--color-ch-accent, #C8D1D9)' }}
+                  />
+                  <span style={{ fontSize: 13, color: '#EDF0F4', minWidth: 36, textAlign: 'right' }}>
+                    {messageHoldDelay === 0 ? 'Off' : `${(messageHoldDelay / 1000).toFixed(1)}s`}
+                  </span>
+                </div>
+              </div>
+
               <NotificationSettings />
             </div>
           )}


### PR DESCRIPTION
## Summary

- Adds a debounce system for Telegram messages: AI starts immediately on first message, but the response is held for a configurable window (default 2s). Follow-up messages during the hold discard the pending response, combine messages, and restart AI processing.
- Replaces the old busy-check system (which silently dropped messages) with a proper batching state machine that supports cancellation between tool-use iterations, typing indicators, stale state detection, and a max-restart cap (3).
- New global "Message batching delay" slider in Settings > Chat (0-10s, 0 = disabled).

## Test plan

- [ ] Send single Telegram message — verify typing indicator appears, response arrives after ~2s hold
- [ ] Send 2 rapid messages — verify one combined response addressing both
- [ ] Send 5+ rapid messages — verify single response (tests max restarts cap)
- [ ] Group chat: multiple senders in burst — verify combined response with correct prefixes
- [ ] Set slider to Off (0) — verify immediate response with no hold delay
- [ ] Set slider to 5s — verify longer hold before response
- [ ] Verify slider persists across page reload in Settings > Chat
- [ ] Run `pytest tests/` — all 287 tests pass