### PR TITLE
Add usage/cost dashboard with pricing, API, and frontend page

### DIFF
--- a/.claude/coach-lessons.md
+++ b/.claude/coach-lessons.md
@@ -3,6 +3,14 @@
 > Instincts extracted from development sessions. Scores reflect real-world effectiveness.
 > Format: `[score]` **When** trigger → **do** action → **because** reason
 
+## Deploy & Infrastructure
+
+- `[0.80]` **When** running the backend from a git worktree → **do** use the absolute venv path (`/Users/willwilson/ai/chatty/.venv/bin/python`), not relative (`../../.venv/bin/python`) → **because** worktrees live under `.claude/worktrees/<name>/backend/` and the relative path resolves to a nonexistent location
+
+## Git & Workflow
+
+- `[0.75]` **When** resolving merge conflicts → **do** use `git add <specific files>`, never `git add -A` → **because** `-A` pulled `.claude/fresh-eyes/context.md` (216 lines of session research notes) into the merge commit, which then shipped in the PR
+
 ## Code & Architecture
 
 - `[0.70]` **When** a code review offers "persist data or remove dead tracking" for an in-memory-only pipeline → **do** remove the dead code unless the consumer is actively planned → **because** half-built pipelines (`_track_recall_usage` writing data `score_session_quality` never reads) create false expectations; a docstring "kept for future use" doesn't justify dead code
@@ -10,15 +18,9 @@
 - `[0.70]` **When** replacing `getattr(obj, "attr", fallback)` with an explicit parameter → **do** verify every call site passes the parameter, or keep the `getattr` fallback at the entry point → **because** the `_slug` UnboundLocalError was introduced by removing `getattr` in the outer function without ensuring callers pass the new arg
 - `[0.70]` **When** adding new admin settings to Chatty → **do** add them to `core/admin_settings.py` (not `setup/router.py`) → **because** admin settings were extracted to a dedicated cached module; adding to the old location creates conflicts and bypasses the mtime cache
 - `[0.70]` **When** reading per-agent MemoryDB data inside `_build_system_prompt` (e.g. observations) → **do** use `ensure_memory_db(slug)`, not `get_instance(data_dir)` → **because** the Telegram and Paperclip entry points don't pre-initialize MemoryDB, so `get_instance` returns None and the data silently never appears on non-web channels
-
-## Git & Workflow
-
-- `[0.70]` **When** resolving merge conflicts → **do** use `git add <specific files>`, never `git add -A` → **because** `-A` pulled `.claude/fresh-eyes/context.md` (216 lines of session research notes) into the merge commit, which then shipped in the PR
+- `[0.70]` **When** building a feature that reads historical data from an existing table → **do** check for retention/cleanup jobs that prune old rows → **because** the usage dashboard would have been silently capped at 30 days without discovering `cleanup_old()`'s pruning; the fresh-eyes agent caught this but the original plan missed it entirely
+- `[0.70]` **When** adding a new FastAPI route that performs synchronous SQLite I/O → **do** use `def`, not `async def` → **because** FastAPI only offloads sync work to a thread pool for plain `def` routes; `async def` with blocking SQLite calls freezes the entire event loop for the duration of the query
 
 ## Database & Migration
 
 - `[0.70]` **When** adding columns to an existing SQLite table in Chatty → **do** use the `_migrate_schema()` try/except pattern (`SELECT col LIMIT 0` / `ALTER TABLE ADD COLUMN`) → **because** this pattern handles both fresh installs and upgrades atomically without a migration framework, and `DEFAULT` values are stored in schema not per-row
-
-## Deploy & Infrastructure
-
-- `[0.75]` **When** running the backend from a git worktree → **do** use the absolute venv path (`/Users/willwilson/ai/chatty/.venv/bin/python`), not relative (`../../.venv/bin/python`) → **because** worktrees live under `.claude/worktrees/<name>/backend/` and the relative path resolves to a nonexistent location

--- a/backend/core/agents/scheduled_actions/history.py
+++ b/backend/core/agents/scheduled_actions/history.py
@@ -169,25 +169,26 @@ def cleanup_old() -> int:
     with db.write_lock():
         # Trim heavy payloads from older scheduled-action rows; keep the rows
         # themselves (tokens/model/status) for the usage dashboard.
-        c0 = conn.execute(
+        trim_cur = conn.execute(
             """UPDATE execution_history
                SET result_full = NULL, tool_calls = NULL
                WHERE (event_type = 'scheduled_action' OR event_type IS NULL)
                  AND started_at < ?
+                 AND started_at >= ?
                  AND (result_full IS NOT NULL OR tool_calls IS NOT NULL)""",
-            (trim_cutoff,),
+            (trim_cutoff, sa_cutoff),
         )
-        c1 = conn.execute(
+        sa_cur = conn.execute(
             "DELETE FROM execution_history WHERE (event_type = 'scheduled_action' OR event_type IS NULL) AND started_at < ?",
             (sa_cutoff,),
         )
-        c2 = conn.execute(
+        chat_cur = conn.execute(
             "DELETE FROM execution_history WHERE event_type = 'chat' AND started_at < ?",
             (chat_cutoff,),
         )
         conn.commit()
-        trimmed = c0.rowcount
-        deleted = c1.rowcount + c2.rowcount
+        trimmed = trim_cur.rowcount
+        deleted = sa_cur.rowcount + chat_cur.rowcount
     if trimmed:
         logger.info("Trimmed payloads from %d old execution history records", trimmed)
     if deleted:

--- a/backend/core/agents/scheduled_actions/history.py
+++ b/backend/core/agents/scheduled_actions/history.py
@@ -13,6 +13,12 @@ from core.agents.reminders import db
 
 logger = logging.getLogger(__name__)
 
+# Retention policy: rows are kept long enough to power the usage/cost
+# dashboard; heavy scheduled-action payloads are trimmed much sooner.
+CHAT_RETENTION_DAYS = 365
+SA_RETENTION_DAYS = 90
+SA_PAYLOAD_TRIM_DAYS = 7
+
 
 def _now_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
@@ -154,12 +160,23 @@ def get_recent_errors(agent: str, action_id: str | None = None, limit: int = 3) 
     return [dict(r) for r in rows]
 
 
-def cleanup_old(retention_days: int = 7) -> int:
+def cleanup_old() -> int:
     conn = db.get_db()
     now = datetime.now(timezone.utc)
-    sa_cutoff = (now - timedelta(days=retention_days)).strftime("%Y-%m-%dT%H:%M:%S")
-    chat_cutoff = (now - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%S")
+    sa_cutoff = (now - timedelta(days=SA_RETENTION_DAYS)).strftime("%Y-%m-%dT%H:%M:%S")
+    chat_cutoff = (now - timedelta(days=CHAT_RETENTION_DAYS)).strftime("%Y-%m-%dT%H:%M:%S")
+    trim_cutoff = (now - timedelta(days=SA_PAYLOAD_TRIM_DAYS)).strftime("%Y-%m-%dT%H:%M:%S")
     with db.write_lock():
+        # Trim heavy payloads from older scheduled-action rows; keep the rows
+        # themselves (tokens/model/status) for the usage dashboard.
+        c0 = conn.execute(
+            """UPDATE execution_history
+               SET result_full = NULL, tool_calls = NULL
+               WHERE (event_type = 'scheduled_action' OR event_type IS NULL)
+                 AND started_at < ?
+                 AND (result_full IS NOT NULL OR tool_calls IS NOT NULL)""",
+            (trim_cutoff,),
+        )
         c1 = conn.execute(
             "DELETE FROM execution_history WHERE (event_type = 'scheduled_action' OR event_type IS NULL) AND started_at < ?",
             (sa_cutoff,),
@@ -169,7 +186,10 @@ def cleanup_old(retention_days: int = 7) -> int:
             (chat_cutoff,),
         )
         conn.commit()
+        trimmed = c0.rowcount
         deleted = c1.rowcount + c2.rowcount
+    if trimmed:
+        logger.info("Trimmed payloads from %d old execution history records", trimmed)
     if deleted:
         logger.info("Cleaned up %d old execution history records", deleted)
     return deleted

--- a/backend/core/agents/scheduled_actions/sweeper.py
+++ b/backend/core/agents/scheduled_actions/sweeper.py
@@ -19,7 +19,7 @@ def sweep() -> None:
         from core.agents.scheduled_actions import service
         from core.agents.alerts import service as alerts_service
 
-        cleaned_history = history_mod.cleanup_old(retention_days=7)
+        cleaned_history = history_mod.cleanup_old()
         cleaned_alerts = alerts_service.cleanup_old(retention_days=30)
         cleaned_usage = _cleanup_context_usage(retention_days=90)
         fixed_drift = _fix_next_run_drift()

--- a/backend/core/agents/usage/__init__.py
+++ b/backend/core/agents/usage/__init__.py
@@ -1,0 +1,1 @@
+"""Chatty — Usage and estimated-cost aggregation over execution history."""

--- a/backend/core/agents/usage/router.py
+++ b/backend/core/agents/usage/router.py
@@ -9,8 +9,8 @@ router = APIRouter()
 
 
 @router.get("/summary")
-async def get_summary(
-    days: int = Query(7, ge=0, le=366),
+def get_summary(
+    days: int = Query(7, ge=0, le=365),
     tz: str = Query("UTC", max_length=64),
     user=Depends(get_current_user),
 ):

--- a/backend/core/agents/usage/router.py
+++ b/backend/core/agents/usage/router.py
@@ -1,0 +1,17 @@
+"""Chatty — Usage/cost dashboard REST endpoints."""
+
+from fastapi import APIRouter, Depends, Query
+
+from core.auth import get_current_user
+from . import service
+
+router = APIRouter()
+
+
+@router.get("/summary")
+async def get_summary(
+    days: int = Query(7, ge=0, le=366),
+    tz: str = Query("UTC", max_length=64),
+    user=Depends(get_current_user),
+):
+    return service.get_usage_summary(days=days, tz=tz)

--- a/backend/core/agents/usage/service.py
+++ b/backend/core/agents/usage/service.py
@@ -1,0 +1,142 @@
+"""Chatty — Usage summary aggregation.
+
+Aggregates token usage and estimated cost from the unified activity log
+(execution_history). Costs are estimates based on the static pricing
+table in core.providers.pricing; unknown/local models count as $0.00.
+"""
+
+import logging
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from core.agents.reminders import db
+from core.providers.pricing import estimate_cost
+
+logger = logging.getLogger(__name__)
+
+
+def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
+    """Aggregate usage over the last `days` days (0 = all time).
+
+    Day bucketing happens in the user's timezone; timestamps in the DB
+    are naive UTC.
+    """
+    try:
+        zone = ZoneInfo(tz)
+    except Exception:
+        zone = timezone.utc
+
+    now_local = datetime.now(timezone.utc).astimezone(zone)
+    cutoff_utc: str | None = None
+    start_day = None
+    if days > 0:
+        start_day = (now_local - timedelta(days=days - 1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        cutoff_utc = start_day.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+    query = """SELECT started_at, agent, event_type, model_used, input_tokens, output_tokens
+               FROM execution_history
+               WHERE status != 'running'"""
+    params: tuple = ()
+    if cutoff_utc:
+        query += " AND started_at >= ?"
+        params = (cutoff_utc,)
+
+    conn = db.get_db()
+    rows = conn.execute(query, params).fetchall()
+
+    totals = {"cost": 0.0, "input_tokens": 0, "output_tokens": 0, "events": 0}
+    daily: dict[str, dict] = {}
+    agents: dict[str, dict] = {}
+    agent_models: dict[str, Counter] = {}
+    earliest_day = None
+
+    for row in rows:
+        try:
+            ts = datetime.fromisoformat(row["started_at"]).replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            continue
+        local_ts = ts.astimezone(zone)
+        day_key = local_ts.strftime("%Y-%m-%d")
+        if earliest_day is None or day_key < earliest_day:
+            earliest_day = day_key
+
+        in_tok = row["input_tokens"] or 0
+        out_tok = row["output_tokens"] or 0
+        model = row["model_used"] or ""
+        cost = estimate_cost(model, in_tok, out_tok)
+        kind = "chat" if row["event_type"] == "chat" else "background"
+
+        totals["cost"] += cost
+        totals["input_tokens"] += in_tok
+        totals["output_tokens"] += out_tok
+        totals["events"] += 1
+
+        day = daily.setdefault(day_key, {
+            "date": day_key,
+            "chat_cost": 0.0, "background_cost": 0.0,
+            "chat_tokens": 0, "background_tokens": 0,
+            "events": 0,
+        })
+        day[f"{kind}_cost"] += cost
+        day[f"{kind}_tokens"] += in_tok + out_tok
+        day["events"] += 1
+
+        slug = row["agent"]
+        agent = agents.setdefault(slug, {
+            "slug": slug, "name": slug, "primary_model": "",
+            "input_tokens": 0, "output_tokens": 0, "events": 0,
+            "chat_events": 0, "background_events": 0, "cost": 0.0,
+        })
+        agent["input_tokens"] += in_tok
+        agent["output_tokens"] += out_tok
+        agent["events"] += 1
+        agent[f"{kind}_events"] += 1
+        agent["cost"] += cost
+        if model:
+            agent_models.setdefault(slug, Counter())[model] += 1
+
+    # Zero-fill missing days from the range start (or earliest seen) to today
+    today_key = now_local.strftime("%Y-%m-%d")
+    if start_day is not None:
+        fill_from = start_day
+    elif earliest_day:
+        y, m, d = (int(p) for p in earliest_day.split("-"))
+        fill_from = datetime(y, m, d, tzinfo=zone)
+    else:
+        fill_from = None
+    if fill_from is not None:
+        cursor = fill_from
+        while cursor.strftime("%Y-%m-%d") <= today_key:
+            key = cursor.strftime("%Y-%m-%d")
+            daily.setdefault(key, {
+                "date": key,
+                "chat_cost": 0.0, "background_cost": 0.0,
+                "chat_tokens": 0, "background_tokens": 0,
+                "events": 0,
+            })
+            cursor += timedelta(days=1)
+
+    # Primary model = most frequent model per agent
+    for slug, counter in agent_models.items():
+        agents[slug]["primary_model"] = counter.most_common(1)[0][0]
+
+    # Enrich display names from the agent registry
+    try:
+        from agents.db import list_agents
+        names = {a["slug"]: a.get("agent_name") or a["slug"] for a in list_agents()}
+        for slug, agent in agents.items():
+            agent["name"] = names.get(slug, slug)
+    except Exception as e:
+        logger.debug("Agent name enrichment skipped: %s", e)
+
+    return {
+        "days": days,
+        "timezone": str(zone),
+        "estimated": True,
+        "totals": totals,
+        "daily": sorted(daily.values(), key=lambda d: d["date"]),
+        "agents": sorted(agents.values(), key=lambda a: a["cost"], reverse=True),
+    }

--- a/backend/core/agents/usage/service.py
+++ b/backend/core/agents/usage/service.py
@@ -25,7 +25,7 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
     try:
         zone = ZoneInfo(tz)
     except Exception:
-        zone = timezone.utc
+        zone = ZoneInfo("UTC")
 
     now_local = datetime.now(timezone.utc).astimezone(zone)
     cutoff_utc: str | None = None
@@ -129,8 +129,10 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
         names = {a["slug"]: a.get("agent_name") or a["slug"] for a in list_agents()}
         for slug, agent in agents.items():
             agent["name"] = names.get(slug, slug)
+    except ImportError:
+        pass
     except Exception as e:
-        logger.debug("Agent name enrichment skipped: %s", e)
+        logger.warning("Agent name enrichment failed: %s", e)
 
     return {
         "days": days,

--- a/backend/core/providers/pricing.py
+++ b/backend/core/providers/pricing.py
@@ -1,0 +1,44 @@
+"""Chatty — Model pricing definitions and cost estimation.
+
+Static USD-per-million-token prices for known models. Hardcoded,
+updated occasionally when providers change published prices.
+Unknown models (including local/Ollama) estimate to $0.00.
+"""
+
+from __future__ import annotations
+
+
+# model id -> (input_usd_per_mtok, output_usd_per_mtok)
+MODEL_PRICING: dict[str, tuple[float, float]] = {
+    "claude-opus-4-6":   (5.00, 25.00),
+    "claude-sonnet-4-6": (3.00, 15.00),
+    "claude-haiku-4-5":  (1.00, 5.00),
+}
+
+
+def get_model_pricing(model: str) -> tuple[float, float] | None:
+    """Resolve pricing for a model id.
+
+    Exact match first, then longest-prefix match so dated snapshots
+    (e.g. claude-haiku-4-5-20251001) resolve to their base model.
+    Returns None for unknown models.
+    """
+    if not model:
+        return None
+    exact = MODEL_PRICING.get(model)
+    if exact is not None:
+        return exact
+    best_key = None
+    for key in MODEL_PRICING:
+        if model.startswith(key) and (best_key is None or len(key) > len(best_key)):
+            best_key = key
+    return MODEL_PRICING[best_key] if best_key else None
+
+
+def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
+    """Estimated USD cost for a single call. 0.0 when pricing is unknown."""
+    pricing = get_model_pricing(model)
+    if pricing is None:
+        return 0.0
+    in_price, out_price = pricing
+    return (input_tokens * in_price + output_tokens * out_price) / 1_000_000

--- a/backend/main.py
+++ b/backend/main.py
@@ -39,6 +39,7 @@ from core.agents.alerts.router import router as alerts_router
 from core.agents.notifications.router import router as notifications_router
 from core.agents.reminders.router import router as reminders_router
 from core.agents.shared_context.router import router as shared_context_router
+from core.agents.usage.router import router as usage_router
 from core.events.router import router as events_router
 
 logger = logging.getLogger(__name__)
@@ -297,6 +298,7 @@ app.include_router(setup_router, prefix="/api/setup", tags=["setup"])
 app.include_router(backup_router, prefix="/api/backup", tags=["backup"])
 app.include_router(telegram_router, prefix="/api/telegram", tags=["telegram"])
 app.include_router(shared_context_router, tags=["shared-context"])
+app.include_router(usage_router, prefix="/api/usage", tags=["usage"])
 app.include_router(events_router)
 
 

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -232,6 +232,28 @@ class TestUsageSummary:
         assert len(summary["daily"]) == 7
         assert summary["agents"] == []
 
+        all_time = get_usage_summary(days=0, tz="UTC")
+        assert all_time["daily"] == []
+
+    def test_all_time_zero_fill_spans_earliest_to_today(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+
+        old = datetime.now(timezone.utc) - timedelta(days=30)
+        _insert_event(
+            reminders_db, started_at=_iso(old),
+            model="claude-sonnet-4-6", input_tokens=1_000_000,
+        )
+        _insert_event(
+            reminders_db, model="claude-sonnet-4-6", input_tokens=1_000_000,
+        )
+
+        summary = get_usage_summary(days=0, tz="UTC")
+        assert summary["totals"]["events"] == 2
+        assert len(summary["daily"]) >= 30
+        dates = [d["date"] for d in summary["daily"]]
+        assert old.strftime("%Y-%m-%d") in dates
+        assert datetime.now(timezone.utc).strftime("%Y-%m-%d") in dates
+
 
 # ── Retention ─────────────────────────────────────────────────────────────────
 
@@ -284,3 +306,7 @@ class TestRetention:
         assert sa_60d in rows
         assert rows[sa_60d]["result_full"] is None
         assert rows[sa_60d]["tool_calls"] is None
+
+        # Idempotency: second call should not delete or trim anything
+        deleted2 = cleanup_old()
+        assert deleted2 == 0

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -1,0 +1,286 @@
+"""Tests for the usage/cost dashboard: pricing, aggregation, retention."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from core.providers.pricing import estimate_cost, get_model_pricing
+
+
+@pytest.fixture
+def reminders_db(monkeypatch, tmp_path):
+    """Fresh reminders DB (execution_history lives here) using production schema."""
+    import core.agents.reminders.db as db_mod
+
+    monkeypatch.setattr(db_mod, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "reminders.db")
+    db_mod._connection = None
+    db_mod.init_db()
+    yield db_mod.get_db()
+    if db_mod._connection:
+        db_mod._connection.close()
+    db_mod._connection = None
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _insert_event(
+    conn,
+    *,
+    agent="test-agent",
+    event_type="chat",
+    status="ok",
+    started_at=None,
+    model="claude-sonnet-4-6",
+    input_tokens=0,
+    output_tokens=0,
+    result_full=None,
+    tool_calls=None,
+):
+    """Insert an execution_history row directly (allows backdating)."""
+    eid = str(uuid.uuid4())
+    started = started_at or _iso(datetime.now(timezone.utc))
+    conn.execute(
+        """INSERT INTO execution_history
+           (id, action_id, agent, action_type, event_type, started_at,
+            completed_at, status, result_full, tool_calls, model_used,
+            input_tokens, output_tokens)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (eid, eid, agent, "chat" if event_type == "chat" else "heartbeat",
+         event_type, started, started, status, result_full, tool_calls,
+         model, input_tokens, output_tokens),
+    )
+    conn.commit()
+    return eid
+
+
+# ── Pricing ───────────────────────────────────────────────────────────────────
+
+
+class TestPricing:
+    def test_exact_match(self):
+        assert get_model_pricing("claude-opus-4-6") == (5.00, 25.00)
+        assert get_model_pricing("claude-sonnet-4-6") == (3.00, 15.00)
+        assert get_model_pricing("claude-haiku-4-5") == (1.00, 5.00)
+
+    def test_prefix_match_dated_snapshot(self):
+        assert get_model_pricing("claude-haiku-4-5-20251001") == (1.00, 5.00)
+
+    def test_unknown_model_returns_none_and_zero_cost(self):
+        assert get_model_pricing("llama3.2") is None
+        assert estimate_cost("llama3.2", 1_000_000, 1_000_000) == 0.0
+
+    def test_empty_model_zero_cost(self):
+        assert get_model_pricing("") is None
+        assert estimate_cost("", 500, 500) == 0.0
+
+    def test_estimate_cost_math(self):
+        # 1M input + 1M output on sonnet = $3 + $15
+        assert estimate_cost("claude-sonnet-4-6", 1_000_000, 1_000_000) == pytest.approx(18.0)
+        assert estimate_cost("claude-haiku-4-5-20251001", 2_000_000, 0) == pytest.approx(2.0)
+
+
+# ── Aggregation ───────────────────────────────────────────────────────────────
+
+
+class TestUsageSummary:
+    def test_totals_and_chat_background_split(self, reminders_db):
+        from core.agents import activity_log
+        from core.agents.usage.service import get_usage_summary
+
+        activity_log.log_chat_event(
+            "alpha", model_used="claude-sonnet-4-6",
+            input_tokens=1_000_000, output_tokens=0,
+        )
+        activity_log.log_chat_event(
+            "alpha", model_used="claude-sonnet-4-6",
+            input_tokens=0, output_tokens=1_000_000,
+        )
+        _insert_event(
+            reminders_db, agent="beta", event_type="scheduled_action",
+            model="claude-haiku-4-5-20251001",
+            input_tokens=1_000_000, output_tokens=0,
+        )
+
+        summary = get_usage_summary(days=7, tz="UTC")
+
+        assert summary["estimated"] is True
+        assert summary["days"] == 7
+        assert summary["totals"]["events"] == 3
+        assert summary["totals"]["input_tokens"] == 2_000_000
+        assert summary["totals"]["output_tokens"] == 1_000_000
+        # $3 (sonnet in) + $15 (sonnet out) + $1 (haiku in)
+        assert summary["totals"]["cost"] == pytest.approx(19.0)
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        day = next(d for d in summary["daily"] if d["date"] == today)
+        assert day["chat_cost"] == pytest.approx(18.0)
+        assert day["background_cost"] == pytest.approx(1.0)
+        assert day["chat_tokens"] == 2_000_000
+        assert day["background_tokens"] == 1_000_000
+        assert day["events"] == 3
+
+        # 7-day window zero-fills to exactly 7 days
+        assert len(summary["daily"]) == 7
+        assert summary["daily"][-1]["date"] == today
+
+    def test_per_agent_breakdown_and_primary_model(self, reminders_db):
+        from core.agents import activity_log
+        from core.agents.usage.service import get_usage_summary
+
+        activity_log.log_chat_event(
+            "alpha", model_used="claude-sonnet-4-6",
+            input_tokens=1_000_000, output_tokens=0,
+        )
+        activity_log.log_chat_event(
+            "alpha", model_used="claude-sonnet-4-6",
+            input_tokens=1_000_000, output_tokens=0,
+        )
+        activity_log.log_chat_event(
+            "alpha", model_used="claude-haiku-4-5-20251001",
+            input_tokens=1_000_000, output_tokens=0,
+        )
+        _insert_event(
+            reminders_db, agent="beta", event_type="scheduled_action",
+            model="claude-haiku-4-5-20251001", input_tokens=500_000,
+        )
+
+        summary = get_usage_summary(days=7, tz="UTC")
+        assert [a["slug"] for a in summary["agents"]] == ["alpha", "beta"]
+
+        alpha = summary["agents"][0]
+        assert alpha["name"] == "alpha"  # registry unavailable → slug fallback
+        assert alpha["primary_model"] == "claude-sonnet-4-6"
+        assert alpha["input_tokens"] == 3_000_000
+        assert alpha["events"] == 3
+        assert alpha["chat_events"] == 3
+        assert alpha["background_events"] == 0
+        assert alpha["cost"] == pytest.approx(7.0)  # 3 + 3 + 1
+
+        beta = summary["agents"][1]
+        assert beta["primary_model"] == "claude-haiku-4-5-20251001"
+        assert beta["chat_events"] == 0
+        assert beta["background_events"] == 1
+        assert beta["cost"] == pytest.approx(0.5)
+
+    def test_running_rows_excluded(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+
+        _insert_event(
+            reminders_db, event_type="scheduled_action", status="running",
+            model="claude-sonnet-4-6", input_tokens=1_000_000,
+        )
+        summary = get_usage_summary(days=7, tz="UTC")
+        assert summary["totals"]["events"] == 0
+        assert summary["totals"]["cost"] == 0.0
+
+    def test_days_filtering(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+
+        old = datetime.now(timezone.utc) - timedelta(days=30)
+        _insert_event(
+            reminders_db, started_at=_iso(old),
+            model="claude-sonnet-4-6", input_tokens=1_000_000,
+        )
+        _insert_event(
+            reminders_db, model="claude-sonnet-4-6", input_tokens=1_000_000,
+        )
+
+        recent = get_usage_summary(days=7, tz="UTC")
+        assert recent["totals"]["events"] == 1
+
+        all_time = get_usage_summary(days=0, tz="UTC")
+        assert all_time["totals"]["events"] == 2
+        assert all_time["days"] == 0
+
+    def test_timezone_bucketing(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+
+        # 03:00 UTC = previous evening in Chicago (UTC-5/-6)
+        utc_day = datetime.now(timezone.utc).date()
+        _insert_event(
+            reminders_db,
+            started_at=f"{utc_day.isoformat()}T03:00:00",
+            model="claude-sonnet-4-6", input_tokens=1_000_000,
+        )
+
+        utc_summary = get_usage_summary(days=7, tz="UTC")
+        utc_buckets = [d["date"] for d in utc_summary["daily"] if d["events"]]
+        assert utc_buckets == [utc_day.isoformat()]
+
+        chi_summary = get_usage_summary(days=7, tz="America/Chicago")
+        assert chi_summary["timezone"] == "America/Chicago"
+        chi_buckets = [d["date"] for d in chi_summary["daily"] if d["events"]]
+        assert chi_buckets == [(utc_day - timedelta(days=1)).isoformat()]
+
+    def test_invalid_timezone_falls_back_to_utc(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+
+        summary = get_usage_summary(days=7, tz="Not/AZone")
+        assert summary["timezone"] == "UTC"
+
+    def test_empty_db(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+
+        summary = get_usage_summary(days=7, tz="UTC")
+        assert summary["totals"] == {
+            "cost": 0.0, "input_tokens": 0, "output_tokens": 0, "events": 0,
+        }
+        assert len(summary["daily"]) == 7
+        assert summary["agents"] == []
+
+
+# ── Retention ─────────────────────────────────────────────────────────────────
+
+
+class TestRetention:
+    def test_cleanup_retention_and_payload_trim(self, reminders_db):
+        from core.agents.scheduled_actions.history import cleanup_old
+
+        now = datetime.now(timezone.utc)
+
+        chat_100d = _insert_event(
+            reminders_db, event_type="chat",
+            started_at=_iso(now - timedelta(days=100)),
+        )
+        chat_400d = _insert_event(
+            reminders_db, event_type="chat",
+            started_at=_iso(now - timedelta(days=400)),
+        )
+        sa_3d = _insert_event(
+            reminders_db, event_type="scheduled_action",
+            started_at=_iso(now - timedelta(days=3)),
+            result_full="full result", tool_calls='[{"tool": "x"}]',
+        )
+        sa_60d = _insert_event(
+            reminders_db, event_type="scheduled_action",
+            started_at=_iso(now - timedelta(days=60)),
+            result_full="full result", tool_calls='[{"tool": "x"}]',
+        )
+        sa_100d = _insert_event(
+            reminders_db, event_type="scheduled_action",
+            started_at=_iso(now - timedelta(days=100)),
+        )
+
+        deleted = cleanup_old()
+        assert deleted == 2  # chat_400d + sa_100d
+
+        rows = {
+            r["id"]: r
+            for r in reminders_db.execute(
+                "SELECT id, result_full, tool_calls FROM execution_history"
+            ).fetchall()
+        }
+        assert chat_100d in rows
+        assert chat_400d not in rows
+        assert sa_100d not in rows
+
+        # Recent SA keeps payloads; 60-day SA survives but is trimmed
+        assert rows[sa_3d]["result_full"] == "full result"
+        assert rows[sa_3d]["tool_calls"] == '[{"tool": "x"}]'
+        assert sa_60d in rows
+        assert rows[sa_60d]["result_full"] is None
+        assert rows[sa_60d]["tool_calls"] is None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { DashboardPage } from './dashboard/DashboardPage';
 import { OnboardingPage } from './onboarding/OnboardingPage';
 import { AgentPage } from './agent/AgentPage';
 import { WebbyPage } from './webby/WebbyPage';
+import { UsagePage } from './usage/UsagePage';
 import { CrmLayout } from './crm/CrmLayout';
 import { CrmDashboardPage } from './crm/CrmDashboardPage';
 import { ContactsPage } from './crm/ContactsPage';
@@ -42,6 +43,7 @@ export default function App() {
               <Route path="pipeline" element={<PipelinePage />} />
               <Route path="tasks" element={<TasksPage />} />
             </Route>
+            <Route path="/usage" element={<UsagePage />} />
             <Route path="/webby" element={<WebbyPage />} />
           </Route>
 

--- a/frontend/src/shared/AppShell.tsx
+++ b/frontend/src/shared/AppShell.tsx
@@ -74,7 +74,7 @@ export function AppShell() {
             the dismissed demo dialog). Recovery from a crash inside CRM
             still works via the fallback's Back to Dashboard / Reload. */}
         <ErrorBoundary
-          key={location.pathname.startsWith('/crm') ? '/crm' : location.pathname.startsWith('/usage') ? '/usage' : location.pathname}
+          key={location.pathname.startsWith('/crm') ? '/crm' : location.pathname}
           fallback={(error, reset) => <RouteErrorFallback error={error} reset={reset} />}
         >
           <Outlet context={{ branding, setBranding }} />

--- a/frontend/src/shared/AppShell.tsx
+++ b/frontend/src/shared/AppShell.tsx
@@ -5,7 +5,7 @@ import { NavRail } from './NavRail';
 import { ErrorBoundary, RouteErrorFallback } from './ErrorBoundary';
 import { SettingsPanel } from '../dashboard/SettingsPanel';
 import { useIsMobile } from './useIsMobile';
-import { IconBot, IconFunnel, IconBook, IconSettings } from './icons';
+import { IconBot, IconFunnel, IconChart, IconBook, IconSettings } from './icons';
 import type { BrandingConfig } from '../core/types';
 
 export function AppShell() {
@@ -37,6 +37,7 @@ export function AppShell() {
   const mobileNavItems = [
     { key: 'agents', icon: IconBot, label: 'Agents', path: '/', match: (p: string) => p === '/' || p.startsWith('/agent/') },
     { key: 'crm', icon: IconFunnel, label: 'CRM', path: '/crm', match: (p: string) => p.startsWith('/crm') },
+    { key: 'usage', icon: IconChart, label: 'Usage', path: '/usage', match: (p: string) => p.startsWith('/usage') },
     { key: 'knowledge', icon: IconBook, label: 'Knowledge', path: null as string | null, match: () => false },
     { key: 'settings', icon: IconSettings, label: 'Settings', path: null as string | null, match: () => false },
   ];
@@ -73,7 +74,7 @@ export function AppShell() {
             the dismissed demo dialog). Recovery from a crash inside CRM
             still works via the fallback's Back to Dashboard / Reload. */}
         <ErrorBoundary
-          key={location.pathname.startsWith('/crm') ? '/crm' : location.pathname}
+          key={location.pathname.startsWith('/crm') ? '/crm' : location.pathname.startsWith('/usage') ? '/usage' : location.pathname}
           fallback={(error, reset) => <RouteErrorFallback error={error} reset={reset} />}
         >
           <Outlet context={{ branding, setBranding }} />

--- a/frontend/src/shared/NavRail.tsx
+++ b/frontend/src/shared/NavRail.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import { IconLogo, IconBot, IconFunnel, IconBook, IconSettings } from './icons';
+import { IconLogo, IconBot, IconFunnel, IconChart, IconBook, IconSettings } from './icons';
 
 interface NavRailProps {
   onSettingsClick: () => void;
@@ -9,6 +9,7 @@ interface NavRailProps {
 const navItems = [
   { key: 'agents', icon: IconBot, path: '/', match: (p: string) => p === '/' || p.startsWith('/agent/') },
   { key: 'crm', icon: IconFunnel, path: '/crm', match: (p: string) => p.startsWith('/crm') },
+  { key: 'usage', icon: IconChart, path: '/usage', match: (p: string) => p.startsWith('/usage') },
   { key: 'knowledge', icon: IconBook, path: null as string | null, match: () => false },
 ];
 

--- a/frontend/src/shared/styles.ts
+++ b/frontend/src/shared/styles.ts
@@ -15,8 +15,10 @@ export const ACCENT = 'var(--color-ch-accent, #C8D1D9)';
 export const ACCENT_INK = 'var(--color-ch-accent-ink, #0E1013)';
 export const ACCENT_SOFT = 'var(--color-ch-accent-soft, rgba(200,209,217,0.12))';
 export const GOLD = 'var(--color-ch-gold, #D4A85A)';
+export const GOLD_HEX = '#D4A85A';
 export const CORAL = 'var(--color-ch-coral, #D97757)';
 export const SAGE = 'var(--color-ch-sage, #8EA589)';
+export const SAGE_HEX = '#8EA589';
 
 // ── Font stacks ──────────────────────────────────────────────────────────────
 

--- a/frontend/src/usage/UsagePage.tsx
+++ b/frontend/src/usage/UsagePage.tsx
@@ -21,11 +21,8 @@ import { useIsMobile } from '../shared/useIsMobile';
 import {
   INK, INK_MUTE, INK_DIM, LINE, BG_ELEV,
   FONT_DISPLAY, FONT_SANS, FONT_MONO, mono, formatNumber,
+  SAGE_HEX, GOLD_HEX,
 } from '../shared/styles';
-
-// Raw hex (not CSS vars): SVG fill attributes don't resolve var().
-const SAGE_HEX = '#8EA589';
-const GOLD_HEX = '#D4A85A';
 
 interface DailyUsage {
   date: string;
@@ -95,7 +92,7 @@ export function UsagePage() {
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
     api<UsageSummary>(`/api/usage/summary?days=${days}&tz=${encodeURIComponent(tz)}`)
       .then(d => { setData(d); setError(false); })
-      .catch(() => setError(true))
+      .catch((err) => { console.error('[UsagePage] load failed:', err); setError(true); })
       .finally(() => setLoading(false));
   }, [days]);
 

--- a/frontend/src/usage/UsagePage.tsx
+++ b/frontend/src/usage/UsagePage.tsx
@@ -1,0 +1,367 @@
+/**
+ * Chatty — Usage & estimated cost dashboard.
+ * Aggregated token/cost data from /api/usage/summary, bucketed daily
+ * in the browser's timezone. Costs are estimates from published prices.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { api } from '../core/api/client';
+import { LoadError } from '../shared/LoadError';
+import { IconChart } from '../shared/icons';
+import { useIsMobile } from '../shared/useIsMobile';
+import {
+  INK, INK_MUTE, INK_DIM, LINE, BG_ELEV,
+  FONT_DISPLAY, FONT_SANS, FONT_MONO, mono, formatNumber,
+} from '../shared/styles';
+
+// Raw hex (not CSS vars): SVG fill attributes don't resolve var().
+const SAGE_HEX = '#8EA589';
+const GOLD_HEX = '#D4A85A';
+
+interface DailyUsage {
+  date: string;
+  chat_cost: number;
+  background_cost: number;
+  chat_tokens: number;
+  background_tokens: number;
+  events: number;
+}
+
+interface AgentUsage {
+  slug: string;
+  name: string;
+  primary_model: string;
+  input_tokens: number;
+  output_tokens: number;
+  events: number;
+  chat_events: number;
+  background_events: number;
+  cost: number;
+}
+
+interface UsageSummary {
+  days: number;
+  timezone: string;
+  estimated: boolean;
+  totals: { cost: number; input_tokens: number; output_tokens: number; events: number };
+  daily: DailyUsage[];
+  agents: AgentUsage[];
+}
+
+const RANGES = [
+  { label: '7 days', days: 7 },
+  { label: '30 days', days: 30 },
+  { label: 'All time', days: 0 },
+];
+
+function formatCost(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+function formatDay(date: string): string {
+  // Parse "YYYY-MM-DD" manually — new Date(string) parses as UTC midnight
+  // and shifts the day in negative-offset timezones.
+  const [y, m, d] = date.split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+const cardStyle = {
+  background: BG_ELEV,
+  border: `1px solid ${LINE}`,
+  borderRadius: 6,
+  padding: '18px 20px',
+};
+
+export function UsagePage() {
+  const [days, setDays] = useState(7);
+  const [metric, setMetric] = useState<'cost' | 'tokens'>('cost');
+  const [data, setData] = useState<UsageSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const isMobile = useIsMobile();
+
+  // Doesn't set loading/error itself (the set-state-in-effect rule forbids
+  // sync setState via the effect); initial state is true, retry resets it.
+  const load = useCallback(() => {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    api<UsageSummary>(`/api/usage/summary?days=${days}&tz=${encodeURIComponent(tz)}`)
+      .then(d => { setData(d); setError(false); })
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, [days]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const px = isMobile ? '20px' : '44px';
+
+  if (loading && !data) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+        <div className="w-8 h-8 border-2 border-ch-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return <LoadError label="Couldn't load usage data" onRetry={() => { setLoading(true); load(); }} />;
+  }
+
+  if (!data) return null;
+
+  const hasUsage = data.totals.events > 0;
+  const chartKeys = metric === 'cost'
+    ? { chat: 'chat_cost', background: 'background_cost' }
+    : { chat: 'chat_tokens', background: 'background_tokens' };
+  const formatMetric = metric === 'cost' ? formatCost : formatNumber;
+
+  return (
+    <div style={{ overflow: 'auto', height: '100%', background: '#0A0C0F' }}>
+      {/* Header */}
+      <div style={{
+        padding: isMobile ? '24px 20px 16px' : '36px 44px 20px',
+        display: 'flex', flexWrap: 'wrap', alignItems: 'flex-end', gap: 16,
+      }}>
+        <div style={{ flex: 1, minWidth: 200 }}>
+          <div style={mono(10, INK_DIM)}>Usage &amp; Cost</div>
+          <h1 style={{
+            fontFamily: FONT_DISPLAY, fontSize: isMobile ? 28 : 38, fontWeight: 400,
+            letterSpacing: '-0.02em', lineHeight: 1.1, margin: '8px 0 0', color: INK,
+          }}>
+            Usage
+          </h1>
+        </div>
+
+        {/* Range tabs */}
+        <div style={{ display: 'flex', gap: 6 }}>
+          {RANGES.map(r => {
+            const active = days === r.days;
+            return (
+              <button
+                key={r.days}
+                onClick={() => setDays(r.days)}
+                style={{
+                  fontFamily: FONT_MONO, fontSize: 11, letterSpacing: '0.06em',
+                  padding: '6px 14px', borderRadius: 999, cursor: 'pointer',
+                  background: active ? 'rgba(200,209,217,0.12)' : 'transparent',
+                  border: `1px solid ${active ? 'rgba(230,235,242,0.2)' : LINE}`,
+                  color: active ? INK : 'rgba(237,240,244,0.5)',
+                }}
+              >
+                {r.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {!hasUsage ? (
+        <div style={{
+          display: 'flex', flexDirection: 'column', alignItems: 'center',
+          justifyContent: 'center', gap: 14, padding: '80px 20px',
+          color: 'rgba(237,240,244,0.25)',
+        }}>
+          <IconChart size={36} strokeWidth={1.5} />
+          <div style={{ fontFamily: FONT_SANS, fontSize: 14, color: 'rgba(237,240,244,0.38)' }}>
+            No usage recorded yet.
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* Stat cards */}
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)',
+            gap: 12, padding: `0 ${px} 16px`,
+          }}>
+            <div style={cardStyle}>
+              <div style={mono(10, INK_DIM)}>Estimated Cost</div>
+              <div style={{
+                fontFamily: FONT_DISPLAY, fontSize: 34, fontWeight: 400,
+                color: INK, marginTop: 8, lineHeight: 1,
+              }}>
+                {formatCost(data.totals.cost)}
+              </div>
+            </div>
+            <div style={cardStyle}>
+              <div style={mono(10, INK_DIM)}>Total Tokens</div>
+              <div style={{
+                fontFamily: FONT_DISPLAY, fontSize: 34, fontWeight: 400,
+                color: INK, marginTop: 8, lineHeight: 1,
+              }}>
+                {formatNumber(data.totals.input_tokens + data.totals.output_tokens)}
+              </div>
+              <div style={{ fontFamily: FONT_MONO, fontSize: 10, color: INK_DIM, marginTop: 8 }}>
+                {formatNumber(data.totals.input_tokens)} in / {formatNumber(data.totals.output_tokens)} out
+              </div>
+            </div>
+            <div style={cardStyle}>
+              <div style={mono(10, INK_DIM)}>Events</div>
+              <div style={{
+                fontFamily: FONT_DISPLAY, fontSize: 34, fontWeight: 400,
+                color: INK, marginTop: 8, lineHeight: 1,
+              }}>
+                {data.totals.events.toLocaleString()}
+              </div>
+            </div>
+          </div>
+
+          {/* Daily chart */}
+          <div style={{ padding: `0 ${px} 16px` }}>
+            <div style={{ ...cardStyle, padding: '18px 14px 10px 6px' }}>
+              <div style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                padding: '0 8px 14px 22px',
+              }}>
+                <div style={mono(10, INK_DIM)}>Daily {metric === 'cost' ? 'Cost' : 'Tokens'}</div>
+                <div style={{ display: 'flex', gap: 4 }}>
+                  {(['cost', 'tokens'] as const).map(m => (
+                    <button
+                      key={m}
+                      onClick={() => setMetric(m)}
+                      style={{
+                        fontFamily: FONT_MONO, fontSize: 10, letterSpacing: '0.08em',
+                        textTransform: 'uppercase', padding: '4px 10px', borderRadius: 4,
+                        cursor: 'pointer', border: 'none',
+                        background: metric === m ? 'rgba(200,209,217,0.12)' : 'transparent',
+                        color: metric === m ? INK : 'rgba(237,240,244,0.4)',
+                      }}
+                    >
+                      {m === 'cost' ? 'Cost' : 'Tokens'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <ResponsiveContainer width="100%" height={260}>
+                <BarChart data={data.daily} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(230,235,242,0.07)" vertical={false} />
+                  <XAxis
+                    dataKey="date"
+                    tickFormatter={formatDay}
+                    tick={{ fontSize: 10, fill: '#6B7280', fontFamily: FONT_MONO }}
+                    axisLine={{ stroke: 'rgba(230,235,242,0.07)' }}
+                    tickLine={false}
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis
+                    tickFormatter={(v: number) => formatMetric(v)}
+                    tick={{ fontSize: 10, fill: '#6B7280', fontFamily: FONT_MONO }}
+                    axisLine={false}
+                    tickLine={false}
+                    width={56}
+                  />
+                  <Tooltip
+                    cursor={{ fill: 'rgba(230,235,242,0.04)' }}
+                    labelFormatter={(label) => formatDay(String(label))}
+                    formatter={(value, name) => [
+                      formatMetric(Number(value)),
+                      name === chartKeys.chat ? 'Chat' : 'Background',
+                    ]}
+                    contentStyle={{
+                      backgroundColor: '#1A1D24',
+                      border: '1px solid rgba(230,235,242,0.14)',
+                      borderRadius: 6,
+                      fontFamily: FONT_MONO,
+                      fontSize: 11,
+                    }}
+                    labelStyle={{ color: '#EDF0F4' }}
+                    itemStyle={{ color: 'rgba(237,240,244,0.78)' }}
+                  />
+                  <Bar dataKey={chartKeys.chat} stackId="usage" fill={SAGE_HEX} />
+                  <Bar dataKey={chartKeys.background} stackId="usage" fill={GOLD_HEX} radius={[2, 2, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+              {/* Legend */}
+              <div style={{ display: 'flex', gap: 16, padding: '8px 0 4px 22px' }}>
+                {[{ label: 'Chat', color: SAGE_HEX }, { label: 'Background', color: GOLD_HEX }].map(item => (
+                  <div key={item.label} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ width: 8, height: 8, borderRadius: 2, background: item.color }} />
+                    <span style={{ fontFamily: FONT_MONO, fontSize: 10, color: INK_DIM }}>{item.label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Per-agent table */}
+          <div style={{ padding: `0 ${px} 8px` }}>
+            <div style={{ ...cardStyle, padding: 0, overflow: 'hidden' }}>
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: FONT_SANS, fontSize: 13 }}>
+                  <thead>
+                    <tr>
+                      {['Agent', 'Model', 'Tokens', 'Events', 'Est. Cost'].map((h, i) => (
+                        <th
+                          key={h}
+                          style={{
+                            ...mono(9, INK_DIM),
+                            textAlign: i >= 2 ? 'right' : 'left',
+                            padding: '12px 16px',
+                            borderBottom: `1px solid ${LINE}`,
+                            fontWeight: 400,
+                          }}
+                        >
+                          {h}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.agents.map(a => (
+                      <tr key={a.slug}>
+                        <td style={{ padding: '11px 16px', color: INK, borderBottom: `1px solid ${LINE}` }}>
+                          {a.name}
+                        </td>
+                        <td style={{
+                          padding: '11px 16px', color: INK_MUTE, borderBottom: `1px solid ${LINE}`,
+                          fontFamily: FONT_MONO, fontSize: 11,
+                        }}>
+                          {a.primary_model || '—'}
+                        </td>
+                        <td style={{
+                          padding: '11px 16px', textAlign: 'right', color: INK_MUTE,
+                          borderBottom: `1px solid ${LINE}`, fontFamily: FONT_MONO, fontSize: 11,
+                          whiteSpace: 'nowrap',
+                        }}>
+                          {formatNumber(a.input_tokens)} in / {formatNumber(a.output_tokens)} out
+                        </td>
+                        <td style={{
+                          padding: '11px 16px', textAlign: 'right', color: INK_MUTE,
+                          borderBottom: `1px solid ${LINE}`, fontFamily: FONT_MONO, fontSize: 11,
+                        }}>
+                          {a.events.toLocaleString()}
+                        </td>
+                        <td style={{
+                          padding: '11px 16px', textAlign: 'right', color: INK,
+                          borderBottom: `1px solid ${LINE}`, fontFamily: FONT_MONO, fontSize: 11,
+                        }}>
+                          {formatCost(a.cost)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Disclaimer */}
+      <div style={{
+        padding: `8px ${px} 28px`,
+        fontFamily: FONT_SANS, fontSize: 11, color: 'rgba(237,240,244,0.38)',
+      }}>
+        Costs are estimates based on published API prices. Local models cost $0.00.
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/usage/UsagePage.tsx
+++ b/frontend/src/usage/UsagePage.tsx
@@ -4,7 +4,7 @@
  * in the browser's timezone. Costs are estimates from published prices.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -86,17 +86,21 @@ export function UsagePage() {
   const [error, setError] = useState(false);
   const isMobile = useIsMobile();
 
-  // Doesn't set loading/error itself (the set-state-in-effect rule forbids
-  // sync setState via the effect); initial state is true, retry resets it.
+  const abortRef = useRef<AbortController | null>(null);
+
   const load = useCallback(() => {
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setLoading(true);
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-    api<UsageSummary>(`/api/usage/summary?days=${days}&tz=${encodeURIComponent(tz)}`)
-      .then(d => { setData(d); setError(false); })
-      .catch((err) => { console.error('[UsagePage] load failed:', err); setError(true); })
-      .finally(() => setLoading(false));
+    api<UsageSummary>(`/api/usage/summary?days=${days}&tz=${encodeURIComponent(tz)}`, { signal: ctrl.signal })
+      .then(d => { if (!ctrl.signal.aborted) { setData(d); setError(false); } })
+      .catch((err) => { if (!ctrl.signal.aborted) { console.error('[UsagePage] load failed:', err); setError(true); } })
+      .finally(() => { if (!ctrl.signal.aborted) setLoading(false); });
   }, [days]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => { load(); return () => abortRef.current?.abort(); }, [load]);
 
   const px = isMobile ? '20px' : '44px';
 
@@ -357,7 +361,7 @@ export function UsagePage() {
         padding: `8px ${px} 28px`,
         fontFamily: FONT_SANS, fontSize: 11, color: 'rgba(237,240,244,0.38)',
       }}>
-        Costs are estimates based on published API prices. Local models cost $0.00.
+        Costs are estimates based on published API prices. Unpriced and local models show $0.00.
       </div>
     </div>
   );

--- a/frontend/src/usage/UsagePage.tsx
+++ b/frontend/src/usage/UsagePage.tsx
@@ -4,7 +4,7 @@
  * in the browser's timezone. Costs are estimates from published prices.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -88,19 +88,18 @@ export function UsagePage() {
 
   const abortRef = useRef<AbortController | null>(null);
 
-  const load = useCallback(() => {
+  function load() {
     abortRef.current?.abort();
     const ctrl = new AbortController();
     abortRef.current = ctrl;
-    setLoading(true);
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
     api<UsageSummary>(`/api/usage/summary?days=${days}&tz=${encodeURIComponent(tz)}`, { signal: ctrl.signal })
       .then(d => { if (!ctrl.signal.aborted) { setData(d); setError(false); } })
       .catch((err) => { if (!ctrl.signal.aborted) { console.error('[UsagePage] load failed:', err); setError(true); } })
       .finally(() => { if (!ctrl.signal.aborted) setLoading(false); });
-  }, [days]);
+  }
 
-  useEffect(() => { load(); return () => abortRef.current?.abort(); }, [load]);
+  useEffect(() => { load(); return () => abortRef.current?.abort(); }, [days]);
 
   const px = isMobile ? '20px' : '44px';
 
@@ -148,7 +147,7 @@ export function UsagePage() {
             return (
               <button
                 key={r.days}
-                onClick={() => setDays(r.days)}
+                onClick={() => { setLoading(true); setDays(r.days); }}
                 style={{
                   fontFamily: FONT_MONO, fontSize: 11, letterSpacing: '0.06em',
                   padding: '6px 14px', borderRadius: 999, cursor: 'pointer',


### PR DESCRIPTION
## Summary

- **Standalone `/usage` page** with stat cards (estimated cost, total tokens, events), stacked daily bar chart (chat vs background split with Cost/Tokens toggle), and per-agent breakdown table
- **Backend**: static Anthropic pricing lookup with prefix matching (`pricing.py`), single `/api/usage/summary` endpoint with timezone-aware daily aggregation via `zoneinfo`, extended retention (chat 365d, SA 90d with payload trimming at 7d)
- **Navigation**: `IconChart` sidebar link on desktop + 5th mobile bottom nav item
- **14 backend tests** covering pricing, aggregation, timezone bucketing, retention, and idempotency
- **4-stage review** (multi-persona Sonnet, Codex, Gemini, Opus) — fixed async→def, AbortController race condition, trim rowcount scoping, ZoneInfo fallback type, and more

## Test plan

- [ ] `cd backend && python -m pytest tests/test_usage.py -v` — 14 tests pass
- [ ] `cd frontend && npm run build` — tsc + vite clean
- [ ] Start dev servers, navigate to `/usage` — page loads with empty state or data
- [ ] Send chat messages with an Anthropic agent, verify bars/cards/table update
- [ ] Test range switching (7d / 30d / All time)
- [ ] Test mobile layout — 5 bottom nav items, Usage navigates correctly
- [ ] Verify $0.00 for Ollama/unknown models (Tokens toggle still charts them)