### PR TITLE
Error/feedback infrastructure: ErrorBoundary, toasts, styled confirms, surfaced fetch errors

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,15 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Native dialogs are replaced by shared/toast.ts and shared/confirm.ts.
+      'no-alert': 'error',
+      'no-restricted-globals': [
+        'error',
+        { name: 'confirm', message: 'Use confirmDialog() from shared/confirm instead.' },
+        { name: 'alert', message: 'Use toast from shared/toast instead.' },
+        { name: 'prompt', message: 'Use a styled input dialog instead.' },
+      ],
+    },
   },
 ])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "highlight.js": "^11.11.1",
         "html2pdf.js": "^0.14.0",
@@ -32,7 +32,8 @@
         "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1197,6 +1198,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -1268,6 +1280,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1703,6 +1722,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1765,6 +1897,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -1909,6 +2051,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2302,6 +2454,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-toolkit": {
       "version": "1.45.1",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
@@ -2519,6 +2678,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2534,6 +2703,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4353,6 +4532,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4466,6 +4659,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -4926,6 +5126,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4946,6 +5153,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -4955,6 +5169,13 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -5060,6 +5281,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5075,6 +5313,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -5464,6 +5712,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5478,6 +5816,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "highlight.js": "^11.11.1",
@@ -34,6 +35,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.8"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from './core/auth/AuthContext';
+import { ToastViewport } from './shared/ToastViewport';
+import { ConfirmHost } from './shared/ConfirmHost';
 import { ProtectedRoute } from './core/auth/ProtectedRoute';
 import { AppShell } from './shared/AppShell';
 import { LoginPage } from './login/LoginPage';
@@ -45,6 +47,8 @@ export default function App() {
 
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
+        <ConfirmHost />
+        <ToastViewport />
       </BrowserRouter>
     </AuthProvider>
   );

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -288,10 +288,12 @@ export function AgentPage() {
   }, [searchParams, setSearchParams]);
 
   async function handleSelectConversation(id: string) {
-    if (chat.trainingMode) chat.setTrainingMode(false);
-    if (chat.planMode) chat.setPlanMode(false);
     const msgs = await convs.selectConversation(id);
     if (!msgs) return;
+    // Mode resets only after a successful load — a failed click shouldn't
+    // silently toggle training/plan mode off.
+    if (chat.trainingMode) chat.setTrainingMode(false);
+    if (chat.planMode) chat.setPlanMode(false);
     chat.loadMessages(msgs, id);
   }
 

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -128,13 +128,13 @@ export function AgentPage() {
     if (!agentId) return;
     api<{ generate_available: boolean }>(`/api/agents/${agentId}/avatar/availability`)
       .then(d => setOpenaiAvailable(d.generate_available))
-      .catch(() => {});
+      .catch(() => {}); // best-effort: hides "Generate with AI" when unknown
   }, [agentId]);
 
   useEffect(() => {
     api<ProviderStatus>('/api/providers')
       .then(p => { setActiveProvider(p.active_provider); })
-      .catch(() => {});
+      .catch(() => {}); // best-effort: tier labels degrade gracefully
   }, []);
 
   // Fetch tier labels and resolve for the agent's provider
@@ -144,7 +144,7 @@ export function AgentPage() {
     if (!providerKey) return;
     api<{ tier_labels: Record<string, Record<string, string>> }>('/api/providers/tiers')
       .then(d => setTierLabels(d.tier_labels[providerKey] || {}))
-      .catch(() => {});
+      .catch(() => {}); // best-effort: tier labels degrade gracefully
   }, [agent, activeProvider]);
 
 
@@ -158,6 +158,7 @@ export function AgentPage() {
         body: JSON.stringify({ model_tier: tier }),
       });
     } catch {
+      // best-effort: revert the optimistic tier change on failure
       setModelTier(prev);
     }
   }, [agentId, modelTier]);
@@ -169,7 +170,7 @@ export function AgentPage() {
         if (s.always_power_mode) chat.setToolMode('power');
         setGlobalModelTier((s.default_model_tier || 'auto') as ModelTier);
       })
-      .catch(() => {});
+      .catch(() => {}); // best-effort: defaults apply when settings unavailable
   }, []);
 
   function handleStartOnboarding() {
@@ -336,6 +337,7 @@ export function AgentPage() {
     setShowAvatarPicker(false);
     setAvatarMenuRect(null);
     setAvatarCacheBust(Date.now());
+    // best-effort: a stale avatar is acceptable until the next full load
     if (agentId) api<AgentRow>(`/api/agents/${agentId}`).then(setAgent).catch(() => {});
   }
 

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -16,6 +16,8 @@ import { AvatarMenu } from './components/AvatarMenu';
 import { AgentMark } from '../shared/AgentMark';
 import { useIsMobile } from '../shared/useIsMobile';
 import { MobileMenuDrawer } from '../shared/MobileMenuDrawer';
+import { confirmDialog } from '../shared/confirm';
+import { toast } from '../shared/toast';
 
 interface AgentRow {
   id: string;
@@ -289,8 +291,18 @@ export function AgentPage() {
   }
 
   async function handleDeleteConversation(id: string) {
-    if (!confirm('Delete this conversation?')) return;
-    await convs.deleteConversation(id);
+    const ok = await confirmDialog({
+      title: 'Delete conversation',
+      message: 'This conversation and its messages will be permanently deleted.',
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
+    const deleted = await convs.deleteConversation(id);
+    if (!deleted) {
+      toast.error('Failed to delete conversation.');
+      return;
+    }
     if (convs.activeId === id) chat.clear();
   }
 
@@ -301,10 +313,15 @@ export function AgentPage() {
     else chat.clear();
   }
 
-  function handleToolModeChange(mode: ToolMode) {
+  async function handleToolModeChange(mode: ToolMode) {
     if (alwaysPowerMode) return;
     if (mode === 'power') {
-      if (!window.confirm(`Enable Power mode? ${agent?.agent_name || 'This agent'} will be able to read and write without asking for confirmation.`)) return;
+      const ok = await confirmDialog({
+        title: 'Enable Power mode',
+        message: `${agent?.agent_name || 'This agent'} will be able to read and write data without asking for confirmation each time.`,
+        confirmLabel: 'Enable Power mode',
+      });
+      if (!ok) return;
     }
     chat.setToolMode(mode);
   }
@@ -561,7 +578,13 @@ export function AgentPage() {
                 chat.setTrainingMode(false);
                 return;
               }
-              if (!confirm(`Exit training? ${agent.agent_name} will use whatever knowledge has been saved so far.`)) return;
+              const ok = await confirmDialog({
+                title: 'Exit training',
+                message: `${agent.agent_name} will use whatever knowledge has been saved so far.`,
+                confirmLabel: 'Exit training',
+                cancelLabel: 'Keep training',
+              });
+              if (!ok) return;
               try {
                 await api(`/api/agents/${agentId}`, { method: 'PUT', body: JSON.stringify({ onboarding_complete: true }) });
                 const updated = await api<AgentRow>(`/api/agents/${agentId}`);
@@ -669,10 +692,22 @@ export function AgentPage() {
               importMode={convs.conversations.find(c => c.id === convs.activeId)?.mode === 'import'}
               greetingPending={chat.greetingPending}
               onCancelImport={async () => {
-                if (!confirm('Cancel this import? The agent and all progress will be deleted.')) return;
+                const ok = await confirmDialog({
+                  title: 'Cancel import',
+                  message: 'The agent and all import progress will be permanently deleted.',
+                  confirmLabel: 'Delete import',
+                  cancelLabel: 'Keep importing',
+                  danger: true,
+                });
+                if (!ok) return;
                 try {
                   await api(`/api/agents/${agentId}`, { method: 'DELETE' });
-                } catch { /* ignore */ }
+                } catch {
+                  // A failed delete leaves the agent live — don't navigate
+                  // away as if it were gone.
+                  toast.error('Failed to cancel import.');
+                  return;
+                }
                 navigate('/');
               }}
             />

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -287,6 +287,7 @@ export function AgentPage() {
     if (chat.trainingMode) chat.setTrainingMode(false);
     if (chat.planMode) chat.setPlanMode(false);
     const msgs = await convs.selectConversation(id);
+    if (!msgs) return;
     chat.loadMessages(msgs, id);
   }
 
@@ -643,6 +644,8 @@ export function AgentPage() {
                     searchQuery={convs.searchQuery}
                     searchResults={convs.searchResults}
                     isSearching={convs.isSearching}
+                    loadError={convs.loadError}
+                    onRetryLoad={convs.loadConversations}
                     onNew={() => { handleNewChat(); setShowSidebar(false); }}
                     onSelect={(id) => { handleSelectConversation(id); setShowSidebar(false); }}
                     onDelete={handleDeleteConversation}
@@ -662,6 +665,8 @@ export function AgentPage() {
                 searchQuery={convs.searchQuery}
                 searchResults={convs.searchResults}
                 isSearching={convs.isSearching}
+                loadError={convs.loadError}
+                onRetryLoad={convs.loadConversations}
                 onNew={handleNewChat}
                 onSelect={handleSelectConversation}
                 onDelete={handleDeleteConversation}

--- a/frontend/src/agent/AgentPage.tsx
+++ b/frontend/src/agent/AgentPage.tsx
@@ -220,6 +220,9 @@ export function AgentPage() {
     if (showAvatarPicker) return;
     if (chat.messages.length > 0 || chat.isStreaming || chat.trainingMode) return;
     if (!convs.loaded) return;
+    // A failed load also sets loaded=true with an empty list — don't greet
+    // (and create a phantom conversation) off a transient fetch failure.
+    if (convs.loadError) return;
     if (convs.conversations.length > 0) {
       chat.setGreetingPending(false);
       return;
@@ -231,7 +234,7 @@ export function AgentPage() {
       '[Start the conversation. Greet the user warmly based on your personality and role. Keep it brief — 1-2 sentences.]',
       undefined, undefined, { hidden: true },
     );
-  }, [agentId, agent, showAvatarPicker, chat.messages.length, chat.isStreaming, chat.trainingMode, convs.loaded, convs.conversations.length]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [agentId, agent, showAvatarPicker, chat.messages.length, chat.isStreaming, chat.trainingMode, convs.loaded, convs.loadError, convs.conversations.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     convs.loadConversations();
@@ -300,12 +303,14 @@ export function AgentPage() {
       danger: true,
     });
     if (!ok) return;
-    const deleted = await convs.deleteConversation(id);
-    if (!deleted) {
+    const res = await convs.deleteConversation(id);
+    if (!res.ok) {
       toast.error('Failed to delete conversation.');
       return;
     }
-    if (convs.activeId === id) chat.clear();
+    // wasActive comes from the hook's ref (not this render's closure), so a
+    // conversation opened mid-DELETE won't get its view wrongly cleared.
+    if (res.wasActive) chat.clear();
   }
 
   function handleNewChat() {
@@ -315,15 +320,28 @@ export function AgentPage() {
     else chat.clear();
   }
 
+  // Invalidates pending Power-mode confirm dialogs when a newer mode choice lands.
+  // The bump is deliberately asymmetric: only NON-power choices increment the
+  // seq, because a Read/Normal click is what should invalidate a pending Power
+  // confirm. The Power path merely reads the seq — if it also bumped, a fast
+  // double-click on Power would increment twice, the duplicate dialog would be
+  // deduped to false, and the user's genuine confirmation of the first dialog
+  // would then be wrongly discarded as stale.
+  const modeChangeSeqRef = useRef(0);
   async function handleToolModeChange(mode: ToolMode) {
     if (alwaysPowerMode) return;
     if (mode === 'power') {
+      const seq = modeChangeSeqRef.current;
       const ok = await confirmDialog({
         title: 'Enable Power mode',
         message: `${agent?.agent_name || 'This agent'} will be able to read and write data without asking for confirmation each time.`,
         confirmLabel: 'Enable Power mode',
       });
       if (!ok) return;
+      // A non-power choice landed while the dialog was open — discard.
+      if (seq !== modeChangeSeqRef.current) return;
+    } else {
+      modeChangeSeqRef.current++;
     }
     chat.setToolMode(mode);
   }

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -169,11 +169,9 @@ export function AgentChatPanel({
   }
 
   function handleToolModeClick(mode: ToolMode) {
-    if (!onToolModeChange) return;
-    if (mode === 'power') {
-      if (!window.confirm(`Enable Power mode? ${agentName || 'This agent'} will be able to read and write without asking for confirmation.`)) return;
-    }
-    onToolModeChange(mode);
+    // The Power-mode confirm lives in AgentPage.handleToolModeChange —
+    // confirming here too showed two stacked dialogs for one click.
+    onToolModeChange?.(mode);
   }
 
   const isMobile = useIsMobile();

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -8,6 +8,7 @@ import NotificationLog from './NotificationLog';
 import { IconAttach, IconArrowUp } from '../../shared/icons';
 import { useIsMobile } from '../../shared/useIsMobile';
 import { api } from '../../core/api/client';
+import { toast } from '../../shared/toast';
 import { localDateKey } from '../utils/dateFormat';
 
 const ALLOWED_EXTENSIONS = new Set(['csv', 'xlsx', 'md', 'txt', 'pdf', 'docx']);
@@ -475,13 +476,14 @@ export function AgentChatPanel({
                 try {
                   await api(`/api/alerts/${alertId}/acknowledge`, { method: 'POST' });
                   setAlerts(prev => prev.filter(a => a.id !== alertId));
-                } catch { /* ignore */ }
+                } catch { toast.error('Failed to dismiss alert.'); }
               }}
               onDiscuss={(alertId) => {
                 const alert = alerts.find(a => a.id === alertId);
                 if (alert) {
                   onSend(`Tell me about this alert: "${alert.title}" — ${alert.message}`);
-                  api(`/api/alerts/${alertId}/acknowledge`, { method: 'POST' }).catch(() => {});
+                  api(`/api/alerts/${alertId}/acknowledge`, { method: 'POST' })
+                    .catch(() => toast.error('Failed to acknowledge alert.'));
                   setAlerts(prev => prev.filter(a => a.id !== alertId));
                 }
               }}

--- a/frontend/src/agent/components/AgentContextEditor.tsx
+++ b/frontend/src/agent/components/AgentContextEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '../../core/api/client';
 import { useIsMobile } from '../../shared/useIsMobile';
 import { confirmDialog } from '../../shared/confirm';
@@ -39,15 +39,25 @@ export function AgentContextEditor({ agentId }: Props) {
   const [observations, setObservations] = useState<Observation[]>([]);
   const [obsExpanded, setObsExpanded] = useState(false);
   const isMobile = useIsMobile();
+  // Track current file-list request so a stale response (agent switch
+  // mid-flight) can't overwrite the new agent's list.
+  const loadSeqRef = useRef(0);
 
   const apiBase = `/api/agents/${agentId}`;
 
-  function loadFiles() {
-    setFilesError(false);
+  const loadFiles = useCallback(() => {
+    const seq = ++loadSeqRef.current;
     api<{ files: ContextFile[] }>(`${apiBase}/context`)
-      .then(data => setFiles(data.files))
-      .catch(() => setFilesError(true));
-  }
+      .then(data => {
+        if (seq !== loadSeqRef.current) return;
+        setFiles(data.files);
+        setFilesError(false);
+      })
+      .catch(() => {
+        if (seq !== loadSeqRef.current) return;
+        setFilesError(true);
+      });
+  }, [apiBase]);
 
   useEffect(() => {
     loadFiles();
@@ -58,8 +68,7 @@ export function AgentContextEditor({ agentId }: Props) {
         if (data.observations.length > 0 && data.observations.length <= 5) setObsExpanded(true);
       })
       .catch(() => {});
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentId, apiBase]);
+  }, [apiBase, loadFiles]);
 
   function confirmDiscard() {
     return confirmDialog({
@@ -90,15 +99,21 @@ export function AgentContextEditor({ agentId }: Props) {
     if (!selectedFile) return;
     setSaving(true);
     try {
-      await api(`${apiBase}/context/${encodeURIComponent(selectedFile)}`, {
-        method: 'PUT',
-        body: JSON.stringify({ content }),
-      });
-      setDirty(false);
-      const data = await api<{ files: ContextFile[] }>(`${apiBase}/context`);
-      setFiles(data.files);
-    } catch {
-      toast.error('Failed to save file.');
+      try {
+        await api(`${apiBase}/context/${encodeURIComponent(selectedFile)}`, {
+          method: 'PUT',
+          body: JSON.stringify({ content }),
+        });
+        setDirty(false);
+      } catch {
+        toast.error('Failed to save file.');
+        return;
+      }
+      // best-effort: list refresh; the save itself succeeded
+      try {
+        const data = await api<{ files: ContextFile[] }>(`${apiBase}/context`);
+        setFiles(data.files);
+      } catch { /* ignore */ }
     } finally {
       setSaving(false);
     }

--- a/frontend/src/agent/components/AgentContextEditor.tsx
+++ b/frontend/src/agent/components/AgentContextEditor.tsx
@@ -3,6 +3,7 @@ import { api } from '../../core/api/client';
 import { useIsMobile } from '../../shared/useIsMobile';
 import { confirmDialog } from '../../shared/confirm';
 import { toast } from '../../shared/toast';
+import { LoadError } from '../../shared/LoadError';
 
 interface ContextFile {
   name: string;
@@ -29,6 +30,7 @@ const mono = (size: number, color = 'rgba(237,240,244,0.38)') => ({
 
 export function AgentContextEditor({ agentId }: Props) {
   const [files, setFiles] = useState<ContextFile[]>([]);
+  const [filesError, setFilesError] = useState(false);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(false);
@@ -40,10 +42,15 @@ export function AgentContextEditor({ agentId }: Props) {
 
   const apiBase = `/api/agents/${agentId}`;
 
-  useEffect(() => {
+  function loadFiles() {
+    setFilesError(false);
     api<{ files: ContextFile[] }>(`${apiBase}/context`)
       .then(data => setFiles(data.files))
-      .catch(console.error);
+      .catch(() => setFilesError(true));
+  }
+
+  useEffect(() => {
+    loadFiles();
     api<{ observations: Observation[] }>(`${apiBase}/observations`)
       .then(data => {
         setObservations(data.observations);
@@ -51,6 +58,7 @@ export function AgentContextEditor({ agentId }: Props) {
         if (data.observations.length > 0 && data.observations.length <= 5) setObsExpanded(true);
       })
       .catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentId, apiBase]);
 
   function confirmDiscard() {
@@ -71,6 +79,8 @@ export function AgentContextEditor({ agentId }: Props) {
       setSelectedFile(name);
       setContent(data.content);
       setDirty(false);
+    } catch {
+      toast.error('Failed to load file.');
     } finally {
       setLoading(false);
     }
@@ -87,6 +97,8 @@ export function AgentContextEditor({ agentId }: Props) {
       setDirty(false);
       const data = await api<{ files: ContextFile[] }>(`${apiBase}/context`);
       setFiles(data.files);
+    } catch {
+      toast.error('Failed to save file.');
     } finally {
       setSaving(false);
     }
@@ -257,7 +269,9 @@ export function AgentContextEditor({ agentId }: Props) {
           <p style={{ ...mono(10, 'rgba(237,240,244,0.62)'), margin: 0 }}>Knowledge Files</p>
         </div>
         <div style={{ flex: 1, overflowY: 'auto', padding: '8px 0' }}>
-          {files.length === 0 ? (
+          {filesError && files.length === 0 ? (
+            <LoadError compact label="Couldn't load files" onRetry={loadFiles} />
+          ) : files.length === 0 ? (
             <p style={{ color: 'rgba(237,240,244,0.38)', fontSize: 12, textAlign: 'center', padding: '16px 12px' }}>
               No knowledge files yet
             </p>
@@ -318,7 +332,9 @@ export function AgentContextEditor({ agentId }: Props) {
           <p style={{ ...mono(10, 'rgba(237,240,244,0.62)'), margin: 0 }}>Knowledge Files</p>
         </div>
         <div style={{ flex: 1, overflowY: 'auto', padding: '8px 0' }}>
-          {files.length === 0 ? (
+          {filesError && files.length === 0 ? (
+            <LoadError compact label="Couldn't load files" onRetry={loadFiles} />
+          ) : files.length === 0 ? (
             <p style={{ color: 'rgba(237,240,244,0.38)', fontSize: 12, textAlign: 'center', padding: '16px 12px' }}>
               No knowledge files yet
             </p>

--- a/frontend/src/agent/components/AgentContextEditor.tsx
+++ b/frontend/src/agent/components/AgentContextEditor.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { api } from '../../core/api/client';
 import { useIsMobile } from '../../shared/useIsMobile';
+import { confirmDialog } from '../../shared/confirm';
+import { toast } from '../../shared/toast';
 
 interface ContextFile {
   name: string;
@@ -51,8 +53,18 @@ export function AgentContextEditor({ agentId }: Props) {
       .catch(() => {});
   }, [agentId, apiBase]);
 
+  function confirmDiscard() {
+    return confirmDialog({
+      title: 'Discard changes',
+      message: 'You have unsaved changes that will be lost.',
+      confirmLabel: 'Discard',
+      cancelLabel: 'Keep editing',
+      danger: true,
+    });
+  }
+
   async function selectFile(name: string) {
-    if (dirty && !confirm('Unsaved changes — discard?')) return;
+    if (dirty && !(await confirmDiscard())) return;
     setLoading(true);
     try {
       const data = await api<{ filename: string; content: string }>(`${apiBase}/context/${encodeURIComponent(name)}`);
@@ -81,25 +93,42 @@ export function AgentContextEditor({ agentId }: Props) {
   }
 
   async function deleteFile(name: string) {
-    if (!confirm(`Delete ${name}?`)) return;
-    await api(`${apiBase}/context/${encodeURIComponent(name)}`, { method: 'DELETE' });
+    const ok = await confirmDialog({
+      title: 'Delete file',
+      message: `${name} will be permanently removed from this agent's knowledge.`,
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      await api(`${apiBase}/context/${encodeURIComponent(name)}`, { method: 'DELETE' });
+    } catch {
+      toast.error('Failed to delete file.');
+      return;
+    }
     setFiles(prev => prev.filter(f => f.name !== name));
     if (selectedFile === name) { setSelectedFile(null); setContent(''); setDirty(false); }
   }
 
-  function handleBack() {
-    if (dirty && !confirm('Unsaved changes — discard?')) return;
+  async function handleBack() {
+    if (dirty && !(await confirmDiscard())) return;
     setSelectedFile(null);
     setContent('');
     setDirty(false);
   }
 
   async function deleteObservation(id: number) {
-    if (!confirm('Delete this observation?')) return;
+    const ok = await confirmDialog({
+      title: 'Delete observation',
+      message: 'This observation will be permanently removed from memory.',
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
     try {
       await api(`${apiBase}/observations/${id}`, { method: 'DELETE' });
       setObservations(prev => prev.filter(o => o.id !== id));
-    } catch { /* ignore */ }
+    } catch { toast.error('Failed to delete observation.'); }
   }
 
   function formatSize(bytes: number) {

--- a/frontend/src/agent/components/AgentRemindersPanel.tsx
+++ b/frontend/src/agent/components/AgentRemindersPanel.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect } from 'react';
 import { api } from '../../core/api/client';
+import { LoadError } from '../../shared/LoadError';
 import type { Reminder } from '../../core/types';
 
 function toUTC(iso: string): Date {
@@ -70,6 +71,8 @@ interface SeriesCache {
 export default function AgentRemindersPanel({ agentSlug }: { agentSlug: string }) {
   const [reminders, setReminders] = useState<Reminder[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
   const [expanded, setExpanded] = useState<string | null>(null);
   const [seriesCache, setSeriesCache] = useState<SeriesCache>({});
   const [loadingSeries, setLoadingSeries] = useState<string | null>(null);
@@ -80,15 +83,15 @@ export default function AgentRemindersPanel({ agentSlug }: { agentSlug: string }
     (async () => {
       try {
         const result = await api<{ reminders: Reminder[] }>(`/api/reminders?agent=${agentSlug}&limit=100`);
-        if (!cancelled) setReminders(result.reminders);
+        if (!cancelled) { setReminders(result.reminders); setLoadFailed(false); }
       } catch {
-        // Supplementary — fail silently
+        if (!cancelled) setLoadFailed(true);
       } finally {
         if (!cancelled) setLoading(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [agentSlug]);
+  }, [agentSlug, retryKey]);
 
   const toggleSection = (section: string) => {
     setCollapsedSections(prev => {
@@ -114,6 +117,15 @@ export default function AgentRemindersPanel({ agentSlug }: { agentSlug: string }
         <div className="animate-spin w-4 h-4 border-2 border-ch-accent border-t-transparent rounded-full" />
         Loading reminders...
       </div>
+    );
+  }
+
+  if (loadFailed && reminders.length === 0) {
+    return (
+      <LoadError
+        label="Couldn't load reminders"
+        onRetry={() => { setLoading(true); setRetryKey(k => k + 1); }}
+      />
     );
   }
 

--- a/frontend/src/agent/components/ConversationSidebar.tsx
+++ b/frontend/src/agent/components/ConversationSidebar.tsx
@@ -35,6 +35,9 @@ export function ConversationSidebar({
   const [editTitle, setEditTitle] = useState('');
   const [localQuery, setLocalQuery] = useState(searchQuery);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Both Enter and blur can fire commitEdit for the same edit; this guards
+  // against a double rename while the first commit's await is in flight.
+  const editCommittingRef = useRef(false);
 
   const handleSearchChange = useCallback((value: string) => {
     setLocalQuery(value);
@@ -49,10 +52,17 @@ export function ConversationSidebar({
   }
 
   async function commitEdit(id: string) {
-    setEditingId(null);
-    if (!editTitle.trim()) return;
-    const ok = await onRename(id, editTitle.trim());
-    if (!ok) toast.error('Failed to rename conversation.');
+    if (editCommittingRef.current) return;
+    if (!editTitle.trim()) { setEditingId(null); return; }
+    editCommittingRef.current = true;
+    try {
+      // Keep the inline edit visible until the rename resolves.
+      const ok = await onRename(id, editTitle.trim());
+      setEditingId(null);
+      if (!ok) toast.error('Failed to rename conversation.');
+    } finally {
+      editCommittingRef.current = false;
+    }
   }
 
   const displayList = searchQuery.trim() ? searchResults : conversations;

--- a/frontend/src/agent/components/ConversationSidebar.tsx
+++ b/frontend/src/agent/components/ConversationSidebar.tsx
@@ -2,6 +2,8 @@ import { useState, useRef, useCallback } from 'react';
 import type { Conversation } from '../hooks/useConversations';
 import { AgentMark } from '../../shared/AgentMark';
 import { IconPlus } from '../../shared/icons';
+import { LoadError } from '../../shared/LoadError';
+import { toast } from '../../shared/toast';
 import { formatSidebarTime } from '../utils/dateFormat';
 
 interface Props {
@@ -13,16 +15,19 @@ interface Props {
   searchQuery: string;
   searchResults: { id: string; title: string; snippet: string }[];
   isSearching: boolean;
+  loadError?: boolean;
+  onRetryLoad?: () => void;
   onNew: () => void;
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
   onSearch: (q: string) => void;
-  onRename: (id: string, title: string) => void;
+  onRename: (id: string, title: string) => Promise<boolean>;
 }
 
 export function ConversationSidebar({
   agentName, avatarUrl, onAvatarClick,
   conversations, activeId, searchQuery, searchResults, isSearching,
+  loadError, onRetryLoad,
   onNew, onSelect, onDelete, onSearch, onRename,
 }: Props) {
   const [collapsed, setCollapsed] = useState(false);
@@ -43,9 +48,11 @@ export function ConversationSidebar({
     setEditTitle(conv.title);
   }
 
-  function commitEdit(id: string) {
-    if (editTitle.trim()) onRename(id, editTitle.trim());
+  async function commitEdit(id: string) {
     setEditingId(null);
+    if (!editTitle.trim()) return;
+    const ok = await onRename(id, editTitle.trim());
+    if (!ok) toast.error('Failed to rename conversation.');
   }
 
   const displayList = searchQuery.trim() ? searchResults : conversations;
@@ -133,6 +140,8 @@ export function ConversationSidebar({
           <div style={{ display: 'flex', justifyContent: 'center', padding: 16 }}>
             <div className="w-4 h-4 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />
           </div>
+        ) : loadError && conversations.length === 0 && !searchQuery.trim() ? (
+          <LoadError compact label="Couldn't load conversations" onRetry={() => onRetryLoad?.()} />
         ) : displayList.length === 0 ? (
           <p style={{ color: 'rgba(237,240,244,0.38)', fontSize: 12, textAlign: 'center', padding: '24px 16px' }}>
             {searchQuery ? 'No results found' : 'No conversations yet'}

--- a/frontend/src/agent/components/ConversationSidebar.tsx
+++ b/frontend/src/agent/components/ConversationSidebar.tsx
@@ -38,6 +38,7 @@ export function ConversationSidebar({
   // Both Enter and blur can fire commitEdit for the same edit; this guards
   // against a double rename while the first commit's await is in flight.
   const editCommittingRef = useRef(false);
+  const [editCommitting, setEditCommitting] = useState(false);
 
   const handleSearchChange = useCallback((value: string) => {
     setLocalQuery(value);
@@ -55,6 +56,7 @@ export function ConversationSidebar({
     if (editCommittingRef.current) return;
     if (!editTitle.trim()) { setEditingId(null); return; }
     editCommittingRef.current = true;
+    setEditCommitting(true);
     try {
       // Keep the inline edit visible until the rename resolves.
       const ok = await onRename(id, editTitle.trim());
@@ -62,6 +64,7 @@ export function ConversationSidebar({
       if (!ok) toast.error('Failed to rename conversation.');
     } finally {
       editCommittingRef.current = false;
+      setEditCommitting(false);
     }
   }
 
@@ -183,11 +186,13 @@ export function ConversationSidebar({
                       onBlur={() => commitEdit(id)}
                       onKeyDown={e => { if (e.key === 'Enter') commitEdit(id); if (e.key === 'Escape') setEditingId(null); }}
                       onClick={e => e.stopPropagation()}
+                      disabled={editCommitting}
                       style={{
                         width: '100%', background: 'rgba(34,40,48,0.55)',
                         color: '#EDF0F4', fontSize: 12, borderRadius: 3,
                         padding: '2px 6px', border: '1px solid rgba(230,235,242,0.14)',
                         outline: 'none',
+                        opacity: editCommitting ? 0.5 : 1,
                       }}
                       autoFocus
                     />

--- a/frontend/src/agent/components/NotificationLog.tsx
+++ b/frontend/src/agent/components/NotificationLog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { AgentNotification } from '../../core/types';
 import { api } from '../../core/api/client';
+import { toast } from '../../shared/toast';
 
 interface Props {
   agentSlug: string;
@@ -35,7 +36,7 @@ export default function NotificationLog({ agentSlug }: Props) {
     try {
       await api(`/api/notifications/${id}/dismiss`, { method: 'POST' });
       setNotifications(prev => prev.filter(n => n.id !== id));
-    } catch { /* ignore */ }
+    } catch { toast.error('Failed to dismiss notification.'); }
   };
 
   const dismissAll = async () => {
@@ -45,7 +46,7 @@ export default function NotificationLog({ agentSlug }: Props) {
         body: JSON.stringify({ agent: agentSlug }),
       });
       setNotifications([]);
-    } catch { /* ignore */ }
+    } catch { toast.error('Failed to dismiss notifications.'); }
   };
 
   const toggleExpand = (id: string) => {

--- a/frontend/src/agent/components/NotificationLog.tsx
+++ b/frontend/src/agent/components/NotificationLog.tsx
@@ -26,7 +26,7 @@ export default function NotificationLog({ agentSlug }: Props) {
     const fetch = () =>
       api<AgentNotification[]>(`/api/notifications?agent=${agentSlug}&status=active&limit=10`)
         .then(data => { if (!cancelled) setNotifications(data); })
-        .catch(() => {});
+        .catch(() => {}); // best-effort: poll retries in 30s
     fetch();
     const interval = setInterval(fetch, 30000);
     return () => { cancelled = true; clearInterval(interval); };

--- a/frontend/src/agent/components/TelegramSettings.tsx
+++ b/frontend/src/agent/components/TelegramSettings.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { api } from '../../core/api/client';
+import { toast } from '../../shared/toast';
 
 interface Props {
   agentId: string;
@@ -551,7 +552,8 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
         body: JSON.stringify({ telegram_group_enabled: !groupEnabled }),
       });
       onUpdate();
-    } finally { setTogglingGroup(false); }
+    } catch { toast.error('Failed to update group setting.'); }
+    finally { setTogglingGroup(false); }
   }
 
   async function handleToggle() {
@@ -562,7 +564,8 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
         body: JSON.stringify({ telegram_enabled: !telegramEnabled }),
       });
       onUpdate();
-    } finally { setToggling(false); }
+    } catch { toast.error('Failed to update Telegram setting.'); }
+    finally { setToggling(false); }
   }
 
   async function handleDisconnect() {
@@ -570,7 +573,8 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
     try {
       await api(`/api/telegram/bot-token/${agentId}`, { method: 'DELETE' });
       onUpdate();
-    } finally {
+    } catch { toast.error('Failed to disconnect Telegram.'); }
+    finally {
       setDisconnecting(false);
       setShowConfirmDisconnect(false);
     }
@@ -586,7 +590,8 @@ function ManagementView({ agentId, agentName, botUsername, telegramEnabled, grou
       });
       setResetSuccess(true);
       setTimeout(() => setResetSuccess(false), 5000);
-    } finally { setResetting(false); }
+    } catch { toast.error('Failed to reset registration.'); }
+    finally { setResetting(false); }
   }
 
   return (

--- a/frontend/src/agent/components/heartbeat/HeartbeatChecklist.tsx
+++ b/frontend/src/agent/components/heartbeat/HeartbeatChecklist.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { toast } from '../../../shared/toast';
 import type { ParsedLine } from '../../hooks/useHeartbeat';
 import { FONT_SANS, FONT_MONO, INK, INK_DIM, INK_MUTE, BG_ELEV, BG_RAISED, LINE_STRONG, ACCENT, ACCENT_INK, SAGE } from '../../../shared/styles';
 
@@ -67,7 +68,8 @@ export function HeartbeatChecklist({ parsedLines, canEditCards, rawMarkdown, onS
     try {
       await onSave(localLines);
       setDirty(false);
-    } finally { setSaving(false); }
+    } catch { toast.error('Failed to save checklist.'); }
+    finally { setSaving(false); }
   }
 
   async function handleSaveRaw() {
@@ -75,7 +77,8 @@ export function HeartbeatChecklist({ parsedLines, canEditCards, rawMarkdown, onS
     try {
       await onSaveRaw(rawText);
       setRawDirty(false);
-    } finally { setSaving(false); }
+    } catch { toast.error('Failed to save checklist.'); }
+    finally { setSaving(false); }
   }
 
   // Raw markdown editor fallback

--- a/frontend/src/agent/hooks/useConversations.ts
+++ b/frontend/src/agent/hooks/useConversations.ts
@@ -100,10 +100,10 @@ export function useConversations(apiPrefix: string) {
     try {
       await api(`${apiPrefix}/conversations/${id}`, { method: 'DELETE' });
       setConversations(prev => prev.filter(c => c.id !== id));
-      if (activeId === id) setActiveId(null);
+      setActiveId(prev => (prev === id ? null : prev));
       return true;
     } catch { return false; }
-  }, [activeId, apiPrefix]);
+  }, [apiPrefix]);
 
   const renameConversation = useCallback(async (id: string, title: string): Promise<boolean> => {
     try {

--- a/frontend/src/agent/hooks/useConversations.ts
+++ b/frontend/src/agent/hooks/useConversations.ts
@@ -5,6 +5,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { api } from '../../core/api/client';
+import { toast } from '../../shared/toast';
 import type { ChatMessage } from './useAgentChat';
 import { parseServerTimestamp } from '../utils/dateFormat';
 
@@ -26,21 +27,23 @@ export function useConversations(apiPrefix: string) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
-  useEffect(() => { setLoaded(false); setConversations([]); setActiveId(null); }, [apiPrefix]);
+  const [loadError, setLoadError] = useState(false);
+  useEffect(() => { setLoaded(false); setConversations([]); setActiveId(null); setLoadError(false); }, [apiPrefix]);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<{ id: string; title: string; snippet: string; updated_at?: string }[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const loadConversations = useCallback(async () => {
+    setLoadError(false);
     try {
       const data = await api<{ conversations: Conversation[] }>(`${apiPrefix}/conversations`);
       setConversations(data.conversations);
-    } catch { /* silent */ }
+    } catch { setLoadError(true); }
     finally { setLoaded(true); }
   }, [apiPrefix]);
 
-  const selectConversation = useCallback(async (id: string): Promise<ChatMessage[]> => {
+  const selectConversation = useCallback(async (id: string): Promise<ChatMessage[] | null> => {
     setLoading(true);
     try {
       const data = await api<{
@@ -78,7 +81,10 @@ export function useConversations(apiPrefix: string) {
         return msg;
       });
     } catch {
-      return [];
+      // null (not []) so callers can distinguish failure from an empty
+      // conversation and skip switching the chat view.
+      toast.error('Failed to load conversation.');
+      return null;
     } finally {
       setLoading(false);
     }
@@ -142,6 +148,7 @@ export function useConversations(apiPrefix: string) {
     setActiveId,
     loading,
     loaded,
+    loadError,
     searchQuery,
     searchResults,
     isSearching,

--- a/frontend/src/agent/hooks/useConversations.ts
+++ b/frontend/src/agent/hooks/useConversations.ts
@@ -3,7 +3,7 @@
  * Adapted from CAKE OS — sender_email/sender_name removed (single-user).
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, type SetStateAction } from 'react';
 import { api } from '../../core/api/client';
 import { toast } from '../../shared/toast';
 import type { ChatMessage } from './useAgentChat';
@@ -24,32 +24,59 @@ export interface Conversation {
 
 export function useConversations(apiPrefix: string) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeId, setActiveIdState] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [loadError, setLoadError] = useState(false);
-  useEffect(() => { setLoaded(false); setConversations([]); setActiveId(null); setLoadError(false); }, [apiPrefix]);
+  // Mirrors activeId so async callbacks (e.g. deleteConversation) can read the
+  // current value instead of a stale render closure. Written through
+  // synchronously by setActiveId below — an effect-based sync would lag a
+  // render, letting a DELETE that resolves between a newer select's commit and
+  // the effect run compute wasActive from the stale id.
+  const activeIdRef = useRef<string | null>(null);
+  const setActiveId = useCallback((value: SetStateAction<string | null>) => {
+    activeIdRef.current = typeof value === 'function' ? (value as (p: string | null) => string | null)(activeIdRef.current) : value;
+    setActiveIdState(value);
+  }, []);
+  // Guards against out-of-order selectConversation responses: only the most
+  // recent call may commit state or surface errors. Also bumped by New Chat
+  // and agent switches, so a slow in-flight select can't land afterwards and
+  // resurrect the old messages/activeId.
+  const selectSeqRef = useRef(0);
+  // Same pattern for loadConversations: a stale failure must not set
+  // loadError over a newer success, nor a stale success overwrite a newer list.
+  const loadSeqRef = useRef(0);
+  useEffect(() => {
+    selectSeqRef.current++;
+    loadSeqRef.current++;
+    setLoaded(false); setConversations([]); setActiveId(null); setLoadError(false);
+  }, [apiPrefix, setActiveId]);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<{ id: string; title: string; snippet: string; updated_at?: string }[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const loadConversations = useCallback(async () => {
+    const seq = ++loadSeqRef.current;
     setLoadError(false);
     try {
       const data = await api<{ conversations: Conversation[] }>(`${apiPrefix}/conversations`);
-      setConversations(data.conversations);
-    } catch { setLoadError(true); }
-    finally { setLoaded(true); }
+      if (seq === loadSeqRef.current) setConversations(data.conversations);
+    } catch { if (seq === loadSeqRef.current) setLoadError(true); }
+    finally { if (seq === loadSeqRef.current) setLoaded(true); }
   }, [apiPrefix]);
 
   const selectConversation = useCallback(async (id: string): Promise<ChatMessage[] | null> => {
+    const seq = ++selectSeqRef.current;
     setLoading(true);
     try {
       const data = await api<{
         id: string; title: string;
         messages: { id: string; role: string; content: string; seq: number; tool_calls?: string; model?: string; created_at?: string }[];
       }>(`${apiPrefix}/conversations/${id}`);
+      // A newer selection started while this one was in flight — discard it
+      // (null is the callers' existing do-nothing path).
+      if (seq !== selectSeqRef.current) return null;
       setActiveId(id);
       return data.messages.map(m => {
         const parsedTimestamp = parseServerTimestamp(m.created_at);
@@ -82,28 +109,35 @@ export function useConversations(apiPrefix: string) {
       });
     } catch {
       // null (not []) so callers can distinguish failure from an empty
-      // conversation and skip switching the chat view.
-      toast.error('Failed to load conversation.');
+      // conversation and skip switching the chat view. A stale failure stays
+      // silent — it shouldn't toast over a newer selection.
+      if (seq === selectSeqRef.current) toast.error('Failed to load conversation.');
       return null;
     } finally {
-      setLoading(false);
+      if (seq === selectSeqRef.current) setLoading(false);
     }
-  }, [apiPrefix]);
+  }, [apiPrefix, setActiveId]);
 
   const startNewChat = useCallback(() => {
+    // Invalidate any in-flight select so a slow response can't land after
+    // New Chat and resurrect the conversation the user just left.
+    selectSeqRef.current++;
     setActiveId(null);
     setSearchQuery('');
     setSearchResults([]);
-  }, []);
+  }, [setActiveId]);
 
-  const deleteConversation = useCallback(async (id: string) => {
+  const deleteConversation = useCallback(async (id: string): Promise<{ ok: boolean; wasActive: boolean }> => {
     try {
       await api(`${apiPrefix}/conversations/${id}`, { method: 'DELETE' });
+      // Read the ref, not the closure: the user may have switched conversations
+      // while the DELETE was in flight, and callers must not clear that view.
+      const wasActive = activeIdRef.current === id;
       setConversations(prev => prev.filter(c => c.id !== id));
       setActiveId(prev => (prev === id ? null : prev));
-      return true;
-    } catch { return false; }
-  }, [apiPrefix]);
+      return { ok: true, wasActive };
+    } catch { return { ok: false, wasActive: false }; }
+  }, [apiPrefix, setActiveId]);
 
   const renameConversation = useCallback(async (id: string, title: string): Promise<boolean> => {
     try {

--- a/frontend/src/agent/hooks/useHeartbeat.ts
+++ b/frontend/src/agent/hooks/useHeartbeat.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '../../core/api/client';
+import { toast } from '../../shared/toast';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -257,7 +258,9 @@ export function useHeartbeat(agentSlug: string, apiPrefix: string): UseHeartbeat
       await api(`/api/scheduled-actions/${action.id}/run-now`, { method: 'POST' });
     } catch (e) {
       if (e instanceof Error && e.message.includes('409')) {
-        alert('Heartbeat is already running.');
+        toast.info('Heartbeat is already running.');
+      } else {
+        toast.error('Failed to run heartbeat.');
       }
     } finally {
       setRunning(false);

--- a/frontend/src/agent/reports/ReportsPanel.tsx
+++ b/frontend/src/agent/reports/ReportsPanel.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { api } from '../../core/api/client';
+import { confirmDialog } from '../../shared/confirm';
+import { toast } from '../../shared/toast';
 import type { Report, ReportSummary } from './types';
 import ReportRenderer from './ReportRenderer';
 
@@ -61,7 +63,13 @@ export default function ReportsPanel({ apiPrefix }: ReportsPanelProps) {
 
   const handleDelete = async (id: string, e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!confirm('Delete this report?')) return;
+    const ok = await confirmDialog({
+      title: 'Delete report',
+      message: 'This report will be permanently deleted.',
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
     try {
       await api(`${apiPrefix}/reports/${id}`, { method: 'DELETE' });
       setReports(prev => prev.filter(r => r.id !== id));
@@ -70,7 +78,7 @@ export default function ReportsPanel({ apiPrefix }: ReportsPanelProps) {
         setExpandedReport(null);
       }
     } catch {
-      // silently fail
+      toast.error('Failed to delete report.');
     }
   };
 

--- a/frontend/src/agent/reports/ReportsPanel.tsx
+++ b/frontend/src/agent/reports/ReportsPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { api } from '../../core/api/client';
 import { confirmDialog } from '../../shared/confirm';
 import { toast } from '../../shared/toast';
+import { LoadError } from '../../shared/LoadError';
 import type { Report, ReportSummary } from './types';
 import ReportRenderer from './ReportRenderer';
 
@@ -12,17 +13,19 @@ interface ReportsPanelProps {
 export default function ReportsPanel({ apiPrefix }: ReportsPanelProps) {
   const [reports, setReports] = useState<ReportSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [expandedReport, setExpandedReport] = useState<Report | null>(null);
   const [loadingReport, setLoadingReport] = useState(false);
   const [search, setSearch] = useState('');
 
   const loadReports = useCallback(async () => {
+    setLoadFailed(false);
     try {
       const data = await api<{ reports: ReportSummary[] }>(`${apiPrefix}/reports`);
       setReports(data.reports);
     } catch {
-      // silently fail
+      setLoadFailed(true);
     } finally {
       setLoading(false);
     }
@@ -53,6 +56,7 @@ export default function ReportsPanel({ apiPrefix }: ReportsPanelProps) {
     } catch {
       if (expandIdRef.current === id) {
         setExpandedReport(null);
+        toast.error('Failed to load report.');
       }
     } finally {
       if (expandIdRef.current === id) {
@@ -108,6 +112,17 @@ export default function ReportsPanel({ apiPrefix }: ReportsPanelProps) {
     return (
       <div className="flex items-center justify-center h-full text-ch-ink-mute text-sm">
         Loading reports...
+      </div>
+    );
+  }
+
+  if (loadFailed && reports.length === 0) {
+    return (
+      <div className="h-full p-4">
+        <LoadError
+          label="Couldn't load reports"
+          onRetry={() => { setLoading(true); loadReports(); }}
+        />
       </div>
     );
   }

--- a/frontend/src/core/api/client.ts
+++ b/frontend/src/core/api/client.ts
@@ -24,7 +24,10 @@ export async function api<T = unknown>(
   if (res.status === 401) {
     sessionStorage.removeItem('chatty_token');
     window.location.href = '/login';
-    throw new Error('Session expired');
+    // Never settle: the page is navigating away. Throwing here would run
+    // every caller's catch block and flash false "Failed to ..." toasts
+    // and error states in the instant before the redirect commits.
+    return new Promise<never>(() => {});
   }
 
   if (!res.ok) {

--- a/frontend/src/core/auth/AuthContext.tsx
+++ b/frontend/src/core/auth/AuthContext.tsx
@@ -67,7 +67,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const ch = new BroadcastChannel(CHANNEL_NAME);
       ch.postMessage({ type: 'login', token });
       ch.close();
-    } catch { /* noop */ }
+    } catch { /* best-effort: BroadcastChannel unsupported — single-tab fallback */ }
   }, []);
 
   useEffect(() => {
@@ -151,7 +151,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const ch = new BroadcastChannel(CHANNEL_NAME);
       ch.postMessage({ type: 'logout' });
       ch.close();
-    } catch { /* noop */ }
+    } catch { /* best-effort: BroadcastChannel unsupported — single-tab fallback */ }
   }, []);
 
   return (

--- a/frontend/src/crm/ContactDetailPage.tsx
+++ b/frontend/src/crm/ContactDetailPage.tsx
@@ -45,20 +45,24 @@ export function ContactDetailPage() {
     setLoading(false);
   }, [id]);
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load(); }, [load]);
 
   async function handleLogActivity() {
     if (!logActivity) return;
     setLogging(true);
-    await api('/api/crm/activity', {
-      method: 'POST',
-      body: JSON.stringify({ activity: logActivity, note: logNote, contact_id: Number(id) }),
-    });
-    setLogActivity('');
-    setLogNote('');
-    setLogging(false);
-    load();
+    try {
+      await api('/api/crm/activity', {
+        method: 'POST',
+        body: JSON.stringify({ activity: logActivity, note: logNote, contact_id: Number(id) }),
+      });
+      setLogActivity('');
+      setLogNote('');
+      load();
+    } catch {
+      toast.error('Failed to log activity.');
+    } finally {
+      setLogging(false);
+    }
   }
 
   async function handleDelete() {

--- a/frontend/src/crm/ContactDetailPage.tsx
+++ b/frontend/src/crm/ContactDetailPage.tsx
@@ -10,6 +10,8 @@ import { PriorityBadge } from './components/badges';
 import { STAGE_COLORS } from './constants';
 import { IconArrowLeft } from '../shared/icons';
 import { useIsMobile } from '../shared/useIsMobile';
+import { confirmDialog } from '../shared/confirm';
+import { toast } from '../shared/toast';
 import {
   INK, INK_MUTE, INK_DIM, LINE, LINE_STRONG, CORAL, SAGE,
   ACCENT, ACCENT_INK,
@@ -60,8 +62,19 @@ export function ContactDetailPage() {
   }
 
   async function handleDelete() {
-    if (!confirm('Delete this contact? This cannot be undone.')) return;
-    await api(`/api/crm/contacts/${id}`, { method: 'DELETE' });
+    const ok = await confirmDialog({
+      title: 'Delete contact',
+      message: `This will permanently delete ${contact?.name || 'this contact'} and their activity history. This cannot be undone.`,
+      confirmLabel: 'Delete contact',
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      await api(`/api/crm/contacts/${id}`, { method: 'DELETE' });
+    } catch {
+      toast.error('Failed to delete contact.');
+      return;
+    }
     navigate('/crm/contacts');
   }
 

--- a/frontend/src/crm/ContactsPage.tsx
+++ b/frontend/src/crm/ContactsPage.tsx
@@ -77,8 +77,10 @@ export function ContactsPage() {
     } catch {
       if (id !== loadIdRef.current) return;
       setLoadFailed(true);
+    } finally {
+      // Guarded: a stale request must not clear the loading flag set by a newer one.
+      if (id === loadIdRef.current) setLoading(false);
     }
-    setLoading(false);
   }, [fetchPage]);
 
   const loadMore = useCallback(async () => {
@@ -93,8 +95,9 @@ export function ContactsPage() {
     } catch {
       if (id !== loadIdRef.current) return;
       toast.error('Failed to load more contacts.');
+    } finally {
+      if (id === loadIdRef.current) setLoadingMore(false);
     }
-    setLoadingMore(false);
   }, [fetchPage, contacts.length, loading, loadingMore]);
 
   useEffect(() => {

--- a/frontend/src/crm/ContactsPage.tsx
+++ b/frontend/src/crm/ContactsPage.tsx
@@ -7,6 +7,8 @@ import { SmartImportModal } from './components/SmartImportModal';
 import { StatusBadge } from './components/badges';
 import { IconPlus, IconSearch } from '../shared/icons';
 import { useIsMobile } from '../shared/useIsMobile';
+import { LoadError } from '../shared/LoadError';
+import { toast } from '../shared/toast';
 import { INK, INK_MUTE, INK_DIM, LINE, BG_RAISED, FONT_SANS, mono } from '../shared/styles';
 import {
   pageHeading, cardStyle, filterTab,
@@ -27,6 +29,7 @@ export function ContactsPage() {
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [tagDropdownOpen, setTagDropdownOpen] = useState(false);
@@ -60,14 +63,21 @@ export function ContactsPage() {
   const reload = useCallback(async () => {
     const id = ++loadIdRef.current;
     setLoading(true);
-    const [data, tagData] = await Promise.all([
-      fetchPage(0),
-      api<{ tags: string[] }>('/api/crm/tags').catch(() => null),
-    ]);
-    if (id !== loadIdRef.current) return;
-    setContacts(data.contacts);
-    setTotal(data.total);
-    if (tagData) setAvailableTags(tagData.tags);
+    setLoadFailed(false);
+    try {
+      const [data, tagData] = await Promise.all([
+        fetchPage(0),
+        // best-effort: tags only feed the filter dropdown
+        api<{ tags: string[] }>('/api/crm/tags').catch(() => null),
+      ]);
+      if (id !== loadIdRef.current) return;
+      setContacts(data.contacts);
+      setTotal(data.total);
+      if (tagData) setAvailableTags(tagData.tags);
+    } catch {
+      if (id !== loadIdRef.current) return;
+      setLoadFailed(true);
+    }
     setLoading(false);
   }, [fetchPage]);
 
@@ -75,10 +85,15 @@ export function ContactsPage() {
     if (loading || loadingMore) return;
     const id = loadIdRef.current;
     setLoadingMore(true);
-    const data = await fetchPage(contacts.length);
-    if (id !== loadIdRef.current) return;
-    setContacts(prev => [...prev, ...data.contacts]);
-    setTotal(data.total);
+    try {
+      const data = await fetchPage(contacts.length);
+      if (id !== loadIdRef.current) return;
+      setContacts(prev => [...prev, ...data.contacts]);
+      setTotal(data.total);
+    } catch {
+      if (id !== loadIdRef.current) return;
+      toast.error('Failed to load more contacts.');
+    }
     setLoadingMore(false);
   }, [fetchPage, contacts.length, loading, loadingMore]);
 
@@ -203,6 +218,8 @@ export function ContactsPage() {
         <div style={{ display: 'flex', justifyContent: 'center', padding: '48px 0' }}>
           <div className="w-6 h-6 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />
         </div>
+      ) : loadFailed && contacts.length === 0 ? (
+        <LoadError label="Couldn't load contacts" onRetry={reload} />
       ) : contacts.length === 0 ? (
         <div style={{ textAlign: 'center', padding: '64px 0' }}>
           <p style={{ color: INK_DIM, fontSize: 14 }}>

--- a/frontend/src/crm/CrmDashboardPage.tsx
+++ b/frontend/src/crm/CrmDashboardPage.tsx
@@ -8,6 +8,8 @@ import { DealDetailSheet } from './components/DealDetailSheet';
 import { STAGE_COLORS, STAGE_ORDER } from './constants';
 import { WarmHalo } from '../shared/WarmHalo';
 import { useIsMobile } from '../shared/useIsMobile';
+import { LoadError } from '../shared/LoadError';
+import { toast } from '../shared/toast';
 import {
   INK, INK_MUTE, INK_SOFT, INK_DIM, LINE,
   GOLD, FONT_DISPLAY,
@@ -24,7 +26,8 @@ export function CrmDashboardPage() {
   const isMobile = useIsMobile();
 
   function reload() {
-    api<CrmDashboard>('/api/crm/dashboard').then(setData);
+    // best-effort: refresh after a mutation; stale data beats a blank page
+    api<CrmDashboard>('/api/crm/dashboard').then(setData).catch(() => {});
   }
 
   async function updateDealStage(deal: CrmDeal, stage: string) {
@@ -36,14 +39,20 @@ export function CrmDashboardPage() {
       reload();
     } catch (err) {
       console.error('Failed to update deal stage:', err);
+      toast.error('Failed to move deal.');
     }
   }
 
-  useEffect(() => {
+  // Doesn't set loading itself (the set-state-in-effect rule forbids sync
+  // setState via the mount effect); initial state is true, retry sets it.
+  function loadDashboard() {
     api<CrmDashboard>('/api/crm/dashboard')
       .then(setData)
+      .catch(() => {}) // data stays null → LoadError below
       .finally(() => setLoading(false));
-  }, []);
+  }
+
+  useEffect(() => { loadDashboard(); }, []);
 
   if (loading) {
     return (
@@ -53,7 +62,7 @@ export function CrmDashboardPage() {
     );
   }
 
-  if (!data) return <p style={{ color: INK_MUTE, padding: 32 }}>Failed to load CRM dashboard.</p>;
+  if (!data) return <LoadError label="Couldn't load CRM dashboard" onRetry={() => { setLoading(true); loadDashboard(); }} />;
 
   const activePipeline = data.pipeline_by_stage
     .filter(s => s.stage !== 'won' && s.stage !== 'lost')

--- a/frontend/src/crm/CrmLayout.tsx
+++ b/frontend/src/crm/CrmLayout.tsx
@@ -142,6 +142,7 @@ export function CrmLayout() {
   const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
+    // best-effort: assume non-demo on failure
     api<{ demo_mode: boolean }>('/api/crm/demo-status').then(r => setDemoMode(r.demo_mode)).catch(() => setDemoMode(false));
   }, []);
 

--- a/frontend/src/crm/PipelinePage.tsx
+++ b/frontend/src/crm/PipelinePage.tsx
@@ -7,6 +7,8 @@ import { DealDetailSheet } from './components/DealDetailSheet';
 import { STAGE_COLORS, STAGE_ORDER } from './constants';
 import { IconPlus } from '../shared/icons';
 import { useIsMobile } from '../shared/useIsMobile';
+import { LoadError } from '../shared/LoadError';
+import { toast } from '../shared/toast';
 import {
   INK, INK_MUTE, INK_DIM, LINE, BG_CARD,
   FONT_DISPLAY, mono, formatNumber,
@@ -48,8 +50,10 @@ export function PipelinePage() {
 
   const load = useCallback(async () => {
     setLoading(true);
-    const d = await api<PipelineData>('/api/crm/deals');
-    setData(d);
+    try {
+      const d = await api<PipelineData>('/api/crm/deals');
+      setData(d);
+    } catch { /* data stays null → LoadError below */ }
     setLoading(false);
   }, []);
 
@@ -65,6 +69,7 @@ export function PipelinePage() {
       load();
     } catch (err) {
       console.error('Failed to update deal stage:', err);
+      toast.error('Failed to move deal.');
     }
   }
 
@@ -75,6 +80,8 @@ export function PipelinePage() {
       </div>
     );
   }
+
+  if (!data) return <LoadError label="Couldn't load pipeline" onRetry={load} />;
 
   const deals = data?.deals || [];
   const grouped = STAGES.reduce<Record<string, CrmDeal[]>>((acc, stage) => {

--- a/frontend/src/crm/PipelinePage.tsx
+++ b/frontend/src/crm/PipelinePage.tsx
@@ -54,10 +54,9 @@ export function PipelinePage() {
       const d = await api<PipelineData>('/api/crm/deals');
       setData(d);
     } catch { /* data stays null → LoadError below */ }
-    setLoading(false);
+    finally { setLoading(false); }
   }, []);
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load(); }, [load]);
 
   async function updateDealStage(deal: CrmDeal, stage: string) {

--- a/frontend/src/crm/TasksPage.tsx
+++ b/frontend/src/crm/TasksPage.tsx
@@ -5,6 +5,8 @@ import { TaskForm } from './components/TaskForm';
 import { PriorityBadge } from './components/badges';
 import { IconPlus, IconCheck } from '../shared/icons';
 import { useIsMobile } from '../shared/useIsMobile';
+import { LoadError } from '../shared/LoadError';
+import { toast } from '../shared/toast';
 import {
   INK, INK_MUTE, INK_SOFT, INK_DIM, LINE, LINE_STRONG,
   CORAL, SAGE, ACCENT_INK,
@@ -22,6 +24,7 @@ type Filter = 'all' | 'pending' | 'due_today' | 'overdue' | 'completed';
 export function TasksPage() {
   const [tasks, setTasks] = useState<CrmTask[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [filter, setFilter] = useState<Filter>('pending');
   const [showCreate, setShowCreate] = useState(false);
   const [selectedTask, setSelectedTask] = useState<CrmTask | null>(null);
@@ -37,11 +40,16 @@ export function TasksPage() {
     else if (filter === 'due_today') { params.set('completed', 'false'); params.set('due_before', today); }
     else if (filter === 'overdue') { params.set('completed', 'false'); params.set('due_before', today); }
     params.set('limit', '100');
-    const data = await api<{ tasks: CrmTask[] }>(`/api/crm/tasks?${params}`);
-    let filtered = data.tasks;
-    if (filter === 'due_today') filtered = filtered.filter(t => t.due_date === today);
-    else if (filter === 'overdue') filtered = filtered.filter(t => t.due_date && t.due_date < today);
-    setTasks(filtered);
+    try {
+      const data = await api<{ tasks: CrmTask[] }>(`/api/crm/tasks?${params}`);
+      let filtered = data.tasks;
+      if (filter === 'due_today') filtered = filtered.filter(t => t.due_date === today);
+      else if (filter === 'overdue') filtered = filtered.filter(t => t.due_date && t.due_date < today);
+      setTasks(filtered);
+      setLoadFailed(false);
+    } catch {
+      setLoadFailed(true);
+    }
     setLoading(false);
   }, [filter]);
 
@@ -49,10 +57,15 @@ export function TasksPage() {
   useEffect(() => { load(); }, [load]);
 
   async function toggleComplete(task: CrmTask) {
-    if (task.completed) {
-      await api(`/api/crm/tasks/${task.id}`, { method: 'PUT', body: JSON.stringify({ completed: 0 }) });
-    } else {
-      await api(`/api/crm/tasks/${task.id}/complete`, { method: 'PUT' });
+    try {
+      if (task.completed) {
+        await api(`/api/crm/tasks/${task.id}`, { method: 'PUT', body: JSON.stringify({ completed: 0 }) });
+      } else {
+        await api(`/api/crm/tasks/${task.id}/complete`, { method: 'PUT' });
+      }
+    } catch {
+      toast.error('Failed to update task.');
+      return;
     }
     load();
   }
@@ -93,6 +106,8 @@ export function TasksPage() {
         <div style={{ display: 'flex', justifyContent: 'center', padding: '48px 0' }}>
           <div className="w-6 h-6 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />
         </div>
+      ) : loadFailed && tasks.length === 0 ? (
+        <LoadError label="Couldn't load tasks" onRetry={load} />
       ) : tasks.length === 0 ? (
         <div style={{ textAlign: 'center', padding: '64px 0' }}>
           <p style={{ color: INK_DIM, fontSize: 14 }}>

--- a/frontend/src/crm/components/ActivityTimeline.tsx
+++ b/frontend/src/crm/components/ActivityTimeline.tsx
@@ -6,6 +6,8 @@ import type { CrmActivity } from '../../core/types';
 import { IconPhone, IconMail, IconUsers, IconFile } from '../../shared/icons';
 import { mono, INK, INK_MUTE, INK_SOFT, INK_DIM, LINE, LINE_STRONG, BG_RAISED, ACCENT, ACCENT_INK, FONT_DISPLAY, FONT_SANS } from '../../shared/styles';
 import { modalOverlay, modalContent, mobileDragHandle, btnDanger } from '../styles';
+import { confirmDialog } from '../../shared/confirm';
+import { toast } from '../../shared/toast';
 
 const ACTIVITY_ICONS: Record<string, React.ComponentType<{ size?: number; strokeWidth?: number }>> = {
   call: IconPhone,
@@ -55,17 +57,24 @@ export function ActivityTimeline({ activities, onUpdate }: Props) {
       });
       setSelected(null);
       onUpdate?.();
-    } catch { /* ignore */ }
+    } catch { toast.error('Failed to save activity.'); }
     setSaving(false);
   }
 
   async function handleDelete() {
-    if (!selected || !confirm('Delete this activity entry?')) return;
+    if (!selected) return;
+    const ok = await confirmDialog({
+      title: 'Delete activity',
+      message: 'This activity entry will be permanently deleted.',
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
     try {
       await api(`/api/crm/activity/${selected.id}`, { method: 'DELETE' });
       setSelected(null);
       onUpdate?.();
-    } catch { /* ignore */ }
+    } catch { toast.error('Failed to delete activity.'); }
   }
 
   return (

--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import { api } from '../core/api/client';
 import { AgentCard } from './AgentCard';
@@ -43,9 +43,11 @@ export function DashboardPage() {
   const context = useOutletContext<{ branding: BrandingConfig | null; setBranding: (b: BrandingConfig) => void }>();
   const branding = context?.branding;
 
-  function loadDashboard() {
-    setLoading(true);
-    setLoadFailed(false);
+  // No synchronous setState here — the initial state is already
+  // loading=true/loadFailed=false, and the retry handler resets both before
+  // calling. Keeping it out lets the effect call this without tripping the
+  // react-hooks/set-state-in-effect rule.
+  const loadDashboard = useCallback(() => {
     Promise.all([
       api<{ agents: Agent[] }>('/api/agents'),
       api<ProviderStatus>('/api/providers'),
@@ -60,10 +62,9 @@ export function DashboardPage() {
       console.error('Dashboard load error:', err);
       setLoadFailed(true);
     }).finally(() => setLoading(false));
-  }
+  }, [navigate]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { loadDashboard(); }, [navigate]);
+  useEffect(() => { loadDashboard(); }, [loadDashboard]);
 
 
   const isMobile = useIsMobile();
@@ -198,7 +199,7 @@ export function DashboardPage() {
             <div className="w-8 h-8 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />
           </div>
         ) : loadFailed ? (
-          <LoadError label="Couldn't load your agents" onRetry={loadDashboard} />
+          <LoadError label="Couldn't load your agents" onRetry={() => { setLoading(true); setLoadFailed(false); loadDashboard(); }} />
         ) : agents.length === 0 ? (
           <div>
             <div style={{

--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { AgentCard } from './AgentCard';
 import { CreateAgentModal } from './CreateAgentModal';
 import { ImportAgentModal } from './ImportAgentModal';
 import { WarmHalo } from '../shared/WarmHalo';
+import { LoadError } from '../shared/LoadError';
 import { IconSearch, IconPlus, IconDownload } from '../shared/icons';
 import { MobileMenuDrawer } from '../shared/MobileMenuDrawer';
 import { useIsMobile } from '../shared/useIsMobile';
@@ -37,11 +38,14 @@ export function DashboardPage() {
   const [showImport, setShowImport] = useState(false);
   const [suggestedTitle, setSuggestedTitle] = useState('');
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const navigate = useNavigate();
   const context = useOutletContext<{ branding: BrandingConfig | null; setBranding: (b: BrandingConfig) => void }>();
   const branding = context?.branding;
 
-  useEffect(() => {
+  function loadDashboard() {
+    setLoading(true);
+    setLoadFailed(false);
     Promise.all([
       api<{ agents: Agent[] }>('/api/agents'),
       api<ProviderStatus>('/api/providers'),
@@ -54,8 +58,12 @@ export function DashboardPage() {
       setAgents(agentsData.agents);
     }).catch(err => {
       console.error('Dashboard load error:', err);
+      setLoadFailed(true);
     }).finally(() => setLoading(false));
-  }, [navigate]);
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { loadDashboard(); }, [navigate]);
 
 
   const isMobile = useIsMobile();
@@ -189,6 +197,8 @@ export function DashboardPage() {
           <div style={{ display: 'flex', justifyContent: 'center', padding: '80px 0' }}>
             <div className="w-8 h-8 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />
           </div>
+        ) : loadFailed ? (
+          <LoadError label="Couldn't load your agents" onRetry={loadDashboard} />
         ) : agents.length === 0 ? (
           <div>
             <div style={{

--- a/frontend/src/dashboard/DataTab.tsx
+++ b/frontend/src/dashboard/DataTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { IconFile } from '../shared/icons';
+import { confirmDialog } from '../shared/confirm';
 
 export function DataTab() {
   const [downloading, setDownloading] = useState(false);
@@ -34,7 +35,13 @@ export function DataTab() {
 
   async function handleRestore() {
     if (!selectedFile) return;
-    if (!window.confirm('Are you sure? This will replace ALL current data and cannot be undone.')) return;
+    const ok = await confirmDialog({
+      title: 'Restore from backup',
+      message: 'This will replace ALL current data with the backup contents. This cannot be undone.',
+      confirmLabel: 'Replace everything',
+      danger: true,
+    });
+    if (!ok) return;
 
     setRestoring(true);
     setMessage(null);

--- a/frontend/src/dashboard/GoogleIntegrationCard.tsx
+++ b/frontend/src/dashboard/GoogleIntegrationCard.tsx
@@ -72,6 +72,7 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
 
   useEffect(() => {
     if (assignmentsOpen && agents.length === 0) {
+      // best-effort: assignment list stays empty on failure
       api<{ agents: Agent[] }>('/api/agents').then(data => setAgents(data.agents)).catch(() => {});
     }
   }, [assignmentsOpen]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { api } from '../core/api/client';
 import { getToken } from '../core/auth/tokenUtils';
+import { LoadError } from '../shared/LoadError';
 import { useOAuthFlow } from '../core/hooks/useOAuthFlow';
 import { GoogleIntegrationCard } from './GoogleIntegrationCard';
 import { AppCredentialsForm } from './AppCredentialsForm';
@@ -32,6 +33,7 @@ const mono = (size: number, color = 'rgba(237,240,244,0.38)') => ({
 export function IntegrationsTab() {
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [setupFor, setSetupFor] = useState<string | null>(null);
 
   const [odooUrl, setOdooUrl] = useState('');
@@ -67,14 +69,20 @@ export function IntegrationsTab() {
   const [tgSelectedAgent, setTgSelectedAgent] = useState<string>('');
   const pollTimers = useRef<Record<string, ReturnType<typeof setInterval>>>({});
 
-  useEffect(() => {
+  function loadIntegrations() {
+    setLoading(true);
+    setLoadFailed(false);
     api<{ integrations: Integration[] }>('/api/integrations')
       .then(data => setIntegrations(data.integrations))
+      .catch(() => setLoadFailed(true))
       .finally(() => setLoading(false));
-  }, []);
+  }
+
+  useEffect(() => { loadIntegrations(); }, []);
 
   useEffect(() => {
     if (waExpanded || telegramExpanded) {
+      // best-effort: failure leaves the expanded section's agent list empty
       api<{ agents: Agent[] }>('/api/agents').then(data => {
         setAgents(data.agents);
         if (waExpanded) {
@@ -89,7 +97,7 @@ export function IntegrationsTab() {
           }
           setWaStatuses(statuses);
         }
-      });
+      }).catch(() => {});
     }
   }, [waExpanded, telegramExpanded]);
 
@@ -274,7 +282,8 @@ export function IntegrationsTab() {
 
   useEffect(() => {
     if (qbOAuth.state.status === 'success') {
-      api<{ integrations: Integration[] }>('/api/integrations').then(d => setIntegrations(d.integrations));
+      // best-effort: refresh after OAuth; stale card beats an error here
+      api<{ integrations: Integration[] }>('/api/integrations').then(d => setIntegrations(d.integrations)).catch(() => {});
       qbOAuth.reset();
     } else if (qbOAuth.state.status === 'error' && qbOAuth.state.error) {
       setError(qbOAuth.state.error);
@@ -323,6 +332,10 @@ export function IntegrationsTab() {
       <div className="w-6 h-6 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />
     </div>
   );
+
+  if (loadFailed && integrations.length === 0) {
+    return <LoadError label="Couldn't load integrations" onRetry={loadIntegrations} />;
+  }
 
   async function refreshIntegrations() {
     const data = await api<{ integrations: Integration[] }>('/api/integrations');
@@ -544,7 +557,8 @@ export function IntegrationsTab() {
                     setPcMappingExpanded(next);
                     if (next) {
                       loadPaperclipAgents();
-                      api<{ agents: Agent[] }>('/api/agents').then(d => setAgents(d.agents));
+                      // best-effort: failure leaves the agent list empty
+    api<{ agents: Agent[] }>('/api/agents').then(d => setAgents(d.agents)).catch(() => {});
                     }
                   }}
                   style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }}
@@ -755,7 +769,7 @@ export function IntegrationsTab() {
                           botUsername={agent.telegram_bot_username || ''}
                           telegramEnabled={agent.telegram_enabled}
                           groupEnabled={agent.telegram_group_enabled}
-                          onUpdate={() => api<{ agents: Agent[] }>('/api/agents').then(data => setAgents(data.agents))}
+                          onUpdate={() => api<{ agents: Agent[] }>('/api/agents').then(data => setAgents(data.agents)).catch(() => {})}
                         />
                       );
                     })()}

--- a/frontend/src/dashboard/IntegrationsTab.tsx
+++ b/frontend/src/dashboard/IntegrationsTab.tsx
@@ -69,16 +69,23 @@ export function IntegrationsTab() {
   const [tgSelectedAgent, setTgSelectedAgent] = useState<string>('');
   const pollTimers = useRef<Record<string, ReturnType<typeof setInterval>>>({});
 
-  function loadIntegrations() {
-    setLoading(true);
-    setLoadFailed(false);
+  // No synchronous setState here — the initial state is already
+  // loading=true/loadFailed=false, and the retry handler resets both before
+  // calling. Keeping it out lets the effect call this without tripping the
+  // react-hooks/set-state-in-effect rule.
+  const loadIntegrations = useCallback(() => {
     api<{ integrations: Integration[] }>('/api/integrations')
       .then(data => setIntegrations(data.integrations))
       .catch(() => setLoadFailed(true))
       .finally(() => setLoading(false));
-  }
+  }, []);
 
-  useEffect(() => { loadIntegrations(); }, []);
+  useEffect(() => { loadIntegrations(); }, [loadIntegrations]);
+
+  async function refreshIntegrations() {
+    const data = await api<{ integrations: Integration[] }>('/api/integrations');
+    setIntegrations(data.integrations);
+  }
 
   useEffect(() => {
     if (waExpanded || telegramExpanded) {
@@ -334,12 +341,7 @@ export function IntegrationsTab() {
   );
 
   if (loadFailed && integrations.length === 0) {
-    return <LoadError label="Couldn't load integrations" onRetry={loadIntegrations} />;
-  }
-
-  async function refreshIntegrations() {
-    const data = await api<{ integrations: Integration[] }>('/api/integrations');
-    setIntegrations(data.integrations);
+    return <LoadError label="Couldn't load integrations" onRetry={() => { setLoading(true); setLoadFailed(false); loadIntegrations(); }} />;
   }
 
   async function openQbCredForm() {
@@ -558,7 +560,7 @@ export function IntegrationsTab() {
                     if (next) {
                       loadPaperclipAgents();
                       // best-effort: failure leaves the agent list empty
-    api<{ agents: Agent[] }>('/api/agents').then(d => setAgents(d.agents)).catch(() => {});
+                      api<{ agents: Agent[] }>('/api/agents').then(d => setAgents(d.agents)).catch(() => {});
                     }
                   }}
                   style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }}

--- a/frontend/src/dashboard/LogsTab.tsx
+++ b/frontend/src/dashboard/LogsTab.tsx
@@ -88,6 +88,7 @@ export function LogsTab() {
   const intervalRef = useRef<number | null>(null);
 
   useEffect(() => {
+    // best-effort: agent filter dropdown stays empty on failure
     api<{ agents: Agent[] }>('/api/agents').then(d => setAgents(d.agents)).catch(() => {});
   }, []);
 

--- a/frontend/src/dashboard/SecurityTab.tsx
+++ b/frontend/src/dashboard/SecurityTab.tsx
@@ -117,6 +117,7 @@ export function SecurityTab() {
   }
 
   function copyBackupCodes() {
+    // best-effort: clipboard may be unavailable; codes stay visible to copy manually
     navigator.clipboard.writeText(backupCodes.join('\n')).catch(() => {});
   }
 

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -30,6 +30,7 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
 
   useEffect(() => {
     if (tab === 'danger') {
+      // best-effort: danger-zone list stays empty on failure
       api<{ agents: Agent[] }>('/api/agents').then(d => setDangerAgents(d.agents)).catch(() => {});
     }
   }, [tab]);

--- a/frontend/src/dashboard/SettingsPanel.tsx
+++ b/frontend/src/dashboard/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { api } from '../core/api/client';
+import { toast } from '../shared/toast';
 import type { Agent, BrandingConfig } from '../core/types';
 import { ProviderSetup } from '../setup/ProviderSetup';
 import { IntegrationsTab } from './IntegrationsTab';
@@ -90,6 +91,8 @@ export function SettingsPanel({ branding, onBrandingUpdate, onClose }: Props) {
       });
       onBrandingUpdate(updated);
       document.documentElement.style.setProperty('--brand-color', updated.accent_color);
+    } catch {
+      toast.error('Failed to save branding.');
     } finally {
       setSaving(false);
     }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -77,6 +77,11 @@ input:focus, textarea:focus, select:focus {
   50% { opacity: 0; }
 }
 
+@keyframes ch-toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+
 .agent-mark-tooltip {
   position: absolute;
   bottom: calc(100% + 8px);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ErrorBoundary, RootErrorFallback } from './shared/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary fallback={error => <RootErrorFallback error={error} />}>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/frontend/src/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/onboarding/OnboardingWizard.tsx
@@ -26,7 +26,7 @@ export function OnboardingWizard({ onComplete }: Props) {
       setProviderStatus(data);
       const anyConfigured = Object.values(data.profiles).some(p => p.configured);
       if (anyConfigured) setPhase('pick-messaging');
-    }).catch(console.error);
+    }).catch(console.error); // best-effort: wizard stays on the provider step
   }, []);
 
   const steps = useMemo(() => {

--- a/frontend/src/onboarding/steps/IntegrationPickerStep.tsx
+++ b/frontend/src/onboarding/steps/IntegrationPickerStep.tsx
@@ -23,6 +23,8 @@ export function IntegrationPickerStep({ onComplete, onSkip }: Props) {
         );
         setIntegrations(available);
       })
+      // best-effort: an empty list still lets the user skip this step
+      .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 

--- a/frontend/src/onboarding/steps/MessagingPickerStep.tsx
+++ b/frontend/src/onboarding/steps/MessagingPickerStep.tsx
@@ -22,6 +22,8 @@ export function MessagingPickerStep({ onComplete, onSkip }: Props) {
         );
         setIntegrations(messaging);
       })
+      // best-effort: an empty list still lets the user skip this step
+      .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 

--- a/frontend/src/setup/SetupWizard.tsx
+++ b/frontend/src/setup/SetupWizard.tsx
@@ -8,6 +8,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../core/api/client';
+import { toast } from '../shared/toast';
 import { ProviderSetup } from './ProviderSetup';
 import type { BrandingConfig } from '../core/types';
 
@@ -62,6 +63,8 @@ export function SetupWizard() {
         document.documentElement.style.setProperty('--brand-color', updated.accent_color);
       }
       await finish();
+    } catch {
+      toast.error('Failed to finish setup.');
     } finally {
       setSaving(false);
     }

--- a/frontend/src/shared/AppShell.tsx
+++ b/frontend/src/shared/AppShell.tsx
@@ -29,7 +29,7 @@ export function AppShell() {
       if (data.accent_color && data.accent_color.toLowerCase() !== OLD_DEFAULT) {
         document.documentElement.style.setProperty('--brand-color', data.accent_color);
       }
-    }).catch(() => {});
+    }).catch(() => {}); // best-effort: default branding applies
   }, []);
 
   const userInitial = branding?.company_name?.charAt(0) || 'C';

--- a/frontend/src/shared/AppShell.tsx
+++ b/frontend/src/shared/AppShell.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { api } from '../core/api/client';
 import { NavRail } from './NavRail';
+import { ErrorBoundary, RouteErrorFallback } from './ErrorBoundary';
 import { SettingsPanel } from '../dashboard/SettingsPanel';
 import { useIsMobile } from './useIsMobile';
 import { IconBot, IconFunnel, IconBook, IconSettings } from './icons';
@@ -65,7 +66,14 @@ export function AppShell() {
         <NavRail onSettingsClick={() => setShowSettings(true)} userInitial={userInitial} />
       )}
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', position: 'relative', overflow: 'hidden' }}>
-        <Outlet context={{ branding, setBranding }} />
+        {/* Keyed by pathname so navigating away resets a crashed route; the
+            nav rail lives outside and survives. */}
+        <ErrorBoundary
+          key={location.pathname}
+          fallback={(error, reset) => <RouteErrorFallback error={error} reset={reset} />}
+        >
+          <Outlet context={{ branding, setBranding }} />
+        </ErrorBoundary>
       </div>
 
       {isMobile && (

--- a/frontend/src/shared/AppShell.tsx
+++ b/frontend/src/shared/AppShell.tsx
@@ -66,10 +66,14 @@ export function AppShell() {
         <NavRail onSettingsClick={() => setShowSettings(true)} userInitial={userInitial} />
       )}
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', position: 'relative', overflow: 'hidden' }}>
-        {/* Keyed by pathname so navigating away resets a crashed route; the
-            nav rail lives outside and survives. */}
+        {/* Keyed by route group so navigating away resets a crashed route
+            while the nav rail (outside) survives. CRM shares one key: its
+            nested tabs change the pathname, and a full-pathname key would
+            remount the stateful CrmLayout on every tab switch (re-showing
+            the dismissed demo dialog). Recovery from a crash inside CRM
+            still works via the fallback's Back to Dashboard / Reload. */}
         <ErrorBoundary
-          key={location.pathname}
+          key={location.pathname.startsWith('/crm') ? '/crm' : location.pathname}
           fallback={(error, reset) => <RouteErrorFallback error={error} reset={reset} />}
         >
           <Outlet context={{ branding, setBranding }} />

--- a/frontend/src/shared/ConfirmHost.tsx
+++ b/frontend/src/shared/ConfirmHost.tsx
@@ -13,7 +13,7 @@ import {
 } from './styles';
 
 export function ConfirmHost() {
-  const current = useSyncExternalStore(subscribeConfirms, getCurrentConfirm);
+  const current = useSyncExternalStore(subscribeConfirms, getCurrentConfirm, () => null);
   return current ? <ConfirmCard key={current.id} options={current.options} /> : null;
 }
 

--- a/frontend/src/shared/ConfirmHost.tsx
+++ b/frontend/src/shared/ConfirmHost.tsx
@@ -1,0 +1,126 @@
+/**
+ * Chatty — confirm dialog host. Mounted once in App.tsx; renders the head
+ * of the confirm store's queue as a styled modal (visual language of
+ * dashboard/DeleteAgentModal.tsx).
+ */
+
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { subscribeConfirms, getCurrentConfirm, settleConfirm } from './confirm';
+import type { ConfirmOptions } from './confirm';
+import {
+  BG_ELEV, LINE_STRONG, INK, INK_MUTE, INK_SOFT, ACCENT, ACCENT_INK, CORAL,
+  FONT_DISPLAY, FONT_SANS,
+} from './styles';
+
+export function ConfirmHost() {
+  const current = useSyncExternalStore(subscribeConfirms, getCurrentConfirm);
+  return current ? <ConfirmCard key={current.id} options={current.options} /> : null;
+}
+
+function ConfirmCard({ options }: { options: ConfirmOptions }) {
+  const { title, message, confirmLabel = 'Confirm', cancelLabel = 'Cancel', danger } = options;
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement;
+    // Danger dialogs focus Cancel so a reflexive Enter can't destroy data;
+    // otherwise Confirm gets focus to match native confirm()'s Enter ≈ OK.
+    (danger ? cancelRef.current : confirmRef.current)?.focus();
+
+    // Capture phase: runs before the bubble-phase document Escape listeners
+    // in AvatarMenu/ConversationSidebar/HeartbeatChecklist, so Escape closes
+    // only the confirm — not a popover underneath it.
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        settleConfirm(false);
+      } else if (e.key === 'Tab') {
+        // Two focusable elements — trap focus by toggling between them.
+        e.preventDefault();
+        e.stopPropagation();
+        (document.activeElement === confirmRef.current ? cancelRef : confirmRef).current?.focus();
+      }
+    }
+    document.addEventListener('keydown', onKeyDown, { capture: true });
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, { capture: true });
+      if (previouslyFocused instanceof HTMLElement && document.contains(previouslyFocused)) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [danger]);
+
+  return (
+    <div
+      onClick={() => settleConfirm(false)}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 150, padding: 16,
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="chatty-confirm-title"
+        aria-describedby="chatty-confirm-message"
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: BG_ELEV, borderRadius: 6,
+          border: `1px solid ${LINE_STRONG}`,
+          padding: 28, width: '100%', maxWidth: 420,
+          boxShadow: '0 8px 40px rgba(0,0,0,0.5)',
+        }}
+      >
+        <h2
+          id="chatty-confirm-title"
+          style={{
+            fontFamily: FONT_DISPLAY, fontSize: 20, fontWeight: 400,
+            letterSpacing: '-0.02em', margin: '0 0 8px', color: INK,
+          }}
+        >
+          {title}
+        </h2>
+        <p
+          id="chatty-confirm-message"
+          style={{
+            fontFamily: FONT_SANS, fontSize: 13, color: INK_SOFT,
+            lineHeight: 1.5, margin: '0 0 24px',
+          }}
+        >
+          {message}
+        </p>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={() => settleConfirm(false)}
+            style={{
+              flex: 1, padding: '9px 16px', borderRadius: 4,
+              border: `1px solid ${LINE_STRONG}`,
+              background: 'transparent', color: INK_MUTE,
+              cursor: 'pointer', fontSize: 13, fontFamily: FONT_SANS,
+            }}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={() => settleConfirm(true)}
+            style={{
+              flex: 1, padding: '9px 16px', borderRadius: 4,
+              background: danger ? CORAL : ACCENT, color: ACCENT_INK,
+              border: 'none', fontWeight: 500, cursor: 'pointer',
+              fontSize: 13, fontFamily: FONT_SANS,
+            }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shared/ErrorBoundary.tsx
+++ b/frontend/src/shared/ErrorBoundary.tsx
@@ -1,0 +1,143 @@
+/**
+ * Chatty — error boundary for render/lifecycle crashes (async/event errors
+ * are the toast layer's job). Two mounts:
+ *  - main.tsx: wraps <App/> with RootErrorFallback (full-screen, reload)
+ *  - AppShell.tsx: wraps the route <Outlet/> with RouteErrorFallback, keyed
+ *    by pathname — a crashed page dies alone while the nav rail survives
+ */
+
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  INK, INK_DIM, INK_MUTE, INK_SOFT, LINE_STRONG, ACCENT, ACCENT_INK,
+  FONT_DISPLAY, FONT_SANS, FONT_MONO, mono,
+} from './styles';
+
+interface Props {
+  fallback: (error: Error, reset: () => void) => ReactNode;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (this.state.error) return this.props.fallback(this.state.error, this.reset);
+    return this.props.children;
+  }
+}
+
+/** Stack traces are an info-disclosure risk on the unauthenticated login
+ *  page (the root boundary wraps it) — only show them in dev builds. */
+function ErrorDetail({ error }: { error: Error }) {
+  return (
+    <details style={{ marginTop: 24, maxWidth: 560, width: '100%' }}>
+      <summary style={{ ...mono(10, INK_DIM), cursor: 'pointer' }}>Error detail</summary>
+      <pre
+        style={{
+          fontFamily: FONT_MONO, fontSize: 11, color: INK_DIM,
+          whiteSpace: 'pre-wrap', overflowWrap: 'break-word',
+          maxHeight: 240, overflowY: 'auto',
+          margin: '8px 0 0', padding: 12,
+          border: `1px solid ${LINE_STRONG}`, borderRadius: 6,
+          textAlign: 'left',
+        }}
+      >
+        {import.meta.env.DEV ? `${error.message}\n${error.stack ?? ''}` : error.message}
+      </pre>
+    </details>
+  );
+}
+
+const buttonStyle = {
+  padding: '9px 20px', borderRadius: 4,
+  background: ACCENT, color: ACCENT_INK,
+  border: 'none', fontWeight: 500, cursor: 'pointer',
+  fontSize: 13, fontFamily: FONT_SANS,
+} as const;
+
+const secondaryButtonStyle = {
+  ...buttonStyle,
+  background: 'transparent', color: INK_MUTE,
+  border: `1px solid ${LINE_STRONG}`,
+} as const;
+
+export function RootErrorFallback({ error }: { error: Error }) {
+  // No router hooks here — this mounts outside BrowserRouter.
+  return (
+    <div
+      style={{
+        minHeight: '100svh', background: '#0A0C0F', color: INK,
+        display: 'flex', flexDirection: 'column', alignItems: 'center',
+        justifyContent: 'center', padding: 24, textAlign: 'center',
+        fontFamily: FONT_SANS,
+      }}
+    >
+      <h1 style={{ fontFamily: FONT_DISPLAY, fontSize: 28, fontWeight: 400, letterSpacing: '-0.02em', margin: '0 0 8px' }}>
+        Something went wrong
+      </h1>
+      <p style={{ fontSize: 13, color: INK_SOFT, lineHeight: 1.5, margin: '0 0 24px' }}>
+        An unexpected error occurred. Reloading usually fixes it.
+      </p>
+      <button onClick={() => window.location.reload()} style={buttonStyle}>
+        Reload
+      </button>
+      <ErrorDetail error={error} />
+    </div>
+  );
+}
+
+export function RouteErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  const navigate = useNavigate();
+
+  // The explicit reset() matters when the crashed route IS '/': the
+  // boundary's pathname key doesn't change, so navigation alone would
+  // leave it stuck in its error state.
+  function handleBackToDashboard() {
+    navigate('/');
+    reset();
+  }
+
+  return (
+    <div
+      style={{
+        flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center',
+        justifyContent: 'center', padding: 24, textAlign: 'center',
+        color: INK, fontFamily: FONT_SANS,
+      }}
+    >
+      <h2 style={{ fontFamily: FONT_DISPLAY, fontSize: 24, fontWeight: 400, letterSpacing: '-0.02em', margin: '0 0 8px' }}>
+        This page hit an error
+      </h2>
+      <p style={{ fontSize: 13, color: INK_SOFT, lineHeight: 1.5, margin: '0 0 24px' }}>
+        The rest of the app is still running. You can head back to the dashboard or reload.
+      </p>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={handleBackToDashboard} style={buttonStyle}>
+          Back to Dashboard
+        </button>
+        <button onClick={() => window.location.reload()} style={secondaryButtonStyle}>
+          Reload
+        </button>
+      </div>
+      <ErrorDetail error={error} />
+    </div>
+  );
+}

--- a/frontend/src/shared/ErrorBoundary.tsx
+++ b/frontend/src/shared/ErrorBoundary.tsx
@@ -44,9 +44,23 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-/** Stack traces are an info-disclosure risk on the unauthenticated login
- *  page (the root boundary wraps it) — only show them in dev builds. */
-function ErrorDetail({ error }: { error: Error }) {
+interface ErrorDetailProps {
+  error: Error;
+  /** Redact error.message in prod builds (set on the unauthenticated root fallback). */
+  redactMessage?: boolean;
+}
+
+/** Stack traces — and, for the root fallback, error messages — are an
+ *  info-disclosure risk on the unauthenticated login page (the root boundary
+ *  wraps it). Dev builds show message + stack; prod shows error.message for
+ *  the authenticated route fallback only, and a generic pointer to the
+ *  console for the root fallback. */
+function ErrorDetail({ error, redactMessage }: ErrorDetailProps) {
+  const detail = import.meta.env.DEV
+    ? `${error.message}\n${error.stack ?? ''}`
+    : redactMessage
+      ? 'Details were logged to the browser console.'
+      : error.message;
   return (
     <details style={{ marginTop: 24, maxWidth: 560, width: '100%' }}>
       <summary style={{ ...mono(10, INK_DIM), cursor: 'pointer' }}>Error detail</summary>
@@ -60,7 +74,7 @@ function ErrorDetail({ error }: { error: Error }) {
           textAlign: 'left',
         }}
       >
-        {import.meta.env.DEV ? `${error.message}\n${error.stack ?? ''}` : error.message}
+        {detail}
       </pre>
     </details>
   );
@@ -79,7 +93,11 @@ const secondaryButtonStyle = {
   border: `1px solid ${LINE_STRONG}`,
 } as const;
 
-export function RootErrorFallback({ error }: { error: Error }) {
+interface RootErrorFallbackProps {
+  error: Error;
+}
+
+export function RootErrorFallback({ error }: RootErrorFallbackProps) {
   // No router hooks here — this mounts outside BrowserRouter.
   return (
     <div
@@ -99,12 +117,17 @@ export function RootErrorFallback({ error }: { error: Error }) {
       <button onClick={() => window.location.reload()} style={buttonStyle}>
         Reload
       </button>
-      <ErrorDetail error={error} />
+      <ErrorDetail error={error} redactMessage />
     </div>
   );
 }
 
-export function RouteErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+interface RouteErrorFallbackProps {
+  error: Error;
+  reset: () => void;
+}
+
+export function RouteErrorFallback({ error, reset }: RouteErrorFallbackProps) {
   const navigate = useNavigate();
 
   // The explicit reset() matters when the crashed route IS '/': the

--- a/frontend/src/shared/LoadError.tsx
+++ b/frontend/src/shared/LoadError.tsx
@@ -1,0 +1,50 @@
+/**
+ * Chatty — inline "Couldn't load — Retry" callout for primary data loads
+ * that failed. Lives where the content would be (errors belong where the
+ * user is looking); toasts are reserved for failed mutations.
+ */
+
+import { INK_MUTE, CORAL, GOLD, FONT_SANS, mono } from './styles';
+
+interface Props {
+  label?: string;
+  onRetry: () => void;
+  compact?: boolean;
+}
+
+export function LoadError({ label = "Couldn't load", onRetry, compact }: Props) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        background: 'rgba(217,119,87,0.06)',
+        border: '1px solid rgba(217,119,87,0.18)',
+        borderRadius: 6,
+        padding: compact ? '10px 12px' : '14px 16px',
+        margin: compact ? '8px 12px' : '12px 16px',
+      }}
+    >
+      <span style={{ ...mono(9, CORAL), flexShrink: 0 }}>Error</span>
+      <span style={{ fontFamily: FONT_SANS, fontSize: compact ? 12 : 13, color: INK_MUTE, flex: 1, minWidth: 0 }}>
+        {label}
+      </span>
+      <button
+        onClick={onRetry}
+        style={{
+          background: 'none',
+          border: 'none',
+          color: GOLD,
+          cursor: 'pointer',
+          fontSize: 12,
+          fontFamily: FONT_SANS,
+          padding: '2px 4px',
+          flexShrink: 0,
+        }}
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/shared/ToastViewport.tsx
+++ b/frontend/src/shared/ToastViewport.tsx
@@ -1,0 +1,124 @@
+/**
+ * Chatty — toast viewport. Mounted once in App.tsx; renders the toast store
+ * as a fixed bottom-right stack (full-width above the bottom nav on mobile).
+ */
+
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { subscribeToasts, getToasts, dismissToast } from './toast';
+import type { ToastItem, ToastSeverity } from './toast';
+import { useIsMobile } from './useIsMobile';
+import { BG_ELEV, LINE_STRONG, INK, INK_DIM, CORAL, SAGE, GOLD, FONT_SANS, mono } from './styles';
+
+const SEVERITY_COLOR: Record<ToastSeverity, string> = {
+  error: CORAL,
+  success: SAGE,
+  info: GOLD,
+};
+
+const SEVERITY_TAG: Record<ToastSeverity, string> = {
+  error: 'Error',
+  success: 'Success',
+  info: 'Notice',
+};
+
+export function ToastViewport() {
+  const items = useSyncExternalStore(subscribeToasts, getToasts);
+  const isMobile = useIsMobile();
+
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        zIndex: 200,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        ...(isMobile
+          ? { left: 12, right: 12, bottom: 68 }
+          : { right: 20, bottom: 16, width: 360 }),
+      }}
+    >
+      {items.map(item => (
+        <ToastCard key={item.id} item={item} onDismiss={() => dismissToast(item.id)} />
+      ))}
+    </div>
+  );
+}
+
+function ToastCard({ item, onDismiss }: { item: ToastItem; onDismiss: () => void }) {
+  const color = SEVERITY_COLOR[item.severity];
+  // Auto-dismiss with hover-pause: track remaining time across pauses.
+  const remainingRef = useRef(item.duration);
+  const startedAtRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    startTimer();
+    return stopTimer;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function startTimer() {
+    startedAtRef.current = Date.now();
+    timerRef.current = setTimeout(onDismiss, remainingRef.current);
+  }
+
+  function stopTimer() {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }
+
+  function handleMouseEnter() {
+    stopTimer();
+    remainingRef.current = Math.max(0, remainingRef.current - (Date.now() - startedAtRef.current));
+  }
+
+  function handleMouseLeave() {
+    startTimer();
+  }
+
+  return (
+    <div
+      role={item.severity === 'error' ? 'alert' : 'status'}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 10,
+        background: BG_ELEV,
+        border: `1px solid ${LINE_STRONG}`,
+        borderLeft: `3px solid ${color}`,
+        borderRadius: 8,
+        padding: '10px 12px 10px 14px',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.45)',
+        animation: 'ch-toast-in 0.18s ease-out',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ ...mono(10, color), marginBottom: 3 }}>{SEVERITY_TAG[item.severity]}</div>
+        <div style={{ fontFamily: FONT_SANS, fontSize: 13, color: INK, lineHeight: 1.45, overflowWrap: 'break-word' }}>
+          {item.message}
+        </div>
+      </div>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        style={{
+          background: 'none',
+          border: 'none',
+          color: INK_DIM,
+          cursor: 'pointer',
+          fontSize: 16,
+          lineHeight: 1,
+          padding: '2px 4px',
+          flexShrink: 0,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/shared/ToastViewport.tsx
+++ b/frontend/src/shared/ToastViewport.tsx
@@ -21,8 +21,12 @@ const SEVERITY_TAG: Record<ToastSeverity, string> = {
   info: 'Notice',
 };
 
+// getServerSnapshot must return a stable reference, or React warns about
+// an infinite loop of new snapshots.
+const EMPTY: ToastItem[] = [];
+
 export function ToastViewport() {
-  const items = useSyncExternalStore(subscribeToasts, getToasts);
+  const items = useSyncExternalStore(subscribeToasts, getToasts, () => EMPTY);
   const isMobile = useIsMobile();
 
   if (items.length === 0) return null;

--- a/frontend/src/shared/confirm.test.ts
+++ b/frontend/src/shared/confirm.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Chatty — confirm store tests. Pure node, no DOM: only the module-level
+ * singleton queue is exercised, not ConfirmHost.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { confirmDialog, settleConfirm, getCurrentConfirm, _resetForTesting } from './confirm';
+
+beforeEach(() => {
+  _resetForTesting();
+});
+
+describe('confirm store', () => {
+  it('dedupes an identical call against the visible head only', async () => {
+    const first = confirmDialog({ title: 'Delete file', message: 'Sure?' });
+    const second = confirmDialog({ title: 'Delete file', message: 'Sure?' });
+
+    // The duplicate resolves false immediately without enqueueing.
+    await expect(second).resolves.toBe(false);
+    expect(getCurrentConfirm()?.options.title).toBe('Delete file');
+
+    // Settling the head empties the queue — proves the dupe never joined it.
+    settleConfirm(true);
+    await expect(first).resolves.toBe(true);
+    expect(getCurrentConfirm()).toBeNull();
+  });
+
+  it('does not dedupe an identical call after the first has settled', async () => {
+    const first = confirmDialog({ title: 'Delete file', message: 'Sure?' });
+    settleConfirm(false);
+    await expect(first).resolves.toBe(false);
+
+    const again = confirmDialog({ title: 'Delete file', message: 'Sure?' });
+    expect(getCurrentConfirm()?.options.title).toBe('Delete file');
+    settleConfirm(true);
+    await expect(again).resolves.toBe(true);
+  });
+
+  it('queues a distinct dialog behind the head (FIFO)', async () => {
+    const first = confirmDialog({ title: 'Dialog A', message: 'same message' });
+    const second = confirmDialog({ title: 'Dialog B', message: 'same message' });
+
+    expect(getCurrentConfirm()?.options.title).toBe('Dialog A');
+
+    settleConfirm(true);
+    await expect(first).resolves.toBe(true);
+
+    // The second dialog becomes the head after the first settles.
+    expect(getCurrentConfirm()?.options.title).toBe('Dialog B');
+    settleConfirm(false);
+    await expect(second).resolves.toBe(false);
+    expect(getCurrentConfirm()).toBeNull();
+  });
+
+  it('settleConfirm on an empty queue is a no-op', () => {
+    expect(() => settleConfirm(false)).not.toThrow();
+    expect(getCurrentConfirm()).toBeNull();
+  });
+
+  it('settle resolves the head promise with the given boolean', async () => {
+    const accepted = confirmDialog({ title: 'Accept', message: 'ok?' });
+    settleConfirm(true);
+    await expect(accepted).resolves.toBe(true);
+
+    const rejected = confirmDialog({ title: 'Reject', message: 'ok?' });
+    settleConfirm(false);
+    await expect(rejected).resolves.toBe(false);
+  });
+});

--- a/frontend/src/shared/confirm.ts
+++ b/frontend/src/shared/confirm.ts
@@ -1,0 +1,64 @@
+/**
+ * Chatty — styled confirm store, a drop-in replacement for native confirm():
+ *
+ *   if (!await confirmDialog({ title: 'Delete report', message: '...', danger: true })) return;
+ *
+ * Module-level singleton (same mechanism as toast.ts) so it works inside
+ * plain async handlers and hooks without threading React context.
+ * ConfirmHost (mounted once in App.tsx) renders the head of the FIFO queue.
+ */
+
+export interface ConfirmOptions {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+}
+
+export interface PendingConfirm {
+  id: number;
+  options: ConfirmOptions;
+  resolve: (ok: boolean) => void;
+}
+
+let queue: PendingConfirm[] = [];
+let listeners: Array<() => void> = [];
+let nextId = 1;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeConfirms(onChange: () => void): () => void {
+  listeners.push(onChange);
+  return () => {
+    listeners = listeners.filter(l => l !== onChange);
+  };
+}
+
+export function getCurrentConfirm(): PendingConfirm | null {
+  return queue[0] ?? null;
+}
+
+export function settleConfirm(ok: boolean) {
+  const head = queue[0];
+  if (!head) return;
+  queue = queue.slice(1);
+  emit();
+  head.resolve(ok);
+}
+
+export function confirmDialog(options: ConfirmOptions): Promise<boolean> {
+  // A duplicate trigger (double-click before the overlay paints) is a no-op:
+  // resolving false for the duplicate preserves native confirm()'s
+  // one-dialog-one-action semantics. Sharing the pending promise instead
+  // would run the action twice on confirm.
+  if (queue.some(p => p.options.title === options.title && p.options.message === options.message)) {
+    return Promise.resolve(false);
+  }
+  return new Promise<boolean>(resolve => {
+    queue = [...queue, { id: nextId++, options, resolve }];
+    emit();
+  });
+}

--- a/frontend/src/shared/confirm.ts
+++ b/frontend/src/shared/confirm.ts
@@ -53,12 +53,22 @@ export function confirmDialog(options: ConfirmOptions): Promise<boolean> {
   // A duplicate trigger (double-click before the overlay paints) is a no-op:
   // resolving false for the duplicate preserves native confirm()'s
   // one-dialog-one-action semantics. Sharing the pending promise instead
-  // would run the action twice on confirm.
-  if (queue.some(p => p.options.title === options.title && p.options.message === options.message)) {
+  // would run the action twice on confirm. Only the queue head (the visible
+  // dialog) is compared — a distinct queued action that happens to share the
+  // same copy must still be asked, not silently dropped.
+  const head = queue[0];
+  if (head && head.options.title === options.title && head.options.message === options.message) {
     return Promise.resolve(false);
   }
   return new Promise<boolean>(resolve => {
     queue = [...queue, { id: nextId++, options, resolve }];
     emit();
   });
+}
+
+// test-only: singletons persist across module imports
+export function _resetForTesting() {
+  queue = [];
+  listeners = [];
+  nextId = 1;
 }

--- a/frontend/src/shared/toast.test.ts
+++ b/frontend/src/shared/toast.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Chatty — toast store tests. Pure node, no DOM: only the module-level
+ * singleton store is exercised, not ToastViewport.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { toast, getToasts, dismissToast, subscribeToasts, _resetForTesting } from './toast';
+
+beforeEach(() => {
+  _resetForTesting();
+});
+
+describe('toast store', () => {
+  it('caps the stack at 5 and drops the oldest toast', () => {
+    for (let i = 1; i <= 6; i++) toast.info(`message ${i}`);
+    const items = getToasts();
+    expect(items).toHaveLength(5);
+    expect(items.some(t => t.message === 'message 1')).toBe(false);
+    expect(items[items.length - 1].message).toBe('message 6');
+  });
+
+  it('dismissToast removes the right item and notifies subscribers', () => {
+    toast.info('first');
+    toast.info('second');
+    const [first, second] = getToasts();
+    const listener = vi.fn();
+    subscribeToasts(listener);
+
+    dismissToast(first.id);
+
+    const items = getToasts();
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe(second.id);
+    expect(items[0].message).toBe('second');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismissToast with an unknown id does not notify subscribers', () => {
+    toast.info('only');
+    const listener = vi.fn();
+    subscribeToasts(listener);
+
+    dismissToast(99999);
+
+    expect(getToasts()).toHaveLength(1);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('an unsubscribed listener is no longer called', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToasts(listener);
+
+    toast.info('a');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    toast.info('b');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps severity to duration: error 7000, success/info 4000', () => {
+    toast.error('e');
+    toast.success('s');
+    toast.info('i');
+    const [e, s, i] = getToasts();
+    expect(e.severity).toBe('error');
+    expect(e.duration).toBe(7000);
+    expect(s.severity).toBe('success');
+    expect(s.duration).toBe(4000);
+    expect(i.severity).toBe('info');
+    expect(i.duration).toBe(4000);
+  });
+});

--- a/frontend/src/shared/toast.ts
+++ b/frontend/src/shared/toast.ts
@@ -1,0 +1,56 @@
+/**
+ * Chatty — toast store.
+ *
+ * Module-level singleton so toast() is callable from anywhere — hooks,
+ * fire-and-forget .catch() handlers — without threading React context.
+ * ToastViewport (mounted once in App.tsx) renders the stack via
+ * useSyncExternalStore. Toasts fired before the viewport mounts just wait
+ * in the module until it does.
+ */
+
+export type ToastSeverity = 'error' | 'success' | 'info';
+
+export interface ToastItem {
+  id: number;
+  severity: ToastSeverity;
+  message: string;
+  duration: number;
+}
+
+const MAX_TOASTS = 5;
+
+let toasts: ToastItem[] = [];
+let listeners: Array<() => void> = [];
+let nextId = 1;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeToasts(onChange: () => void): () => void {
+  listeners.push(onChange);
+  return () => {
+    listeners = listeners.filter(l => l !== onChange);
+  };
+}
+
+export function getToasts(): ToastItem[] {
+  return toasts;
+}
+
+export function dismissToast(id: number) {
+  if (!toasts.some(t => t.id === id)) return;
+  toasts = toasts.filter(t => t.id !== id);
+  emit();
+}
+
+function push(severity: ToastSeverity, message: string, duration: number) {
+  toasts = [...toasts, { id: nextId++, severity, message, duration }].slice(-MAX_TOASTS);
+  emit();
+}
+
+export const toast = {
+  error: (message: string) => push('error', message, 7000),
+  success: (message: string) => push('success', message, 4000),
+  info: (message: string) => push('info', message, 4000),
+};

--- a/frontend/src/shared/toast.ts
+++ b/frontend/src/shared/toast.ts
@@ -54,3 +54,10 @@ export const toast = {
   success: (message: string) => push('success', message, 4000),
   info: (message: string) => push('info', message, 4000),
 };
+
+// test-only: singletons persist across module imports
+export function _resetForTesting() {
+  toasts = [];
+  listeners = [];
+  nextId = 1;
+}

--- a/frontend/src/webby/WebbyPage.tsx
+++ b/frontend/src/webby/WebbyPage.tsx
@@ -88,12 +88,14 @@ export function WebbyPage() {
       danger: true,
     });
     if (!ok) return;
-    const deleted = await convs.deleteConversation(id);
-    if (!deleted) {
+    const res = await convs.deleteConversation(id);
+    if (!res.ok) {
       toast.error('Failed to delete conversation.');
       return;
     }
-    if (convs.activeId === id) chat.clear();
+    // wasActive comes from the hook's ref (not this render's closure), so a
+    // conversation opened mid-DELETE won't get its view wrongly cleared.
+    if (res.wasActive) chat.clear();
   }
 
   function handleNewChat() {

--- a/frontend/src/webby/WebbyPage.tsx
+++ b/frontend/src/webby/WebbyPage.tsx
@@ -9,6 +9,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../core/api/client';
+import { confirmDialog } from '../shared/confirm';
+import { toast } from '../shared/toast';
 import { useAgentChat } from '../agent/hooks/useAgentChat';
 import { useConversations } from '../agent/hooks/useConversations';
 import { AgentChatPanel } from '../agent/components/AgentChatPanel';
@@ -71,8 +73,18 @@ export function WebbyPage() {
   }
 
   async function handleDeleteConversation(id: string) {
-    if (!confirm('Delete this conversation?')) return;
-    await convs.deleteConversation(id);
+    const ok = await confirmDialog({
+      title: 'Delete conversation',
+      message: 'This conversation and its messages will be permanently deleted.',
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
+    const deleted = await convs.deleteConversation(id);
+    if (!deleted) {
+      toast.error('Failed to delete conversation.');
+      return;
+    }
     if (convs.activeId === id) chat.clear();
   }
 

--- a/frontend/src/webby/WebbyPage.tsx
+++ b/frontend/src/webby/WebbyPage.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { api } from '../core/api/client';
 import { confirmDialog } from '../shared/confirm';
 import { toast } from '../shared/toast';
+import { LoadError } from '../shared/LoadError';
 import { useAgentChat } from '../agent/hooks/useAgentChat';
 import { useConversations } from '../agent/hooks/useConversations';
 import { AgentChatPanel } from '../agent/components/AgentChatPanel';
@@ -29,6 +30,7 @@ type Tab = 'chat' | 'knowledge' | 'preview';
 export function WebbyPage() {
   const navigate = useNavigate();
   const [status, setStatus] = useState<WebbyStatus | null>(null);
+  const [statusError, setStatusError] = useState(false);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>('chat');
   const [creating, setCreating] = useState(false);
@@ -43,12 +45,15 @@ export function WebbyPage() {
 
   const chat = useAgentChat(apiPrefix, { onTitleUpdate: handleTitleUpdate });
 
-  useEffect(() => {
+  function loadStatus() {
+    setStatusError(false);
     api<WebbyStatus>('/api/webby/status').then(s => {
       setStatus(s);
       if (s.agent_id) setAgentId(s.agent_id);
-    });
-  }, []);
+    }).catch(() => setStatusError(true));
+  }
+
+  useEffect(() => { loadStatus(); }, []);
 
   useEffect(() => {
     if (agentId) convs.loadConversations();
@@ -62,6 +67,8 @@ export function WebbyPage() {
       setAgentId(data.agent_id);
       setStatus(prev => prev ? { ...prev, exists: true, agent_id: data.agent_id } : null);
       chat.setTrainingMode(true);
+    } catch {
+      toast.error('Failed to create agent.');
     } finally {
       setCreating(false);
     }
@@ -69,6 +76,7 @@ export function WebbyPage() {
 
   async function handleSelectConversation(id: string) {
     const msgs = await convs.selectConversation(id);
+    if (!msgs) return;
     chat.loadMessages(msgs, id);
   }
 
@@ -97,7 +105,9 @@ export function WebbyPage() {
   if (!status) {
     return (
       <div className="flex items-center justify-center h-screen bg-ch-bg">
-        <div className="w-6 h-6 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />
+        {statusError
+          ? <LoadError label="Couldn't load Webby status" onRetry={loadStatus} />
+          : <div className="w-6 h-6 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />}
       </div>
     );
   }
@@ -192,6 +202,8 @@ export function WebbyPage() {
               searchQuery={convs.searchQuery}
               searchResults={convs.searchResults}
               isSearching={convs.isSearching}
+              loadError={convs.loadError}
+              onRetryLoad={convs.loadConversations}
               onNew={handleNewChat}
               onSelect={handleSelectConversation}
               onDelete={handleDeleteConversation}


### PR DESCRIPTION
Roadmap Phase 1, item 6 — frontend-wide error/feedback plumbing that the usage dashboard (#7) and FTS search (#8) will build on.

## What's new

**Five shared pieces** (`frontend/src/shared/`), all hand-rolled on the existing design tokens — no new dependencies:

- **`toast.ts` + `ToastViewport.tsx`** — module-singleton toast store callable from anywhere (hooks, fire-and-forget handlers) without context threading. Bottom-right stack (full-width above the mobile nav), capped at 5, coral/sage/gold severity variants, auto-dismiss with hover-pause (7s errors, 4s success/info), `role="alert"`/`role="status"`.
- **`confirm.ts` + `ConfirmHost.tsx`** — promise-based `confirmDialog({title, message, confirmLabel, danger})` as a drop-in for native `confirm()`. Danger variant fills the confirm button coral and gives Cancel initial focus (no reflexive-Enter data loss). Capture-phase Escape (doesn't close popovers underneath), Tab trap, dialog ARIA, duplicate triggers no-op (resolve `false`), zIndex 150 so it layers above SettingsPanel.
- **`ErrorBoundary.tsx`** — root mount in `main.tsx` (full-screen fallback + reload) and per-route mount around the AppShell `Outlet`, keyed by pathname with an explicit `reset()` so a crash at `/` itself can still recover. The nav rail survives route crashes. Stack detail is dev-only (the root boundary wraps the unauthenticated login page).
- **`LoadError.tsx`** — inline "Couldn't load — Retry" callout for failed primary data loads; errors live where the user is looking, toasts stay reserved for mutation feedback.

## Migrations

- **All 14 native `confirm()`/`alert()` sites** replaced with styled dialogs/toasts, with real titles, explicit confirm labels, and `danger` on every destructive action.
- **Bug fixed along the way:** enabling Power mode from the chat panel showed **two** stacked confirms (panel confirmed, then AgentPage confirmed again). AgentPage is now the single owner.
- **~30 silently-failing operations surfaced.** Failed user mutations now toast: deal drag-drop, knowledge file save (a `try/finally` with **no catch** — failed saves were completely invisible), conversation delete/rename/load, task toggle, activity log/save/delete, alert + notification dismiss, Telegram toggles, heartbeat checklist saves, branding save, setup finish, heartbeat run-now (non-409 failures were swallowed).
- **Failed primary loads show inline retry** instead of a silent empty state or stuck spinner: dashboard agents (failure used to show the misleading "Build your team" fresh-install screen), conversations sidebar, reminders, reports, knowledge files, integrations, Webby status, and CRM dashboard/pipeline/contacts/tasks (these four awaited `api()` with no catch — an infinite spinner on failure).
- **Intentionally-silent catches annotated** with `// best-effort:` comments so the convention is auditable.
- **eslint**: `no-alert` + `no-restricted-globals` (confirm/alert/prompt) prevent regressions.

## Verification

25/25 automated browser checks passed (Playwright against the dev stack, StrictMode on): toast singleton/cap/dismiss/auto-dismiss, confirm focus/Escape/Enter/Tab-trap/overlay/dedupe semantics, route-boundary crash at `/` with `reset()` recovery and surviving shell, LoadError render + in-place retry recovery on CRM, login flow, no unexpected console errors. Plus `tsc -b` strict build and eslint (0 errors; the 5 remaining warnings are pre-existing `exhaustive-deps` in untouched code).

Plan was reviewed through 4 rounds of adversarial review until convergence (route-boundary reset edge case, confirm dedupe semantics, missing-catch audit, a11y, DEV-gated stacks all incorporated).