### PR TITLE
Add HTTP test tier with FastAPI TestClient

### DIFF
--- a/.claude/coach-lessons.md
+++ b/.claude/coach-lessons.md
@@ -5,16 +5,20 @@
 
 ## Deploy & Infrastructure
 
-- `[0.85]` **When** running the backend from a git worktree → **do** use the absolute venv path (`/Users/willwilson/ai/chatty/.venv/bin/python`), not relative (`../../.venv/bin/python`) → **because** worktrees live under `.claude/worktrees/<name>/backend/` and the relative path resolves to a nonexistent location
+- `[0.75]` **When** running the backend from a git worktree → **do** use the absolute venv path (`/Users/willwilson/ai/chatty/.venv/bin/python`), not relative (`../../.venv/bin/python`) → **because** worktrees live under `.claude/worktrees/<name>/backend/` and the relative path resolves to a nonexistent location
 
 ## Git & Workflow
 
-- `[0.80]` **When** resolving merge conflicts → **do** use `git add <specific files>`, never `git add -A` → **because** `-A` pulled `.claude/fresh-eyes/context.md` (216 lines of session research notes) into the merge commit, which then shipped in the PR
+- `[0.85]` **When** resolving merge conflicts → **do** use `git add <specific files>`, never `git add -A` → **because** `-A` pulled `.claude/fresh-eyes/context.md` (216 lines of session research notes) into the merge commit, which then shipped in the PR
 - `[0.70]` **When** committing frontend changes → **do** run `npm run lint` (eslint) in addition to `npm run build` → **because** CI's build-and-lint job enforces react-hooks rules (e.g. `set-state-in-effect`) that tsc and vite never check — the playbooks PR went red on exactly this
 
 ## Database & Migration
 
 - `[0.75]` **When** adding columns to an existing SQLite table in Chatty → **do** use the `_migrate_schema()` try/except pattern (`SELECT col LIMIT 0` / `ALTER TABLE ADD COLUMN`) → **because** this pattern handles both fresh installs and upgrades atomically without a migration framework, and `DEFAULT` values are stored in schema not per-row
+
+## Testing
+
+- `[0.70]` **When** testing Chatty chat flows that resume or reconstruct state (`approved_tool`) → **do** end the messages with the frontend's literal `[Approved] <tool>` user message → **because** `ai_service` strips that placeholder conditionally (ai_service.py:1143) — a generic message silently bypasses the strip branch, and the test stays green while production leaks `[Approved] send_email` into provider history
 
 ## Code & Architecture
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -62,3 +62,106 @@ async def collect_events(async_gen):
             except json.JSONDecodeError:
                 pass
     return events
+
+
+def parse_sse(response):
+    """Parse a buffered TestClient SSE response body into event dicts."""
+    events = []
+    for line in response.text.split("\n"):
+        if line.startswith("data: "):
+            events.append(json.loads(line[len("data: "):]))
+    return events
+
+
+@pytest.fixture
+def http_env(agent_db, encryption_env, monkeypatch, tmp_path):
+    """Isolation patches for HTTP tests against main.app (no lifespan).
+
+    Shared by both `client` and `anon_client`: a few routes are intentionally
+    non-JWT (WhatsApp webhook, Paperclip heartbeat) and their handlers run
+    during the 401 sweep, so even anonymous requests must hit tmp paths.
+    """
+    import agents.engine as engine_mod
+    import agents.router as router_mod
+    import branding.storage as branding_storage
+    import core.admin_settings as admin_mod
+    import core.agents.memory.db as memory_db_mod
+    import core.agents.playbooks.service as pb_service
+    import core.agents.reminders.db as reminders_db
+    import core.agents.shared_context.bootstrap as bootstrap_mod
+    import core.providers.credentials as creds_mod
+    import integrations.pending_setup as pending_mod
+    import integrations.registry as registry_mod
+
+    # agents.router captures DATA_DIR from agents.engine at import time —
+    # delete-agent rmtrees DATA_DIR/{slug}, so this must point at tmp.
+    monkeypatch.setattr(router_mod, "DATA_DIR", tmp_path)
+    # Empty integrations dir: no dev-integration leak, no mkdir of the real dir.
+    monkeypatch.setattr(registry_mod, "DATA_DIR", tmp_path / "integrations")
+    # Create-agent reads AND deletes pending-setup.json.
+    monkeypatch.setattr(pending_mod, "DATA_DIR", tmp_path)
+    # Chat route instantiates CredentialStore() — keep it off the real profiles.
+    monkeypatch.setattr(creds_mod, "PROFILES_PATH", tmp_path / "auth-profiles.json")
+    # Admin settings → defaults (always_power_mode off, injection_scanning flag).
+    monkeypatch.setattr(admin_mod, "ADMIN_SETTINGS_FILE", tmp_path / "admin-settings.json")
+    monkeypatch.setattr(admin_mod, "_cached_settings", None)
+    monkeypatch.setattr(admin_mod, "_cached_mtime", 0.0)
+    # Playbook GCS sync no-ops (matches playbook_env in test_playbooks_service.py).
+    monkeypatch.setattr(pb_service, "upload_config", lambda *a, **k: None)
+    monkeypatch.setattr(pb_service, "delete_config", lambda *a, **k: None)
+    # Creating a 2nd agent spawns a shared-knowledge bootstrap thread otherwise.
+    monkeypatch.setattr(bootstrap_mod, "should_bootstrap", lambda: False)
+    # GET /api/branding/logo is public (the 401 sweep reaches its handler).
+    monkeypatch.setattr(branding_storage, "BRANDING_DIR", tmp_path / "branding")
+    monkeypatch.setattr(branding_storage, "CONFIG_FILE", tmp_path / "branding" / "config.json")
+    monkeypatch.setattr(branding_storage, "LOGO_FILE", tmp_path / "branding" / "logo.png")
+    # Reminders DB backs the activity log; chat's completion logging calls
+    # get_db() which raises RuntimeError when uninitialized (lifespan never ran).
+    monkeypatch.setattr(reminders_db, "DATA_DIR", tmp_path / "reminders")
+    monkeypatch.setattr(reminders_db, "DB_PATH", tmp_path / "reminders" / "reminders.db")
+    (tmp_path / "reminders").mkdir(exist_ok=True)
+    reminders_db.close_db()
+    reminders_db._setup_connection()
+    # Per-slug caches would hand a previous test's DB to a same-named agent.
+    engine_mod._get_initialized_db.cache_clear()
+    engine_mod._get_initialized_memory_db.cache_clear()
+
+    try:
+        yield
+    finally:
+        engine_mod.close_all_agent_dbs()
+        engine_mod._get_initialized_memory_db.cache_clear()
+        # MemoryDB keeps a module-level instance cache with no close() API;
+        # close handles so tmp-dir SQLite connections don't leak across tests.
+        for inst in memory_db_mod._instances.values():
+            if inst._connection is not None:
+                inst._connection.close()
+        memory_db_mod._instances.clear()
+        reminders_db.close_db()
+
+
+@pytest.fixture
+def client(http_env):
+    """Authenticated TestClient. No `with` block: lifespan never runs."""
+    from fastapi.testclient import TestClient
+
+    import main
+    from core.auth import get_current_user
+
+    main.app.dependency_overrides[get_current_user] = lambda: {"sub": "user", "role": "admin"}
+    try:
+        yield TestClient(main.app)
+    finally:
+        main.app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+def anon_client(http_env):
+    """Unauthenticated TestClient (same isolation patches, no auth override)."""
+    from fastapi.testclient import TestClient
+
+    import main
+    from core.auth import get_current_user
+
+    assert get_current_user not in main.app.dependency_overrides
+    return TestClient(main.app)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -132,6 +132,10 @@ def http_env(agent_db, encryption_env, monkeypatch, tmp_path):
     # Per-slug caches would hand a previous test's DB to a same-named agent.
     engine_mod._get_initialized_db.cache_clear()
     engine_mod._get_initialized_memory_db.cache_clear()
+    # test_health's lifespan-never-ran sentinel reads app.state.db_statuses;
+    # keep it self-defending if any future test runs lifespan on the shared app.
+    import main
+    monkeypatch.delattr(main.app.state, "db_statuses", raising=False)
 
     try:
         yield

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -69,7 +69,7 @@ def parse_sse(response):
     events = []
     for line in response.text.split("\n"):
         if line.startswith("data: "):
-            events.append(json.loads(line[len("data: "):]))
+            events.append(json.loads(line[len("data: "):].strip()))
     return events
 
 
@@ -89,6 +89,8 @@ def http_env(agent_db, encryption_env, monkeypatch, tmp_path):
     import core.agents.playbooks.service as pb_service
     import core.agents.reminders.db as reminders_db
     import core.agents.shared_context.bootstrap as bootstrap_mod
+    import core.agents.shared_context.db as shared_db
+    import core.agents.shared_context.service as shared_service
     import core.providers.credentials as creds_mod
     import integrations.pending_setup as pending_mod
     import integrations.registry as registry_mod
@@ -111,6 +113,11 @@ def http_env(agent_db, encryption_env, monkeypatch, tmp_path):
     monkeypatch.setattr(pb_service, "delete_config", lambda *a, **k: None)
     # Creating a 2nd agent spawns a shared-knowledge bootstrap thread otherwise.
     monkeypatch.setattr(bootstrap_mod, "should_bootstrap", lambda: False)
+    # Chat's system-prompt builder globs the shared-context dir for a manifest;
+    # service.SHARED_DATA_DIR is a module-level copy of db.DATA_DIR, patch both.
+    monkeypatch.setattr(shared_db, "DATA_DIR", tmp_path / "shared")
+    monkeypatch.setattr(shared_db, "DB_PATH", tmp_path / "shared" / "shared_context.db")
+    monkeypatch.setattr(shared_service, "SHARED_DATA_DIR", tmp_path / "shared")
     # GET /api/branding/logo is public (the 401 sweep reaches its handler).
     monkeypatch.setattr(branding_storage, "BRANDING_DIR", tmp_path / "branding")
     monkeypatch.setattr(branding_storage, "CONFIG_FILE", tmp_path / "branding" / "config.json")
@@ -164,4 +171,4 @@ def anon_client(http_env):
     from core.auth import get_current_user
 
     assert get_current_user not in main.app.dependency_overrides
-    return TestClient(main.app)
+    yield TestClient(main.app)

--- a/backend/tests/test_http_agents.py
+++ b/backend/tests/test_http_agents.py
@@ -115,7 +115,10 @@ def test_context_delete_then_404(client):
 
 def test_context_rejects_bad_filenames(client):
     agent = make_agent(client)
-    # Single-segment names that route but fail _safe_filename → 400, on all verbs.
+    # Single-segment names rejected with 400 on all verbs. The first three
+    # fail _safe_filename directly; back%5Cslash.md relies on Starlette
+    # percent-decoding %5C to a backslash BEFORE validation — it also guards
+    # that decode-then-validate ordering.
     for bad in ("notes.txt", "noextension", "..sneaky.md", "back%5Cslash.md"):
         for method, kwargs in (
             ("GET", {}),

--- a/backend/tests/test_http_agents.py
+++ b/backend/tests/test_http_agents.py
@@ -1,0 +1,134 @@
+"""HTTP tests: agent CRUD and per-agent context file CRUD."""
+
+
+def make_agent(client, name="Helper", personality="friendly"):
+    resp = client.post("/api/agents", json={"agent_name": name, "personality": personality})
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# ── Agent CRUD ────────────────────────────────────────────────────────────────
+
+def test_list_agents_empty(client):
+    resp = client.get("/api/agents")
+    assert resp.status_code == 200
+    assert resp.json() == {"agents": []}
+
+
+def test_create_agent_seeds_context(client, tmp_path):
+    agent = make_agent(client)
+    assert agent["slug"] == "helper"
+    assert agent["id"]
+    # Seeding is synchronous and lands in the patched tmp tree — proves the
+    # router-level DATA_DIR patch is effective.
+    assert (tmp_path / "helper" / "context" / "soul.md").exists()
+
+
+def test_create_agent_blank_name_400(client):
+    resp = client.post("/api/agents", json={"agent_name": "   "})
+    assert resp.status_code == 400
+
+
+def test_get_agent(client):
+    agent = make_agent(client)
+    resp = client.get(f"/api/agents/{agent['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "helper"
+
+
+def test_get_agent_unknown_404(client):
+    assert client.get("/api/agents/no-such-id").status_code == 404
+
+
+def test_rename_keeps_slug_and_context(client):
+    agent = make_agent(client)
+    files_before = client.get(f"/api/agents/{agent['id']}/context").json()["files"]
+    names_before = sorted(f["name"] for f in files_before)
+    assert names_before
+
+    resp = client.put(f"/api/agents/{agent['id']}", json={"agent_name": "Renamed Agent"})
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["agent_name"] == "Renamed Agent"
+    assert updated["slug"] == "helper"
+
+    files_after = client.get(f"/api/agents/{agent['id']}/context").json()["files"]
+    assert sorted(f["name"] for f in files_after) == names_before
+
+
+def test_update_no_fields_400(client):
+    agent = make_agent(client)
+    resp = client.put(f"/api/agents/{agent['id']}", json={})
+    assert resp.status_code == 400
+
+
+def test_update_invalid_model_tier_400(client):
+    agent = make_agent(client)
+    resp = client.put(f"/api/agents/{agent['id']}", json={"model_tier": "ludicrous"})
+    assert resp.status_code == 400
+
+
+def test_delete_agent(client, tmp_path):
+    agent = make_agent(client)
+    assert (tmp_path / "helper").exists()
+
+    resp = client.delete(f"/api/agents/{agent['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+    assert client.get(f"/api/agents/{agent['id']}").status_code == 404
+    assert not (tmp_path / "helper").exists()
+
+
+# ── Context file CRUD ─────────────────────────────────────────────────────────
+
+def test_context_list_seeded(client):
+    agent = make_agent(client)
+    files = client.get(f"/api/agents/{agent['id']}/context").json()["files"]
+    assert "soul.md" in [f["name"] for f in files]
+
+
+def test_context_put_get_roundtrip(client):
+    agent = make_agent(client)
+    put = client.put(
+        f"/api/agents/{agent['id']}/context/notes.md", json={"content": "# Notes\nhello"}
+    )
+    assert put.status_code == 200
+    assert put.json() == {"filename": "notes.md", "ok": True}
+
+    got = client.get(f"/api/agents/{agent['id']}/context/notes.md")
+    assert got.status_code == 200
+    assert got.json()["content"] == "# Notes\nhello"
+
+
+def test_context_get_missing_404(client):
+    agent = make_agent(client)
+    assert client.get(f"/api/agents/{agent['id']}/context/nope.md").status_code == 404
+
+
+def test_context_delete_then_404(client):
+    agent = make_agent(client)
+    client.put(f"/api/agents/{agent['id']}/context/notes.md", json={"content": "x"})
+    resp = client.delete(f"/api/agents/{agent['id']}/context/notes.md")
+    assert resp.status_code == 200
+    assert client.get(f"/api/agents/{agent['id']}/context/notes.md").status_code == 404
+
+
+def test_context_rejects_bad_filenames(client):
+    agent = make_agent(client)
+    # Single-segment names that route but fail _safe_filename → 400.
+    for bad in ("notes.txt", "noextension", "..sneaky.md", "back%5Cslash.md"):
+        resp = client.get(f"/api/agents/{agent['id']}/context/{bad}")
+        assert resp.status_code == 400, f"{bad!r} returned {resp.status_code}"
+
+
+def test_context_encoded_traversal_blocked(client, tmp_path):
+    agent = make_agent(client)
+    # %2F decodes to a slash, which the single-segment path param can't match;
+    # depending on routing this is a 404 (no route) or 400 (validator). The
+    # property under test: never 200, and nothing written outside context/.
+    resp = client.put(
+        f"/api/agents/{agent['id']}/context/..%2Fevil.md", json={"content": "pwned"}
+    )
+    assert resp.status_code in (400, 404)
+    assert not (tmp_path / "helper" / "evil.md").exists()
+    assert not (tmp_path / "evil.md").exists()

--- a/backend/tests/test_http_agents.py
+++ b/backend/tests/test_http_agents.py
@@ -115,10 +115,19 @@ def test_context_delete_then_404(client):
 
 def test_context_rejects_bad_filenames(client):
     agent = make_agent(client)
-    # Single-segment names that route but fail _safe_filename → 400.
+    # Single-segment names that route but fail _safe_filename → 400, on all verbs.
     for bad in ("notes.txt", "noextension", "..sneaky.md", "back%5Cslash.md"):
-        resp = client.get(f"/api/agents/{agent['id']}/context/{bad}")
-        assert resp.status_code == 400, f"{bad!r} returned {resp.status_code}"
+        for method, kwargs in (
+            ("GET", {}),
+            ("PUT", {"json": {"content": "x"}}),
+            ("DELETE", {}),
+        ):
+            resp = client.request(
+                method, f"/api/agents/{agent['id']}/context/{bad}", **kwargs
+            )
+            assert resp.status_code == 400, (
+                f"{method} {bad!r} returned {resp.status_code}"
+            )
 
 
 def test_context_encoded_traversal_blocked(client, tmp_path):

--- a/backend/tests/test_http_chat.py
+++ b/backend/tests/test_http_chat.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from .conftest import parse_sse
-from .test_ai_service import MockAIProvider
-from .test_http_agents import make_agent
+from tests.conftest import parse_sse
+from tests.test_ai_service import MockAIProvider
+from tests.test_http_agents import make_agent
 
 SEND_EMAIL_DEF = {
     "name": "send_email",
@@ -21,6 +21,19 @@ LOOKUP_DEF = {
     "input_schema": {"type": "object", "properties": {}},
     "description": "Look something up",
 }
+
+
+class RecordingProvider(MockAIProvider):
+    """MockAIProvider that records the messages sent to each stream_turn call."""
+
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.seen_messages = []
+
+    async def stream_turn(self, messages, tools, system_prompt):
+        self.seen_messages.append(messages)
+        async for event in super().stream_turn(messages, tools, system_prompt):
+            yield event
 
 
 @pytest.fixture
@@ -111,17 +124,25 @@ def test_chat_write_tool_confirm_flow(chat_client, mock_provider, email_tool):
     confirm = next(e for e in events if e["type"] == "confirm")
     assert confirm["tool"] == "send_email"
     assert confirm["tool_use_id"] == "tu1"
+    assert confirm["args"] == {"to": "a@b.com", "subject": "hi", "body": "test"}
     assert confirm["description"] == "Send an email"
+    # The frontend spinner keys off tool_start arriving before the confirm.
+    assert "tool_start" in types
     # Confirmation means no execution: no tool_end, stub untouched.
     assert "tool_end" not in types
     assert email_tool == []
     assert types[-1] == "done"
 
 
-def test_chat_approved_tool_resume(chat_client, mock_provider, email_tool):
-    agent = make_agent(chat_client)
+def test_chat_approved_tool_resume(client, email_tool, monkeypatch):
+    # Record what reaches the provider: the engine must reconstruct the
+    # approved tool as tool_use/tool_result blocks, not silently drop it.
+    recording = RecordingProvider()
+    monkeypatch.setattr("agents.router.get_ai_provider", lambda **kw: recording)
+
+    agent = make_agent(client)
     events = parse_sse(chat(
-        chat_client, agent,
+        client, agent,
         tool_mode="normal",
         approved_tool={
             "tool": "send_email",
@@ -134,6 +155,14 @@ def test_chat_approved_tool_resume(chat_client, mock_provider, email_tool):
     assert "confirm" not in types
     assert "text" in types
     assert types[-1] == "done"
+
+    sent = recording.seen_messages[0]
+    tool_uses = [b for m in sent if isinstance(m.get("content"), list)
+                 for b in m["content"] if b.get("type") == "tool_use"]
+    tool_results = [b for m in sent if isinstance(m.get("content"), list)
+                    for b in m["content"] if b.get("type") == "tool_result"]
+    assert any(b["name"] == "send_email" and b["id"] == "tu1" for b in tool_uses)
+    assert any(b["tool_use_id"] == "tu1" and '"ok": true' in b["content"] for b in tool_results)
 
 
 def test_tool_execute_approved_write(chat_client, email_tool):

--- a/backend/tests/test_http_chat.py
+++ b/backend/tests/test_http_chat.py
@@ -1,0 +1,155 @@
+"""HTTP tests: chat SSE streaming, confirm flow, tool execute, conversations."""
+
+import pytest
+
+from .conftest import parse_sse
+from .test_ai_service import MockAIProvider
+from .test_http_agents import make_agent
+
+SEND_EMAIL_DEF = {
+    "name": "send_email",
+    "kind": "integration",
+    "writes": True,
+    "input_schema": {"type": "object", "properties": {}},
+    "description": "Send an email",
+}
+
+LOOKUP_DEF = {
+    "name": "lookup_thing",
+    "kind": "integration",
+    "writes": False,
+    "input_schema": {"type": "object", "properties": {}},
+    "description": "Look something up",
+}
+
+
+@pytest.fixture
+def mock_provider():
+    return MockAIProvider()
+
+
+@pytest.fixture
+def chat_client(client, mock_provider, monkeypatch):
+    monkeypatch.setattr("agents.router.get_ai_provider", lambda **kw: mock_provider)
+    return client
+
+
+@pytest.fixture
+def email_tool(monkeypatch):
+    """Expose a stub write tool through the integration loader."""
+    calls = []
+
+    def stub(**kwargs):
+        calls.append(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        "agents.router.load_integration_tools",
+        lambda: ([SEND_EMAIL_DEF, LOOKUP_DEF], {"send_email": stub, "lookup_thing": stub}),
+    )
+    return calls
+
+
+def chat(chat_client, agent, **extra):
+    payload = {"messages": [{"role": "user", "content": "hello quixotic unicorn"}], **extra}
+    return chat_client.post(f"/api/agents/{agent['id']}/chat", json=payload)
+
+
+def test_chat_text_turn_event_order(chat_client):
+    agent = make_agent(chat_client)
+    resp = chat(chat_client, agent)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+
+    events = parse_sse(resp)
+    types = [e["type"] for e in events]
+    assert types[0] == "conversation_id"
+    assert "text" in types
+    text = "".join(e["text"] for e in events if e["type"] == "text")
+    assert text == "Hello from mock"
+    assert types[-1] == "done"
+    assert events[-1]["model"] == "mock-model"
+
+
+def test_chat_persists_conversation_and_fts_search(chat_client):
+    agent = make_agent(chat_client)
+    events = parse_sse(chat(chat_client, agent))
+    conv_id = events[0]["id"]
+
+    listed = chat_client.get(f"/api/agents/{agent['id']}/conversations").json()
+    assert [c["id"] for c in listed["conversations"]] == [conv_id]
+
+    found = chat_client.get(
+        f"/api/agents/{agent['id']}/conversations/search", params={"q": "quixotic"}
+    ).json()["results"]
+    assert any(r["id"] == conv_id for r in found)
+
+
+def test_chat_unknown_agent_404(chat_client):
+    resp = chat_client.post(
+        "/api/agents/nope/chat", json={"messages": [{"role": "user", "content": "hi"}]}
+    )
+    assert resp.status_code == 404
+
+
+def test_chat_write_tool_confirm_flow(chat_client, mock_provider, email_tool):
+    agent = make_agent(chat_client)
+    mock_provider.set_responses([
+        [
+            {"type": "tool_start", "tool": "send_email", "tool_use_id": "tu1"},
+            {"type": "_turn_complete", "tool_calls": [
+                {"name": "send_email", "id": "tu1",
+                 "args": {"to": "a@b.com", "subject": "hi", "body": "test"}},
+            ], "stop_reason": "tool_use", "usage": {}},
+        ],
+        MockAIProvider._default_response(),
+    ])
+
+    events = parse_sse(chat(chat_client, agent, tool_mode="normal"))
+    types = [e["type"] for e in events]
+    assert "confirm" in types
+    confirm = next(e for e in events if e["type"] == "confirm")
+    assert confirm["tool"] == "send_email"
+    assert confirm["tool_use_id"] == "tu1"
+    assert confirm["description"] == "Send an email"
+    # Confirmation means no execution: no tool_end, stub untouched.
+    assert "tool_end" not in types
+    assert email_tool == []
+    assert types[-1] == "done"
+
+
+def test_chat_approved_tool_resume(chat_client, mock_provider, email_tool):
+    agent = make_agent(chat_client)
+    events = parse_sse(chat(
+        chat_client, agent,
+        tool_mode="normal",
+        approved_tool={
+            "tool": "send_email",
+            "args": {"to": "a@b.com"},
+            "toolUseId": "tu1",
+            "result": {"ok": True},
+        },
+    ))
+    types = [e["type"] for e in events]
+    assert "confirm" not in types
+    assert "text" in types
+    assert types[-1] == "done"
+
+
+def test_tool_execute_approved_write(chat_client, email_tool):
+    agent = make_agent(chat_client)
+    resp = chat_client.post(
+        f"/api/agents/{agent['id']}/tool/execute",
+        json={"tool": "send_email", "args": {"to": "a@b.com"}},
+    )
+    assert resp.status_code == 200
+    assert email_tool == [{"to": "a@b.com"}]
+
+
+def test_tool_execute_rejects_non_write(chat_client, email_tool):
+    agent = make_agent(chat_client)
+    resp = chat_client.post(
+        f"/api/agents/{agent['id']}/tool/execute",
+        json={"tool": "lookup_thing", "args": {}},
+    )
+    assert resp.status_code == 400

--- a/backend/tests/test_http_chat.py
+++ b/backend/tests/test_http_chat.py
@@ -127,7 +127,7 @@ def test_chat_write_tool_confirm_flow(chat_client, mock_provider, email_tool):
     assert confirm["args"] == {"to": "a@b.com", "subject": "hi", "body": "test"}
     assert confirm["description"] == "Send an email"
     # The frontend spinner keys off tool_start arriving before the confirm.
-    assert "tool_start" in types
+    assert types.index("tool_start") < types.index("confirm")
     # Confirmation means no execution: no tool_end, stub untouched.
     assert "tool_end" not in types
     assert email_tool == []

--- a/backend/tests/test_http_chat.py
+++ b/backend/tests/test_http_chat.py
@@ -137,20 +137,28 @@ def test_chat_write_tool_confirm_flow(chat_client, mock_provider, email_tool):
 def test_chat_approved_tool_resume(client, email_tool, monkeypatch):
     # Record what reaches the provider: the engine must reconstruct the
     # approved tool as tool_use/tool_result blocks, not silently drop it.
+    # (Block shapes are the mock's Anthropic-style add_tool_results format —
+    # per-provider wire shapes are each provider's own responsibility.)
     recording = RecordingProvider()
     monkeypatch.setattr("agents.router.get_ai_provider", lambda **kw: recording)
 
     agent = make_agent(client)
-    events = parse_sse(chat(
-        client, agent,
-        tool_mode="normal",
-        approved_tool={
+    # The frontend sends the approval turn as a "[Approved] <tool>" user
+    # message; the engine must strip it and substitute the tool blocks.
+    resp = client.post(f"/api/agents/{agent['id']}/chat", json={
+        "messages": [
+            {"role": "user", "content": "send the email"},
+            {"role": "user", "content": "[Approved] send_email"},
+        ],
+        "tool_mode": "normal",
+        "approved_tool": {
             "tool": "send_email",
             "args": {"to": "a@b.com"},
             "toolUseId": "tu1",
             "result": {"ok": True},
         },
-    ))
+    })
+    events = parse_sse(resp)
     types = [e["type"] for e in events]
     assert "confirm" not in types
     assert "text" in types
@@ -163,6 +171,9 @@ def test_chat_approved_tool_resume(client, email_tool, monkeypatch):
                     for b in m["content"] if b.get("type") == "tool_result"]
     assert any(b["name"] == "send_email" and b["id"] == "tu1" for b in tool_uses)
     assert any(b["tool_use_id"] == "tu1" and '"ok": true' in b["content"] for b in tool_results)
+    # The placeholder must not leak into provider history.
+    assert not [m for m in sent
+                if isinstance(m.get("content"), str) and m["content"].startswith("[Approved]")]
 
 
 def test_tool_execute_approved_write(chat_client, email_tool):

--- a/backend/tests/test_http_misc.py
+++ b/backend/tests/test_http_misc.py
@@ -105,7 +105,7 @@ SWEEP_ALLOWLIST = {
     ("POST", "/api/login/verify-2fa"),          # pending-token + TOTP auth
     ("GET", "/api/health"),                     # public health
     ("GET", "/api/health/live"),                # liveness probe
-    ("POST", "/api/telegram/webhook/{agent_slug}"),  # secret-token header auth
+    ("POST", "/api/telegram/webhook/{agent_slug}"),  # secret-token header auth; invalid secrets get 200 by design (stops Telegram retries)
     ("GET", "/api/oauth/callback"),             # OAuth provider redirect — no JWT possible
     ("GET", "/api/branding/logo"),              # served in <img>/CSS tags
     ("POST", "/api/messaging/whatsapp/webhook"),  # Baileys sidecar, X-Api-Key auth
@@ -139,3 +139,33 @@ def test_route_rejects_unauthenticated(anon_client, method, path):
     url = re.sub(r"\{[^}]+\}", "x", path)
     resp = anon_client.request(method, url)
     assert resp.status_code == 401, f"{method} {path} returned {resp.status_code}"
+
+
+def test_no_sub_app_mounts_under_api():
+    """The sweep can't see inside Mount sub-apps, so none may live under /api."""
+    from starlette.routing import Mount
+
+    mounts = [r for r in main.app.routes if isinstance(r, Mount)]
+    assert not [m.path for m in mounts if m.path.startswith("/api")]
+
+
+# ── Webhook auth (allowlisted non-JWT routes) ─────────────────────────────────
+
+def test_paperclip_heartbeat_closed_when_unconfigured(anon_client):
+    # No webhook secret in the (tmp, empty) registry → closed by default.
+    resp = anon_client.post(
+        "/api/integrations/paperclip/heartbeat", json={"agentId": "x"}
+    )
+    assert resp.status_code == 403
+
+
+def test_whatsapp_webhook_rejects_bad_api_key(anon_client, monkeypatch):
+    from core.config import settings
+
+    monkeypatch.setattr(settings.whatsapp, "webhook_secret", "wh-secret")
+    missing = anon_client.post("/api/messaging/whatsapp/webhook", json={})
+    assert missing.status_code == 401
+    wrong = anon_client.post(
+        "/api/messaging/whatsapp/webhook", json={}, headers={"X-Api-Key": "nope"}
+    )
+    assert wrong.status_code == 401

--- a/backend/tests/test_http_misc.py
+++ b/backend/tests/test_http_misc.py
@@ -1,0 +1,135 @@
+"""HTTP tests: health, login, usage, and the unauthenticated-route sweep."""
+
+import re
+
+import pytest
+
+import main
+
+
+# ── Health ────────────────────────────────────────────────────────────────────
+
+def test_health(anon_client):
+    resp = anon_client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    # Lifespan never ran, so no DB statuses were recorded — this is the
+    # sentinel that the HTTP tier runs without startup side effects.
+    assert body["databases"] == {}
+
+
+def test_health_live(anon_client):
+    resp = anon_client.get("/api/health/live")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+# ── Login ─────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def login_env(monkeypatch):
+    """Known password, no 2FA, fresh rate-limiter state."""
+    import core.auth as auth_mod
+    from core.config import settings
+
+    monkeypatch.setattr(settings.auth, "password", "test-password")
+    monkeypatch.setattr("core.auth_2fa.is_2fa_enabled", lambda: False)
+    auth_mod._login_attempts.clear()
+    yield
+    auth_mod._login_attempts.clear()
+
+
+def test_login_wrong_password(anon_client, login_env):
+    resp = anon_client.post("/api/login", json={"password": "nope"})
+    assert resp.status_code == 401
+
+
+def test_login_correct_password_token_round_trip(anon_client, login_env):
+    resp = anon_client.post("/api/login", json={"password": "test-password"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["token_type"] == "bearer"
+
+    me = anon_client.get(
+        "/api/me", headers={"Authorization": f"Bearer {body['access_token']}"}
+    )
+    assert me.status_code == 200
+    assert me.json() == {"sub": "user", "role": "admin"}
+
+
+def test_login_rate_limited(anon_client, login_env):
+    for _ in range(10):
+        assert anon_client.post("/api/login", json={"password": "nope"}).status_code == 401
+    resp = anon_client.post("/api/login", json={"password": "nope"})
+    assert resp.status_code == 429
+
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+
+def test_usage_summary_empty(client):
+    resp = client.get("/api/usage/summary")
+    assert resp.status_code == 200
+    totals = resp.json()["totals"]
+    assert totals["events"] == 0
+    assert totals["input_tokens"] == 0
+
+
+def test_usage_summary_aggregates(client):
+    from core.agents.activity_log import log_chat_event
+
+    log_chat_event("helper", model_used="mock-model",
+                   input_tokens=100, output_tokens=50)
+    resp = client.get("/api/usage/summary", params={"days": 7})
+    assert resp.status_code == 200
+    totals = resp.json()["totals"]
+    assert totals["events"] == 1
+    assert totals["input_tokens"] == 100
+    assert totals["output_tokens"] == 50
+
+
+def test_usage_summary_bad_tz_falls_back(client):
+    resp = client.get("/api/usage/summary", params={"tz": "Not/AZone"})
+    assert resp.status_code == 200
+
+
+# ── Unauthenticated-route sweep ───────────────────────────────────────────────
+
+# Routes that are intentionally reachable without a JWT.
+SWEEP_ALLOWLIST = {
+    ("POST", "/api/login"),                     # password login
+    ("POST", "/api/login/verify-2fa"),          # pending-token + TOTP auth
+    ("GET", "/api/health"),                     # public health
+    ("GET", "/api/health/live"),                # liveness probe
+    ("POST", "/api/telegram/webhook/{agent_slug}"),  # secret-token header auth
+    ("GET", "/api/oauth/callback"),             # OAuth provider redirect — no JWT possible
+    ("GET", "/api/branding/logo"),              # served in <img>/CSS tags
+    ("POST", "/api/messaging/whatsapp/webhook"),  # Baileys sidecar, X-Api-Key auth
+    ("POST", "/api/integrations/paperclip/heartbeat"),  # X-Webhook-Secret auth
+}
+
+
+def _protected_routes():
+    from fastapi.routing import APIRoute
+
+    cases = []
+    for route in main.app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
+            if (method, route.path) in SWEEP_ALLOWLIST:
+                continue
+            cases.append((method, route.path))
+    return cases
+
+
+@pytest.mark.parametrize("method,path", _protected_routes())
+def test_route_rejects_unauthenticated(anon_client, method, path):
+    """Every route outside the allowlist must 401 without a token.
+
+    get_current_user raises 401 during dependency resolution, before body
+    or path-param validation, so no payload is needed.
+    """
+    url = re.sub(r"\{[^}]+\}", "x", path)
+    resp = anon_client.request(method, url)
+    assert resp.status_code == 401, f"{method} {path} returned {resp.status_code}"

--- a/backend/tests/test_http_misc.py
+++ b/backend/tests/test_http_misc.py
@@ -4,6 +4,9 @@ import re
 
 import pytest
 
+# Imported at collection time because _protected_routes() feeds parametrize.
+# main is import-side-effect-free (all init lives in lifespan) — test_health
+# asserts that holds.
 import main
 
 
@@ -91,6 +94,7 @@ def test_usage_summary_aggregates(client):
 def test_usage_summary_bad_tz_falls_back(client):
     resp = client.get("/api/usage/summary", params={"tz": "Not/AZone"})
     assert resp.status_code == 200
+    assert resp.json()["timezone"] == "UTC"
 
 
 # ── Unauthenticated-route sweep ───────────────────────────────────────────────
@@ -114,6 +118,8 @@ def _protected_routes():
 
     cases = []
     for route in main.app.routes:
+        # Only APIRoutes are swept; Mount sub-apps (e.g. static files) are
+        # intentionally excluded and must be audited manually if ever added.
         if not isinstance(route, APIRoute):
             continue
         for method in sorted(route.methods - {"HEAD", "OPTIONS"}):

--- a/backend/tests/test_http_playbooks.py
+++ b/backend/tests/test_http_playbooks.py
@@ -1,0 +1,181 @@
+"""HTTP tests: playbook CRUD/archive/restore and the learning-events feed."""
+
+import pytest
+
+from core.agents.playbooks import learning_log
+
+from .test_http_agents import make_agent
+
+PLAYBOOK_BODY = {
+    "name": "Morning Brief",
+    "description": "Summarize overnight email and calendar",
+    "content": "## Procedure\n1. Pull unread email.\n2. Summarize.",
+    "integrations": [],
+    "chip": True,
+}
+
+
+@pytest.fixture
+def agent(client):
+    return make_agent(client)
+
+
+def put_playbook(client, agent, slug="morning-brief", **overrides):
+    body = {**PLAYBOOK_BODY, **overrides}
+    return client.put(f"/api/agents/{agent['id']}/playbooks/{slug}", json=body)
+
+
+# ── Playbook CRUD ─────────────────────────────────────────────────────────────
+
+def test_list_empty(client, agent):
+    resp = client.get(f"/api/agents/{agent['id']}/playbooks")
+    assert resp.status_code == 200
+    assert resp.json() == {"playbooks": []}
+
+
+def test_put_creates_and_get_roundtrip(client, agent):
+    resp = put_playbook(client, agent)
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "morning-brief"
+
+    got = client.get(f"/api/agents/{agent['id']}/playbooks/morning-brief")
+    assert got.status_code == 200
+    pb = got.json()
+    assert pb["meta"]["name"] == "Morning Brief"
+    assert pb["meta"]["chip"] is True
+    assert "## Procedure" in pb["body"]
+    assert pb["archived"] is False
+
+    listed = client.get(f"/api/agents/{agent['id']}/playbooks").json()["playbooks"]
+    assert [p["slug"] for p in listed] == ["morning-brief"]
+
+
+def test_get_missing_404(client, agent):
+    assert client.get(f"/api/agents/{agent['id']}/playbooks/nope").status_code == 404
+
+
+def test_put_invalid_slug_400(client, agent):
+    resp = put_playbook(client, agent, slug="Bad_Slug")
+    assert resp.status_code == 400
+
+
+def test_archive_restore_cycle(client, agent):
+    put_playbook(client, agent)
+
+    resp = client.post(f"/api/agents/{agent['id']}/playbooks/morning-brief/archive")
+    assert resp.status_code == 200
+    assert resp.json()["archived"] is True
+    listed = client.get(f"/api/agents/{agent['id']}/playbooks").json()["playbooks"]
+    assert [p["archived"] for p in listed] == [True]
+
+    resp = client.post(f"/api/agents/{agent['id']}/playbooks/morning-brief/restore")
+    assert resp.status_code == 200
+    listed = client.get(f"/api/agents/{agent['id']}/playbooks").json()["playbooks"]
+    assert [p["archived"] for p in listed] == [False]
+
+
+def test_archive_missing_404(client, agent):
+    resp = client.post(f"/api/agents/{agent['id']}/playbooks/nope/archive")
+    assert resp.status_code == 404
+
+
+def test_delete_playbook(client, agent):
+    put_playbook(client, agent)
+    resp = client.delete(f"/api/agents/{agent['id']}/playbooks/morning-brief")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+    assert client.get(f"/api/agents/{agent['id']}/playbooks/morning-brief").status_code == 404
+
+
+def test_delete_missing_404(client, agent):
+    assert client.delete(f"/api/agents/{agent['id']}/playbooks/nope").status_code == 404
+
+
+# ── Learning events ───────────────────────────────────────────────────────────
+
+def test_learning_events_empty(client, agent):
+    # Also verifies ensure_memory_db lazily creates the per-agent memory DB
+    # under the patched tmp tree when reached over HTTP.
+    resp = client.get(f"/api/agents/{agent['id']}/learning-events")
+    assert resp.status_code == 200
+    assert resp.json() == {"events": []}
+
+
+def test_learning_events_list_after_seed(client, agent):
+    eid = learning_log.log_event(
+        "helper", event_type="playbook_created", source="review",
+        target="morning-brief", title="New playbook “Morning Brief”",
+        after_content="full file text",
+    )
+    assert eid
+
+    resp = client.get(f"/api/agents/{agent['id']}/learning-events")
+    events = resp.json()["events"]
+    assert len(events) == 1
+    assert events[0]["event_type"] == "playbook_created"
+    assert events[0]["reverted_at"] is None
+
+    paged = client.get(
+        f"/api/agents/{agent['id']}/learning-events", params={"limit": 1, "offset": 1}
+    )
+    assert paged.json()["events"] == []
+
+
+def test_revert_playbook_updated_restores_content(client, agent):
+    put_playbook(client, agent)
+    v1_path_resp = client.get(f"/api/agents/{agent['id']}/playbooks/morning-brief")
+    v1_body = v1_path_resp.json()["body"]
+
+    # Reconstruct the on-disk v1 text the way the service stores it, then
+    # simulate an agent-learned update with before_content = v1.
+    from core.agents.playbooks import service as pb_service
+    v1_text = (pb_service.playbooks_dir("helper") / "morning-brief.md").read_text()
+
+    put_playbook(client, agent, content="## Procedure\nCOMPLETELY REWRITTEN")
+    eid = learning_log.log_event(
+        "helper", event_type="playbook_updated", source="agent",
+        target="morning-brief", title="Updated playbook",
+        before_content=v1_text,
+    )
+
+    resp = client.post(f"/api/agents/{agent['id']}/learning-events/{eid}/revert")
+    assert resp.status_code == 200
+    assert resp.json()["reverted"] is True
+
+    got = client.get(f"/api/agents/{agent['id']}/playbooks/morning-brief").json()
+    assert got["body"] == v1_body
+    assert "COMPLETELY REWRITTEN" not in got["body"]
+
+
+def test_revert_playbook_created_archives(client, agent):
+    put_playbook(client, agent)
+    eid = learning_log.log_event(
+        "helper", event_type="playbook_created", source="review",
+        target="morning-brief", title="New playbook",
+    )
+
+    resp = client.post(f"/api/agents/{agent['id']}/learning-events/{eid}/revert")
+    assert resp.status_code == 200
+
+    got = client.get(f"/api/agents/{agent['id']}/playbooks/morning-brief").json()
+    assert got["archived"] is True
+
+
+def test_revert_twice_400(client, agent):
+    put_playbook(client, agent)
+    eid = learning_log.log_event(
+        "helper", event_type="playbook_created", source="review",
+        target="morning-brief", title="New playbook",
+    )
+    assert client.post(
+        f"/api/agents/{agent['id']}/learning-events/{eid}/revert"
+    ).status_code == 200
+
+    resp = client.post(f"/api/agents/{agent['id']}/learning-events/{eid}/revert")
+    assert resp.status_code == 400
+    assert "already reverted" in resp.json()["detail"]
+
+
+def test_revert_unknown_event_400(client, agent):
+    resp = client.post(f"/api/agents/{agent['id']}/learning-events/9999/revert")
+    assert resp.status_code == 400

--- a/backend/tests/test_http_playbooks.py
+++ b/backend/tests/test_http_playbooks.py
@@ -4,7 +4,7 @@ import pytest
 
 from core.agents.playbooks import learning_log
 
-from .test_http_agents import make_agent
+from tests.test_http_agents import make_agent
 
 PLAYBOOK_BODY = {
     "name": "Morning Brief",
@@ -103,7 +103,7 @@ def test_learning_events_empty(client, agent):
 
 def test_learning_events_list_after_seed(client, agent):
     eid = learning_log.log_event(
-        "helper", event_type="playbook_created", source="review",
+        agent["slug"], event_type="playbook_created", source="review",
         target="morning-brief", title="New playbook “Morning Brief”",
         after_content="full file text",
     )
@@ -129,11 +129,11 @@ def test_revert_playbook_updated_restores_content(client, agent):
     # Reconstruct the on-disk v1 text the way the service stores it, then
     # simulate an agent-learned update with before_content = v1.
     from core.agents.playbooks import service as pb_service
-    v1_text = (pb_service.playbooks_dir("helper") / "morning-brief.md").read_text()
+    v1_text = (pb_service.playbooks_dir(agent["slug"]) / "morning-brief.md").read_text()
 
     put_playbook(client, agent, content="## Procedure\nCOMPLETELY REWRITTEN")
     eid = learning_log.log_event(
-        "helper", event_type="playbook_updated", source="agent",
+        agent["slug"], event_type="playbook_updated", source="agent",
         target="morning-brief", title="Updated playbook",
         before_content=v1_text,
     )
@@ -150,7 +150,7 @@ def test_revert_playbook_updated_restores_content(client, agent):
 def test_revert_playbook_created_archives(client, agent):
     put_playbook(client, agent)
     eid = learning_log.log_event(
-        "helper", event_type="playbook_created", source="review",
+        agent["slug"], event_type="playbook_created", source="review",
         target="morning-brief", title="New playbook",
     )
 
@@ -164,7 +164,7 @@ def test_revert_playbook_created_archives(client, agent):
 def test_revert_twice_400(client, agent):
     put_playbook(client, agent)
     eid = learning_log.log_event(
-        "helper", event_type="playbook_created", source="review",
+        agent["slug"], event_type="playbook_created", source="review",
         target="morning-brief", title="New playbook",
     )
     assert client.post(

--- a/docs/solutions/architecture-patterns/http-testclient-without-lifespan.md
+++ b/docs/solutions/architecture-patterns/http-testclient-without-lifespan.md
@@ -1,0 +1,127 @@
+---
+title: HTTP test tier with FastAPI TestClient — running without lifespan and isolating module-level data paths
+date: 2026-06-12
+category: architecture-patterns
+module: backend/tests/conftest.py, backend/main.py, backend/agents/router.py
+tags: [testing, fastapi, testclient, fixtures, monkeypatch, isolation, sse, auth]
+problem_type: pattern
+---
+
+## Context
+
+Chatty's backend had 505 service-level tests but zero coverage of the HTTP layer
+(route handlers, auth dependencies, request/response shapes, SSE streaming). We
+needed an HTTP test tier as a safety net before a refactor that merges the three
+hand-rolled tool-execution loops into one `AgentTurnRunner`. The constraints:
+purely additive, no behavior changes, suite stays fast (<10s, no network), and —
+critically — tests must never read or destroy real developer data under
+`backend/data/`.
+
+`main.py` builds `app` at import time with all routers mounted, but **all**
+filesystem/DB/scheduler initialization lives in the `lifespan` function (data-dir
+mkdirs, APScheduler, every DB `init_db`). The whole approach hinges on one fact:
+`TestClient(main.app)` used **without** a `with` block never runs lifespan, so
+tests get the full route table with no schedulers and no startup disk writes.
+
+## Guidance
+
+### 1. Verify the app is import-side-effect-free, then skip lifespan
+
+```python
+from fastapi.testclient import TestClient
+import main
+client = TestClient(main.app)   # NO `with` block → lifespan never runs
+```
+
+Pin this invariant with a sentinel test: the health endpoint reads
+`getattr(request.app.state, "db_statuses", {})`, and `app.state.db_statuses` is
+only set inside lifespan. So `GET /api/health` returning `databases == {}` proves
+lifespan never ran. Make the fixture self-defending against any future test that
+*does* run lifespan on the shared module-level `app`:
+`monkeypatch.delattr(main.app.state, "db_statuses", raising=False)`.
+
+### 2. Sweep for module-level path constants — including import-time captures
+
+The non-obvious hazard: patching a `DATA_DIR` in its source module does **not**
+patch copies other modules captured at import time via `from x import DATA_DIR`,
+nor constants *derived* from it (`SHARED_DATA_DIR = db.DATA_DIR`). In this codebase
+five such hazards existed beyond the obvious ones; one (`agents.router.DATA_DIR`,
+a captured copy used by delete-agent's `shutil.rmtree(DATA_DIR / slug)`) would have
+**rmtree'd the real agents directory** from a delete test. A shared `http_env`
+fixture patches every one to `tmp_path`:
+
+```python
+import agents.router as router_mod              # captured copy of engine.DATA_DIR
+import integrations.registry as registry_mod    # mkdirs on access
+import integrations.pending_setup as pending_mod # create-agent reads AND deletes it
+import core.providers.credentials as creds_mod   # chat route reads real auth-profiles
+import core.admin_settings as admin_mod          # mtime-cached settings
+import core.agents.shared_context.service as shared_service  # SHARED_DATA_DIR = db.DATA_DIR
+import core.agents.reminders.db as reminders_db  # activity log; get_db() raises if uninit
+import branding.storage as branding_storage      # public /logo route serves real file
+# ... monkeypatch.setattr each to tmp_path subdirs
+```
+
+Reminders is special: chat completion logging calls `reminders.db.get_db()`, which
+**raises `RuntimeError` when uninitialized** (and the surrounding catch is
+`(ImportError, OSError)` only), so without lifespan every chat test dies mid-stream.
+The fixture must `_setup_connection()` a tmp reminders DB.
+
+### 3. Reset LRU/instance caches in setup AND teardown
+
+`agents.engine._get_initialized_db` / `_get_initialized_memory_db` are
+`@lru_cache` keyed by slug; `core.agents.memory.db._instances` is a module dict with
+no `close()` API. Clear them at setup (so a same-named agent in a later test doesn't
+get a previous test's DB) and close+clear at teardown (so tmp-dir SQLite handles
+don't leak). Order matters: tear down `http_env` before `agent_db` so
+`close_all_agent_dbs()` runs against a still-live registry connection.
+
+### 4. Auth: override the dependency, not the token
+
+```python
+main.app.dependency_overrides[get_current_user] = lambda: {"sub": "user", "role": "admin"}
+# teardown: pop ONLY our key — app is a module-global shared across tests
+main.app.dependency_overrides.pop(get_current_user, None)
+```
+
+A patch-free `anon_client` (same `http_env`, no override) drives 401 tests.
+
+### 5. Parametrized 401 sweep — strict 401, documented allowlist
+
+Walk `main.app.routes`, keep only `APIRoute` (skips static `Mount`), substitute
+`{param}` with `"x"`, assert **strictly 401**. FastAPI resolves dependencies (where
+`get_current_user` raises) before body/path-param validation, so no body and dummy
+params still yield 401 — never a masking 422. Allowlist the intentionally tokenless
+routes with a code comment each (login, health, OAuth callback, secret-header
+webhooks). Add a separate test that no `Mount` sub-app lives under `/api` (the
+sweep can't see inside mounted sub-apps), and for each allowlisted webhook add a
+test that its alternate auth rejects a missing/wrong secret — otherwise the
+allowlist hides a "route went fully open" regression.
+
+### 6. SSE chat over TestClient
+
+`client.post(...)` buffers the finite mock stream into `.text`; parse `data: {json}`
+lines (strip before `json.loads` so a stray `\r` can't silently drop an event).
+Drive the engine with the existing `MockAIProvider` (`set_responses([turn_events])`).
+For the approved-tool resume path, send the frontend's literal `[Approved] <tool>`
+user message and record what reaches the provider — the engine strips that
+placeholder and reconstructs `tool_use`/`tool_result` blocks; a generic message
+silently bypasses the strip branch and the test passes while production leaks the
+placeholder.
+
+## Why This Matters
+
+The pattern gives fast, hermetic HTTP coverage (≈237 tests in ~2s) with zero real
+disk side effects — verified by `git status` showing nothing changed under
+`backend/data/` after a full run. The isolation sweep is the load-bearing part:
+without it, ordinary-looking CRUD tests read live credentials, leak dev
+integrations into the tool set, and can delete real agent data.
+
+## When to Apply
+
+Any FastAPI app where (a) `app` is built at import time but startup work lives in
+`lifespan`, and (b) routes touch module-level path/DB constants. Before writing the
+fixtures, grep the routes-under-test for every `DATA_DIR` / `*_PATH` / `*_FILE`
+constant they reach — directly and via import-time captures — and patch all of
+them. The auth sweep and the webhook-secret tests are cheap and catch an entire
+class of future "forgot the `Depends`" / "left the webhook open" bugs.


### PR DESCRIPTION
## Summary
- Adds the first HTTP-level tests (237 new test cases, suite total 742, runs in ~5.5s) as the safety net for the upcoming `AgentTurnRunner` refactor. Purely additive — no backend behavior changes.
- New `http_env`/`client`/`anon_client` fixtures run `TestClient(main.app)` **without** lifespan (no schedulers, no disk init) and redirect every module-level data path to `tmp_path` — including hazards the existing fixtures didn't cover: the router-level `DATA_DIR` copy used by delete-agent's `rmtree`, pending-setup file deletion on agent create, the real credential store read by the chat route, the integrations registry dir (mkdir on access), the shared-context dir read into every chat system prompt, branding logo, and the reminders/activity DB (required by chat completion logging).
- Reviewed via a 2-round Codex plan review before implementation, then a four-stage `/review-super` pipeline after (multi-persona Sonnet → Codex → Gemini → Opus, with fixes committed per stage — see commit trail).

## Route coverage added
- **`tests/test_http_agents.py`** — agent CRUD, rename-keeps-slug regression (context files intact across rename), delete (tmp-only rmtree asserted), context-file CRUD, `_safe_filename` rejections on **all three verbs** + encoded-traversal probes (including the decode-then-validate ordering guard).
- **`tests/test_http_playbooks.py`** — all 8 playbooks routes: list/get/put/delete, archive/restore, learning-events list (verifies lazy per-agent memory-DB creation over HTTP) and revert (`playbook_updated` restores before-content, `playbook_created` archives, double-revert 400).
- **`tests/test_http_chat.py`** — chat SSE with `MockAIProvider` through the real engine: event order (`conversation_id` → `text` → `done`; `tool_start` before `confirm`), write-tool confirm flow in normal mode (args/description asserted, no execution), approved-tool resume with a recording provider asserting the engine reconstructs `tool_use`/`tool_result` blocks AND strips the frontend's `[Approved]` placeholder (mutation-tested), `/tool/execute` write + non-write rejection, conversations list + FTS search after a persisted chat.
- **`tests/test_http_misc.py`** — health (asserts lifespan never ran, self-defending sentinel), login (wrong/right/rate-limited, real JWT round-trip via `/api/me`), usage summary (incl. UTC fallback), a **parametrized 401 sweep** over every mounted route (~190 cases) with a documented allowlist of the 9 intentionally tokenless routes, a guard that no `Mount` sub-app ever lands under `/api`, and webhook-auth tests for the allowlisted routes (Paperclip closed-by-default 403, WhatsApp 401 on missing/wrong `X-Api-Key`).

## Coverage boundary (deliberate)
This tier guards the **browser-chat streaming loop** end-to-end over HTTP. The other two tool-execution loops the `AgentTurnRunner` refactor will merge — `ai_service.run_sync()` (Telegram/WhatsApp/Paperclip replies) and `background_runner` (heartbeat/scheduled actions) — are not reachable synchronously over HTTP (webhooks return 200 and process in background threads) and remain essentially untested. **Direct service-level tests for `run_sync` write-tool stripping and the background runner's iteration/write semantics should land before or with the refactor.**

## Found while testing
- No bugs in the routes under test. The 401 sweep found **zero** unprotected routes beyond the intentional allowlist. No xfails/skips needed.
- Pre-existing hardening notes (not changed here): `POST /api/messaging/whatsapp/webhook` accepts requests when **no** secret is configured (`integrations/whatsapp/router.py:44-52`); Paperclip's heartbeat parses the JSON body **before** checking the shared secret (`integrations/paperclip/webhook.py:105` — auth-before-body would be stricter); chat completion logging only catches `(ImportError, OSError)` around the activity log (`core/agents/ai_service.py:787`), so an uninitialized reminders DB breaks the SSE stream.

## Test plan
- [x] `cd backend && pytest -q` — 742 passed in ~5.2s
- [x] `ruff check .` — clean
- [x] `git status` after full run — nothing changed under `backend/data/` (zero real-disk side effects)
- [x] CI (pr-checks) green