### PR TITLE
Dynamic model selection, inferred/overridable tiers, provider-aware pricing

### DIFF
--- a/.claude/skills/price-check/SKILL.md
+++ b/.claude/skills/price-check/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: price-check
+description: Verify and refresh AI model pricing in Chatty's pricing.py from official provider pricing pages, and regenerate PRICING.md. Run during any PR that touches providers or usage. Skips re-fetching if pricing was already verified earlier in the current chat. Only operates inside the Chatty repo.
+---
+
+# price-check
+
+Keeps `backend/core/providers/pricing.py` (`MODEL_PRICING` + `PRICING_SOURCES`) current with published per-token rates and regenerates the reviewable report `backend/core/providers/PRICING.md`. No provider's models API exposes price, so this skill is the maintenance mechanism that keeps the usage/cost dashboard accurate as new models are added dynamically.
+
+## When to run
+- During any PR that adds/changes models or touches `core/providers/` or `core/agents/usage/` (required by the project `CLAUDE.md` → Model Pricing).
+- On request: "check prices", "refresh model pricing", "is pricing current?".
+
+## Guard 1 — ship only in the Chatty repo
+Before writing or committing anything, confirm this is the Chatty repo:
+- `git remote -v` contains `wwilson1017/chatty`, **OR**
+- `CLAUDE.md` starts with `# Chatty` **AND** `backend/core/providers/pricing.py` exists.
+
+If neither holds, STOP: report that price-check only runs in the Chatty repo, and make no changes.
+
+## Guard 2 — skip if already verified this chat
+If model pricing was already fetched/verified earlier in THIS conversation, or `backend/core/providers/PRICING.md` already shows `Last verified: <today>` with no pending diff, do NOT re-fetch. Reuse the in-session results and report "already current". Re-fetching wastes calls and risks rate limits.
+
+## Procedure
+1. **Model set.** Union of the keys in `MODEL_PRICING` and each provider's current model list — the fallback `*_MODELS` constants, plus (if credentials are configured) what `GET /api/providers/{provider}/models` returns. This prices newly-surfaced dynamic models, not just legacy ones.
+2. **Fetch** current STANDARD-tier rates (USD per 1M input / output tokens) via WebFetch from the official pages:
+   - Anthropic — `https://platform.claude.com/docs/en/about-claude/models/overview`
+   - OpenAI — `https://developers.openai.com/api/docs/pricing`
+   - Google — `https://ai.google.dev/gemini-api/docs/pricing`
+   - Together — `https://www.together.ai/pricing`
+   Record tier caveats (e.g. Gemini 2.5 Pro is the ≤200K-prompt tier) in a code comment.
+3. **Diff** against the current `MODEL_PRICING`; classify each model: added / changed / unchanged / unverifiable.
+4. **Never fabricate.** If a model's rate isn't on the official page, leave it OUT of `MODEL_PRICING` and report it as "unknown" — the usage dashboard already flags unpriced paid models (`is_priced` / per-agent `has_unknown_pricing`). Do NOT guess from memory or community posts.
+5. **Write** `backend/core/providers/pricing.py`:
+   - `MODEL_PRICING[model] = (input, output)`
+   - `PRICING_SOURCES[model] = (source_url, "<YYYY-MM-DD>")` — use the current session date.
+   Keep proven legacy entries (the dashboard prices historical rows by model id via longest-prefix match).
+6. **Regenerate** `backend/core/providers/PRICING.md` from the updated `pricing.py` (do not hand-author divergent numbers): a header line `Last verified: <YYYY-MM-DD> (price-check)` followed by a per-provider table `model | input $/M | output $/M | source | verified`.
+7. **Report** a concise diff table to the user. When run during a PR, also place the diff in the PR description.
+
+## Commit
+- Commit `pricing.py` and `PRICING.md` together, e.g. `Refresh model pricing (price-check <YYYY-MM-DD>)`.
+- No `Co-Authored-By` or "Generated with Claude Code" footers (repo policy).
+- Never commit secrets; never run `gcloud secrets`/`--set-secrets` commands.
+
+## Notes
+- The session date is authoritative for the `verified` date — read it from the environment context, don't compute it in code.
+- This skill is committed into the Chatty repo so it travels with the project; it is the canonical place to evolve the pricing-refresh workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,16 @@ Tools appear for agents automatically when their integration is enabled globally
 
 Tools that modify external data (send email, create event, upload file) must set `writes: True` in their tool definition. Chatty's `tool_mode` system will require user confirmation before executing write tools in "normal" mode. Write tools (excluding `context_memory` tools) are also subject to per-turn write budgets and optional hourly rate limits configured in admin settings.
 
+## Model Pricing
+
+The model selector is **dynamic** — each provider's `list_models()` fetches live from the provider's API (Anthropic/OpenAI/Google/Together/Ollama), cached with a fallback to the hardcoded `*_MODELS` constants. New models appear automatically; no code change needed to add one to the dropdown.
+
+**Tiers** (top/mid/light) are inferred from model naming and persisted to `data/model-tiers.json`; the user can override them in Provider Setup. `resolve_tier_model()` stays synchronous (override → inferred → hardcoded).
+
+**Pricing is the one thing no provider API exposes**, so it is maintained manually in `backend/core/providers/pricing.py` (`MODEL_PRICING` + `PRICING_SOURCES`), mirrored to `backend/core/providers/PRICING.md`. The usage dashboard flags paid models with no price entry as "pricing unknown" (it never silently reports $0 for a paid model; only local Ollama is free).
+
+**Every PR that adds/changes models or touches `core/providers/` or `core/agents/usage/` MUST run the `price-check` skill first** (`.claude/skills/price-check/`) and include any resulting `pricing.py` / `PRICING.md` changes in the same PR. The skill pulls current rates from official pricing pages, never fabricates a rate, and skips re-fetching if pricing was already verified in the chat.
+
 ## Solution Docs
 
 Non-trivial problems solved in past sessions are written up in `docs/solutions/` (categorized, with YAML frontmatter). Search there before re-deriving a fix or pattern: `grep -ri <keyword> docs/solutions/`.

--- a/backend/core/agents/activity_log.py
+++ b/backend/core/agents/activity_log.py
@@ -39,6 +39,7 @@ def log_chat_event(
     result_summary: str = "",
     tool_calls: list | None = None,
     model_used: str = "",
+    provider: str = "",
     input_tokens: int = 0,
     output_tokens: int = 0,
     duration_ms: int = 0,
@@ -57,15 +58,15 @@ def log_chat_event(
             """INSERT INTO execution_history
                (id, action_id, agent, action_type, event_type, source,
                 conversation_id, started_at, completed_at, status,
-                result_summary, tool_calls, model_used,
+                result_summary, tool_calls, model_used, provider,
                 input_tokens, output_tokens, duration_ms)
                VALUES (?, ?, ?, 'chat', 'chat', ?,
                        ?, ?, ?, ?,
-                       ?, ?, ?,
+                       ?, ?, ?, ?,
                        ?, ?, ?)""",
             (event_id, event_id, agent, source,
              conversation_id, now, now, status,
-             result_summary[:500], tool_calls_json, model_used,
+             result_summary[:500], tool_calls_json, model_used, provider,
              input_tokens, output_tokens, duration_ms),
         )
         conn.commit()

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -762,6 +762,7 @@ def _log_chat_completion(
     total_input_tokens: int,
     total_output_tokens: int,
     chat_start_time: float,
+    provider_name: str = "",
 ) -> None:
     try:
         from core.agents.activity_log import log_chat_event
@@ -780,6 +781,7 @@ def _log_chat_completion(
             result_summary=summary,
             tool_calls=all_tool_calls or None,
             model_used=model_used,
+            provider=provider_name,
             input_tokens=total_input_tokens,
             output_tokens=total_output_tokens,
             duration_ms=int((time.time() - chat_start_time) * 1000),
@@ -836,6 +838,7 @@ async def chat(
     total_input_tokens = 0
     total_output_tokens = 0
     model_used = getattr(provider, "model", "") or ""
+    provider_name = getattr(provider, "provider_name", "") or ""
 
     # Validate tool_mode
     if tool_mode not in ("read-only", "normal", "power"):
@@ -1232,7 +1235,7 @@ async def chat(
                 if stop_reason != "tool_use" or not tool_calls_this_turn:
                     _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                         accumulated_text, all_tool_calls, model_used,
-                                        total_input_tokens, total_output_tokens, chat_start_time)
+                                        total_input_tokens, total_output_tokens, chat_start_time, provider_name)
                     if not training_mode and not plan_mode and not import_mode:
                         from core.agents.playbooks.review import maybe_schedule_review
                         maybe_schedule_review(config, conversation_id, messages,
@@ -1246,7 +1249,7 @@ async def chat(
             elif etype == "error":
                 _log_chat_completion(config.slug, conversation_id, "chat", "error",
                                     event.get("error", "Unknown error"), all_tool_calls, model_used,
-                                    total_input_tokens, total_output_tokens, chat_start_time)
+                                    total_input_tokens, total_output_tokens, chat_start_time, provider_name)
                 yield _sse({"type": "error", "error": event.get("error", "Unknown error")})
                 return
 
@@ -1254,7 +1257,7 @@ async def chat(
         if not tool_calls_this_turn:
             _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                 accumulated_text, all_tool_calls, model_used,
-                                total_input_tokens, total_output_tokens, chat_start_time)
+                                total_input_tokens, total_output_tokens, chat_start_time, provider_name)
             if not training_mode and not plan_mode and not import_mode:
                 from core.agents.playbooks.review import maybe_schedule_review
                 maybe_schedule_review(config, conversation_id, messages,
@@ -1334,7 +1337,7 @@ async def chat(
                         break
                 _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                     accumulated_text, all_tool_calls, model_used,
-                                    total_input_tokens, total_output_tokens, chat_start_time)
+                                    total_input_tokens, total_output_tokens, chat_start_time, provider_name)
                 done_event = {"type": "done", "model": model_used}
                 if triage_info:
                     done_event["tier"] = triage_info.get("tier")
@@ -1453,7 +1456,7 @@ async def chat(
                     break
             _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                 accumulated_text, all_tool_calls, model_used,
-                                total_input_tokens, total_output_tokens, chat_start_time)
+                                total_input_tokens, total_output_tokens, chat_start_time, provider_name)
             done_event = {"type": "done", "model": model_used}
             if triage_info:
                 done_event["tier"] = triage_info.get("tier")
@@ -1463,7 +1466,7 @@ async def chat(
     # Exceeded max iterations
     _log_chat_completion(config.slug, conversation_id, "chat", "error",
                         "Tool loop exceeded maximum iterations", all_tool_calls, model_used,
-                        total_input_tokens, total_output_tokens, chat_start_time)
+                        total_input_tokens, total_output_tokens, chat_start_time, provider_name)
     yield _sse({"type": "error", "error": "Tool loop exceeded maximum iterations"})
 
 
@@ -1492,6 +1495,7 @@ async def run_sync(
     """
     chat_start_time = time.time()
     model_used = getattr(provider, "model", "") or ""
+    provider_name = getattr(provider, "provider_name", "") or ""
 
     # Build tool definitions (same as streaming path)
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
@@ -1653,7 +1657,7 @@ async def run_sync(
                 logger.error("run_sync: provider error: %s", event.get("error"))
                 _log_chat_completion(config.slug, conversation_id, source, "error",
                                     event.get("error", "Provider error"), all_tool_calls, model_used,
-                                    total_input_tokens, total_output_tokens, chat_start_time)
+                                    total_input_tokens, total_output_tokens, chat_start_time, provider_name)
                 return accumulated_text or "I encountered an error. Please try again."
 
         # Save assistant turn to history (with tool calls)
@@ -1675,7 +1679,7 @@ async def run_sync(
         if stop_reason != "tool_use" or not tool_calls_this_turn:
             _log_chat_completion(config.slug, conversation_id, source, "ok",
                                 accumulated_text, all_tool_calls, model_used,
-                                total_input_tokens, total_output_tokens, chat_start_time)
+                                total_input_tokens, total_output_tokens, chat_start_time, provider_name)
             break
 
         # Execute tool calls (power mode — no confirmation flow for messaging)
@@ -1726,7 +1730,7 @@ async def run_sync(
                         pass
                     _log_chat_completion(config.slug, conversation_id, source, "error",
                                         "Write budget exceeded — turn terminated", all_tool_calls, model_used,
-                                        total_input_tokens, total_output_tokens, chat_start_time)
+                                        total_input_tokens, total_output_tokens, chat_start_time, provider_name)
                     return accumulated_text or "Write budget exceeded. Turn terminated."
 
                 if _sync_hourly_enabled and not _get_limiter().check_and_record(_sync_hourly_limit):
@@ -1772,6 +1776,6 @@ async def run_sync(
     else:
         _log_chat_completion(config.slug, conversation_id, source, "error",
                             "Tool loop exceeded maximum iterations", all_tool_calls, model_used,
-                            total_input_tokens, total_output_tokens, chat_start_time)
+                            total_input_tokens, total_output_tokens, chat_start_time, provider_name)
 
     return accumulated_text or "I had trouble generating a response. Please try again."

--- a/backend/core/agents/background_runner.py
+++ b/backend/core/agents/background_runner.py
@@ -30,6 +30,7 @@ class BackgroundResult:
     output_tokens: int = 0
     tool_log: list[dict] = field(default_factory=list)
     model_used: str = ""
+    provider: str = ""
     error: bool = False
 
 
@@ -59,6 +60,7 @@ async def _run_turn(
         return BackgroundResult(text="No AI provider configured", error=True)
 
     model_used = getattr(provider, "model", "") or ""
+    provider_name = getattr(provider, "provider_name", "") or ""
 
     # Convert tool defs to provider format (strip 'kind')
     kind_map: dict[str, str] = {}
@@ -110,7 +112,7 @@ async def _run_turn(
                     text="(lease lost -- aborted)",
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
-                    model_used=model_used,
+                    model_used=model_used, provider=provider_name,
                     tool_log=tool_log,
                     error=True,
                 )
@@ -137,7 +139,7 @@ async def _run_turn(
                         text=accumulated_text or "(provider error)",
                         input_tokens=total_input_tokens,
                         output_tokens=total_output_tokens,
-                        model_used=model_used,
+                        model_used=model_used, provider=provider_name,
                         tool_log=tool_log,
                         error=True,
                     )
@@ -147,7 +149,7 @@ async def _run_turn(
                         text=accumulated_text or "(no response)",
                         input_tokens=total_input_tokens,
                         output_tokens=total_output_tokens,
-                        model_used=model_used,
+                        model_used=model_used, provider=provider_name,
                         tool_log=tool_log,
                         error=not accumulated_text,
                     )
@@ -216,7 +218,7 @@ async def _run_turn(
                     result_str = json.dumps({"error": "Turn terminated: write budget exceeded"})
                     tool_log.append({"tool": tool_name, "args": json.dumps(tool_args)[:200], "result": result_str[:500], "duration_ms": 0})
                     results.append({"tool_use_id": tc.get("id", ""), "tool_name": tool_name, "content": result_str})
-                    return BackgroundResult(text="(terminated: write budget exceeded)", input_tokens=total_input_tokens, output_tokens=total_output_tokens, model_used=model_used, tool_log=tool_log, error=True)
+                    return BackgroundResult(text="(terminated: write budget exceeded)", input_tokens=total_input_tokens, output_tokens=total_output_tokens, model_used=model_used, provider=provider_name, tool_log=tool_log, error=True)
 
                 if _hourly_enabled and not get_limiter().check_and_record(_hourly_limit):
                     result_str = json.dumps({"error": "Hourly write rate limit exceeded."})
@@ -256,6 +258,7 @@ async def _run_turn(
         input_tokens=total_input_tokens,
         output_tokens=total_output_tokens,
         model_used=model_used,
+        provider=provider_name,
         tool_log=tool_log,
         error=True,
     )
@@ -333,6 +336,7 @@ def run_background_turn(
                 result_summary=result.text[:500],
                 tool_calls=result.tool_log or None,
                 model_used=result.model_used,
+                provider=result.provider,
                 input_tokens=result.input_tokens,
                 output_tokens=result.output_tokens,
                 duration_ms=int((time.time() - t0) * 1000),

--- a/backend/core/agents/background_runner.py
+++ b/backend/core/agents/background_runner.py
@@ -159,7 +159,7 @@ async def _run_turn(
                 text=accumulated_text or "(no response)",
                 input_tokens=total_input_tokens,
                 output_tokens=total_output_tokens,
-                model_used=model_used,
+                model_used=model_used, provider=provider_name,
                 tool_log=tool_log,
                 error=not accumulated_text,
             )

--- a/backend/core/agents/playbooks/review.py
+++ b/backend/core/agents/playbooks/review.py
@@ -292,6 +292,7 @@ async def _run_review(config, conversation_id: str | None, transcript: str) -> N
                 result_summary=(result.text or "")[:500],
                 tool_calls=result.tool_log,
                 model_used=result.model_used,
+                provider=result.provider,
                 input_tokens=result.input_tokens,
                 output_tokens=result.output_tokens,
             )

--- a/backend/core/agents/reminders/db.py
+++ b/backend/core/agents/reminders/db.py
@@ -186,6 +186,11 @@ def _setup_connection() -> None:
         _connection.execute("ALTER TABLE execution_history ADD COLUMN source TEXT DEFAULT 'system'")
     if "conversation_id" not in eh_cols:
         _connection.execute("ALTER TABLE execution_history ADD COLUMN conversation_id TEXT")
+    if "provider" not in eh_cols:
+        # AI provider for the row (anthropic/openai/google/together/ollama).
+        # Lets the usage dashboard treat only local Ollama rows as free and
+        # flag unpriced PAID models instead of silently reporting $0.
+        _connection.execute("ALTER TABLE execution_history ADD COLUMN provider TEXT")
     _connection.execute("CREATE INDEX IF NOT EXISTS idx_eh_event_type ON execution_history(event_type, started_at DESC)")
     _connection.commit()
 

--- a/backend/core/agents/scheduled_actions/history.py
+++ b/backend/core/agents/scheduled_actions/history.py
@@ -46,6 +46,7 @@ def record_complete(
     result_full: str = "",
     tool_calls: list | None = None,
     model_used: str = "",
+    provider: str = "",
     input_tokens: int = 0,
     output_tokens: int = 0,
     duration_ms: int = 0,
@@ -57,13 +58,13 @@ def record_complete(
         conn.execute(
             """UPDATE execution_history SET
                completed_at = ?, status = ?, result_summary = ?,
-               result_full = ?, tool_calls = ?, model_used = ?,
+               result_full = ?, tool_calls = ?, model_used = ?, provider = ?,
                input_tokens = ?, output_tokens = ?, duration_ms = ?,
                notification_sent = ?
                WHERE id = ?""",
             (
                 _now_utc(), status, result_summary[:500],
-                result_full[:5000], tool_calls_json, model_used,
+                result_full[:5000], tool_calls_json, model_used, provider,
                 input_tokens, output_tokens, duration_ms,
                 1 if notification_sent else 0,
                 execution_id,

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -32,11 +32,9 @@ _AGENT_TURN_ERRORS = frozenset({
     "(max iterations reached)",
 })
 
-_TRIAGE_MODELS = {
-    "anthropic": "claude-haiku-4-5-20251001",
-    "openai": "gpt-4.1-nano",
-    "google": "gemini-2.0-flash-lite",
-}
+# Triage classifier model is resolved via tiers.get_triage_classifier()
+# (override -> inferred -> hardcoded), unifying what used to be a separate,
+# drift-prone _TRIAGE_MODELS map here.
 
 # -- In-flight tracking --------------------------------------------------
 _in_flight_count = 0
@@ -424,7 +422,8 @@ def _process_heartbeat(action: dict) -> None:
         triage_model_override = model_override
         cheap_model = None
         if triage_mode in ("cheap", "always_cheap"):
-            cheap_model = _TRIAGE_MODELS.get(_resolve_triage_provider(agent))
+            from core.providers.tiers import get_triage_classifier
+            cheap_model = get_triage_classifier(_resolve_triage_provider(agent))
             if cheap_model:
                 triage_model_override = cheap_model
 
@@ -475,7 +474,7 @@ def _process_heartbeat(action: dict) -> None:
                         execution_id, status="error" if completed else "lease_lost",
                         result_summary=f"triage failed: {triage_result.text[:200]}",
                         result_full=triage_result.text,
-                        model_used=triage_result.model_used,
+                        model_used=triage_result.model_used, provider=triage_result.provider,
                         input_tokens=triage_result.input_tokens,
                         output_tokens=triage_result.output_tokens,
                         duration_ms=duration_ms,
@@ -502,7 +501,7 @@ def _process_heartbeat(action: dict) -> None:
                             result_summary="Triage: all clear",
                             result_full="Triage returned ALL_CLEAR — skipping full check.",
                             tool_calls=[{"triage": triage_data}],
-                            model_used=triage_result.model_used,
+                            model_used=triage_result.model_used, provider=triage_result.provider,
                             input_tokens=triage_result.input_tokens,
                             output_tokens=triage_result.output_tokens,
                             duration_ms=duration_ms,
@@ -629,7 +628,7 @@ def _process_heartbeat(action: dict) -> None:
                 result_summary=result.text[:500],
                 result_full=result.text,
                 tool_calls=full_tool_log,
-                model_used=result.model_used,
+                model_used=result.model_used, provider=result.provider,
                 input_tokens=total_inp,
                 output_tokens=total_out,
                 duration_ms=duration_ms,
@@ -749,7 +748,7 @@ def _process_cron(action: dict) -> None:
                 result_summary=result.text[:500],
                 result_full=result.text,
                 tool_calls=result.tool_log,
-                model_used=result.model_used,
+                model_used=result.model_used, provider=result.provider,
                 input_tokens=result.input_tokens,
                 output_tokens=result.output_tokens,
                 duration_ms=duration_ms,

--- a/backend/core/agents/usage/service.py
+++ b/backend/core/agents/usage/service.py
@@ -84,7 +84,7 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
         in_tok = row["input_tokens"] or 0
         out_tok = row["output_tokens"] or 0
         model = row["model_used"] or ""
-        provider = row["provider"] if "provider" in row.keys() else ""
+        provider = row["provider"] or ""  # column added by migration; NULL on legacy rows
         cost, unknown = _cost_and_unknown(provider, model, in_tok, out_tok)
         kind = "chat" if row["event_type"] == "chat" else "background"
 

--- a/backend/core/agents/usage/service.py
+++ b/backend/core/agents/usage/service.py
@@ -11,9 +11,25 @@ from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from core.agents.reminders import db
-from core.providers.pricing import estimate_cost
+from core.providers.pricing import estimate_cost, is_priced
 
 logger = logging.getLogger(__name__)
+
+
+def _cost_and_unknown(provider: str, model: str, in_tok: int, out_tok: int) -> tuple[float, bool]:
+    """Return (estimated_cost, pricing_unknown).
+
+    Local Ollama rows are genuinely free ($0, not flagged). Any other row whose
+    model has no published price — including paid Together and legacy rows with
+    no provider — is flagged 'unknown' rather than silently reported as $0.
+    """
+    if (provider or "").lower() == "ollama":
+        return 0.0, False
+    if not model:
+        return 0.0, False
+    if is_priced(model):
+        return estimate_cost(model, in_tok, out_tok), False
+    return 0.0, True
 
 
 def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
@@ -36,7 +52,7 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
         )
         cutoff_utc = start_day.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
 
-    query = """SELECT started_at, agent, event_type, model_used, input_tokens, output_tokens
+    query = """SELECT started_at, agent, event_type, model_used, provider, input_tokens, output_tokens
                FROM execution_history
                WHERE status != 'running'"""
     params: tuple = ()
@@ -51,6 +67,8 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
     daily: dict[str, dict] = {}
     agents: dict[str, dict] = {}
     agent_models: dict[str, Counter] = {}
+    agent_unknown: dict[str, set] = {}
+    unknown_models_all: set = set()
     earliest_day = None
 
     for row in rows:
@@ -66,7 +84,8 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
         in_tok = row["input_tokens"] or 0
         out_tok = row["output_tokens"] or 0
         model = row["model_used"] or ""
-        cost = estimate_cost(model, in_tok, out_tok)
+        provider = row["provider"] if "provider" in row.keys() else ""
+        cost, unknown = _cost_and_unknown(provider, model, in_tok, out_tok)
         kind = "chat" if row["event_type"] == "chat" else "background"
 
         totals["cost"] += cost
@@ -89,6 +108,7 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
             "slug": slug, "name": slug, "primary_model": "",
             "input_tokens": 0, "output_tokens": 0, "events": 0,
             "chat_events": 0, "background_events": 0, "cost": 0.0,
+            "has_unknown_pricing": False, "unknown_pricing_models": [],
         })
         agent["input_tokens"] += in_tok
         agent["output_tokens"] += out_tok
@@ -97,6 +117,9 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
         agent["cost"] += cost
         if model:
             agent_models.setdefault(slug, Counter())[model] += 1
+        if unknown and model:
+            agent_unknown.setdefault(slug, set()).add(model)
+            unknown_models_all.add(model)
 
     # Zero-fill missing days from the range start (or earliest seen) to today
     today_key = now_local.strftime("%Y-%m-%d")
@@ -123,6 +146,12 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
     for slug, counter in agent_models.items():
         agents[slug]["primary_model"] = counter.most_common(1)[0][0]
 
+    # Flag agents that used a paid model we have no price for
+    for slug, models in agent_unknown.items():
+        if slug in agents:
+            agents[slug]["unknown_pricing_models"] = sorted(models)
+            agents[slug]["has_unknown_pricing"] = True
+
     # Enrich display names from the agent registry
     try:
         from agents.db import list_agents
@@ -141,4 +170,5 @@ def get_usage_summary(days: int = 7, tz: str = "UTC") -> dict:
         "totals": totals,
         "daily": sorted(daily.values(), key=lambda d: d["date"]),
         "agents": sorted(agents.values(), key=lambda a: a["cost"], reverse=True),
+        "unknown_pricing_models": sorted(unknown_models_all),
     }

--- a/backend/core/providers/PRICING.md
+++ b/backend/core/providers/PRICING.md
@@ -1,0 +1,45 @@
+# Model Pricing
+
+Last verified: 2026-06-13 (price-check)
+
+USD per 1M tokens, standard / short-context tier. Generated from `pricing.py`
+(`MODEL_PRICING` + `PRICING_SOURCES`) by the `price-check` skill — do not hand-edit;
+run `price-check` to refresh. Local models (Ollama) are free; paid models without an
+entry here are flagged "pricing unknown" by the usage dashboard, never silently $0.
+
+## Anthropic
+
+| Model | Input $/M | Output $/M | Source | Verified |
+|---|---|---|---|---|
+| `claude-fable-5` | 10.00 | 50.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
+| `claude-opus-4-8` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
+| `claude-opus-4-7` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
+| `claude-opus-4-6` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
+| `claude-sonnet-4-6` | 3.00 | 15.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
+| `claude-haiku-4-5` | 1.00 | 5.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
+
+## OpenAI
+
+| Model | Input $/M | Output $/M | Source | Verified |
+|---|---|---|---|---|
+| `gpt-5.5` | 5.00 | 30.00 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-13 |
+| `gpt-5.4` | 2.50 | 15.00 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-13 |
+| `gpt-5.4-mini` | 0.75 | 4.50 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-13 |
+| `gpt-5.4-nano` | 0.20 | 1.25 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-13 |
+
+## Google
+
+| Model | Input $/M | Output $/M | Source | Verified |
+|---|---|---|---|---|
+| `gemini-2.5-pro` | 1.25 | 10.00 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
+| `gemini-2.5-flash` | 0.30 | 2.50 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
+| `gemini-2.5-flash-lite` | 0.10 | 0.40 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
+| `gemini-2.0-flash` | 0.10 | 0.40 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
+| `gemini-2.0-flash-lite` | 0.075 | 0.30 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
+
+> `gemini-2.5-pro` is the standard ≤200K-prompt tier; long prompts bill higher.
+
+## Not yet priced
+
+- **Together AI** (paid, Qwen/Llama/etc.) — pull from <https://www.together.ai/pricing> via `price-check`. Until added, Together rows are flagged "pricing unknown" in the usage dashboard (never $0).
+- **Legacy OpenAI** (`o3`, `o4-mini`, `gpt-4o`, `gpt-4o-mini`) — removed from OpenAI's current pricing page; historical usage rows referencing them flag as unknown.

--- a/backend/core/providers/__init__.py
+++ b/backend/core/providers/__init__.py
@@ -48,8 +48,8 @@ def get_ai_provider(
     if profile_name.startswith("anthropic:"):
         from core.providers.anthropic_provider import AnthropicProvider
         if profile.get("type") == "setup_token":
-            return AnthropicProvider(api_key=profile.get("token", ""), model=model or "claude-opus-4-6")
-        return AnthropicProvider(api_key=profile.get("key", ""), model=model or "claude-opus-4-6")
+            return AnthropicProvider(api_key=profile.get("token", ""), model=model or "claude-opus-4-8")
+        return AnthropicProvider(api_key=profile.get("key", ""), model=model or "claude-opus-4-8")
 
     elif profile_name.startswith("openai:"):
         from core.providers.openai_provider import OpenAIProvider
@@ -82,9 +82,9 @@ def get_ai_provider(
     elif profile_name.startswith("google:"):
         from core.providers.google_provider import GoogleProvider
         if profile.get("type") == "api_key":
-            return GoogleProvider(api_key=profile.get("key", ""), model=model or "gemini-2.0-flash-exp")
+            return GoogleProvider(api_key=profile.get("key", ""), model=model or "gemini-2.5-flash")
         access_token = profile.get("access", "")
-        return GoogleProvider(access_token=access_token, model=model or "gemini-2.0-flash-exp")
+        return GoogleProvider(access_token=access_token, model=model or "gemini-2.5-flash")
 
     elif profile_name.startswith("ollama:"):
         from core.providers.ollama_provider import OllamaProvider

--- a/backend/core/providers/anthropic_provider.py
+++ b/backend/core/providers/anthropic_provider.py
@@ -16,10 +16,12 @@ from core.providers.base import AIProvider
 
 logger = logging.getLogger(__name__)
 
+# Fallback list only — list_models() fetches live from the Anthropic Models API
+# and this is used when that call fails. Kept current by the price-check skill.
 ANTHROPIC_MODELS = [
-    "claude-opus-4-6",
+    "claude-opus-4-8",
     "claude-sonnet-4-6",
-    "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5",
 ]
 
 _CACHE_CONTROL: dict = {"type": "ephemeral"}
@@ -41,7 +43,7 @@ def _get_client(api_key: str = "", auth_token: str = "") -> anthropic.AsyncAnthr
 
 
 class AnthropicProvider(AIProvider):
-    def __init__(self, api_key: str = "", auth_token: str = "", model: str = "claude-opus-4-6"):
+    def __init__(self, api_key: str = "", auth_token: str = "", model: str = "claude-opus-4-8"):
         super().__init__(model=model)
         self.api_key = api_key
         self.auth_token = auth_token
@@ -254,8 +256,18 @@ class AnthropicProvider(AIProvider):
             {"role": "user", "content": user_content},
         ]
 
+    async def _fetch_models(self) -> list[str]:
+        client = _get_client(self.api_key, self.auth_token)
+        resp = await client.models.list(limit=1000)
+        # The Models API returns Claude chat models only (newest first).
+        return [m.id for m in resp.data]
+
     async def list_models(self) -> list[str]:
-        return ANTHROPIC_MODELS
+        from core.providers.model_listing import cache_key, cached_models, materialize_inference
+        key = cache_key("anthropic", self.api_key, self.auth_token)
+        models, is_live = await cached_models(key, self._fetch_models, ANTHROPIC_MODELS)
+        materialize_inference("anthropic", models, is_live)
+        return models
 
     async def validate(self) -> bool:
         try:

--- a/backend/core/providers/anthropic_provider.py
+++ b/backend/core/providers/anthropic_provider.py
@@ -276,7 +276,7 @@ class AnthropicProvider(AIProvider):
                 auth_token=self.auth_token or None,
             )
             client.messages.create(
-                model="claude-haiku-4-5-20251001",
+                model="claude-haiku-4-5",
                 max_tokens=1,
                 messages=[{"role": "user", "content": "hi"}],
             )

--- a/backend/core/providers/credentials.py
+++ b/backend/core/providers/credentials.py
@@ -53,7 +53,7 @@ def _resolved_default_model(provider: str) -> str:
             return top
     except Exception:
         pass
-    return _resolved_default_model(provider)
+    return PROVIDER_DEFAULTS.get(provider, "")
 
 
 class CredentialStore:

--- a/backend/core/providers/credentials.py
+++ b/backend/core/providers/credentials.py
@@ -30,9 +30,8 @@ logger = logging.getLogger(__name__)
 DATA_DIR = Path(__file__).parent.parent.parent / "data"
 PROFILES_PATH = DATA_DIR / "auth-profiles.json"
 
-# Last-resort fallback when no model is specified at connect time and live
-# listing/inference is unavailable. apply_inferred_default() (router) prefers
-# the inferred "top" model over these.
+# Last-resort fallback when no model is specified. _resolved_default_model()
+# (below) prefers the inferred "top" tier from model-tiers.json when available.
 PROVIDER_DEFAULTS = {
     "anthropic": "claude-opus-4-8",
     "openai": "gpt-5.4",

--- a/backend/core/providers/credentials.py
+++ b/backend/core/providers/credentials.py
@@ -6,7 +6,7 @@ Reads and writes data/auth-profiles.json.
 Schema:
 {
     "active_provider": "anthropic" | "openai" | "google",
-    "active_model": "claude-opus-4-6",
+    "active_model": "claude-opus-4-8",
     "profiles": {
         "anthropic:default": {"type": "api_key", "key": "sk-ant-..."}
                            | {"type": "setup_token", "token": "..."},
@@ -30,13 +30,30 @@ logger = logging.getLogger(__name__)
 DATA_DIR = Path(__file__).parent.parent.parent / "data"
 PROFILES_PATH = DATA_DIR / "auth-profiles.json"
 
+# Last-resort fallback when no model is specified at connect time and live
+# listing/inference is unavailable. apply_inferred_default() (router) prefers
+# the inferred "top" model over these.
 PROVIDER_DEFAULTS = {
-    "anthropic": "claude-opus-4-6",
+    "anthropic": "claude-opus-4-8",
     "openai": "gpt-5.4",
-    "google": "gemini-2.0-flash-exp",
+    "google": "gemini-2.5-flash",
     "ollama": "",
     "together": "Qwen/Qwen3.5-7B",
 }
+
+
+def _resolved_default_model(provider: str) -> str:
+    """Default model when none is specified: the inferred/resolved 'top' tier if
+    materialized, else the hardcoded PROVIDER_DEFAULTS. Keeps fresh connections
+    pointed at a current model even outside the connect-flow inference path."""
+    try:
+        from core.providers.model_tiers import get_resolved
+        top = get_resolved(provider).get("top")
+        if top:
+            return top
+    except Exception:
+        pass
+    return _resolved_default_model(provider)
 
 
 class CredentialStore:
@@ -110,7 +127,7 @@ class CredentialStore:
             "expires": int(time.time()) + expires_in,
         }
         self.data["active_provider"] = "openai"
-        self.data["active_model"] = model or PROVIDER_DEFAULTS.get("openai", "")
+        self.data["active_model"] = model or _resolved_default_model("openai")
         self._save()
 
     def set_setup_token(self, provider: str, token: str, model: str | None = None):
@@ -120,7 +137,7 @@ class CredentialStore:
             self.data["profiles"] = {}
         self.data["profiles"][profile_name] = {"type": "setup_token", "token": token}
         self.data["active_provider"] = provider
-        self.data["active_model"] = model or PROVIDER_DEFAULTS.get(provider, "")
+        self.data["active_model"] = model or _resolved_default_model(provider)
         self._save()
 
     def set_api_key(self, provider: str, key: str, model: str | None = None):
@@ -130,7 +147,7 @@ class CredentialStore:
             self.data["profiles"] = {}
         self.data["profiles"][profile_name] = {"type": "api_key", "key": key}
         self.data["active_provider"] = provider
-        self.data["active_model"] = model or PROVIDER_DEFAULTS.get(provider, "")
+        self.data["active_model"] = model or _resolved_default_model(provider)
         self._save()
 
     def set_oauth_tokens(
@@ -168,7 +185,7 @@ class CredentialStore:
         }
         if set_active:
             self.data["active_provider"] = provider
-            self.data["active_model"] = model or PROVIDER_DEFAULTS.get(provider, "")
+            self.data["active_model"] = model or _resolved_default_model(provider)
         self._save()
 
     def set_active_model(self, model: str):
@@ -177,14 +194,14 @@ class CredentialStore:
             self.data["active_model"] = model
         else:
             provider = self.data.get("active_provider", "")
-            self.data["active_model"] = PROVIDER_DEFAULTS.get(provider, "")
+            self.data["active_model"] = _resolved_default_model(provider)
         self._save()
 
     def set_active_provider(self, provider: str):
         """Switch active provider (must already have credentials stored)."""
         self.data["active_provider"] = provider
         if not self.data.get("active_model"):
-            self.data["active_model"] = PROVIDER_DEFAULTS.get(provider, "")
+            self.data["active_model"] = _resolved_default_model(provider)
         self._save()
 
     def remove_provider(self, provider: str):

--- a/backend/core/providers/google_provider.py
+++ b/backend/core/providers/google_provider.py
@@ -30,18 +30,19 @@ def _clean_schema(schema: dict) -> dict:
         result["items"] = _clean_schema(result["items"])
     return result
 
+# Fallback list only — list_models() fetches live from the Gemini API and this
+# is used when that call fails. Kept current by the price-check skill.
 GOOGLE_MODELS = [
-    "gemini-2.5-flash",
     "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
     "gemini-2.0-flash",
     "gemini-2.0-flash-lite",
-    "gemini-1.5-pro",
-    "gemini-1.5-flash",
 ]
 
 
 class GoogleProvider(AIProvider):
-    def __init__(self, access_token: str = "", api_key: str = "", model: str = "gemini-2.0-flash"):
+    def __init__(self, access_token: str = "", api_key: str = "", model: str = "gemini-2.5-flash"):
         super().__init__(model=model)
         self.access_token = access_token
         self.api_key = api_key
@@ -239,8 +240,33 @@ class GoogleProvider(AIProvider):
 
         return messages + [assistant_msg, user_msg]
 
+    async def _fetch_models(self) -> list[str]:
+        import asyncio
+        import google.generativeai as genai
+        if self.api_key:
+            genai.configure(api_key=self.api_key)
+        else:
+            from google.oauth2.credentials import Credentials
+            genai.configure(credentials=Credentials(token=self.access_token))
+
+        def _list() -> list[str]:
+            out = []
+            for m in genai.list_models():
+                methods = getattr(m, "supported_generation_methods", []) or []
+                if "generateContent" not in methods:
+                    continue
+                name = m.name
+                out.append(name[len("models/"):] if name.startswith("models/") else name)
+            return out
+
+        return await asyncio.to_thread(_list)
+
     async def list_models(self) -> list[str]:
-        return GOOGLE_MODELS
+        from core.providers.model_listing import cache_key, cached_models, materialize_inference
+        key = cache_key("google", self.api_key, self.access_token)
+        models, is_live = await cached_models(key, self._fetch_models, GOOGLE_MODELS)
+        materialize_inference("google", models, is_live)
+        return models
 
     async def validate(self) -> bool:
         try:

--- a/backend/core/providers/model_listing.py
+++ b/backend/core/providers/model_listing.py
@@ -17,6 +17,7 @@ import asyncio
 import hashlib
 import logging
 import time
+import weakref
 from typing import Awaitable, Callable
 
 logger = logging.getLogger(__name__)
@@ -27,14 +28,17 @@ DEFAULT_TTL = 12 * 60 * 60
 
 # key -> (monotonic_timestamp, models)
 _cache: dict[str, tuple[float, list[str]]] = {}
-# key -> asyncio.Lock for single-flight (avoid concurrent cold fetches per key)
-_locks: dict[str, asyncio.Lock] = {}
+# key -> asyncio.Lock for single-flight (avoid concurrent cold fetches per key).
+# WeakValueDictionary so locks are reclaimed once no coroutine holds one — the
+# dict can't grow unboundedly as credentials rotate (each rotation = a new key).
+_locks: "weakref.WeakValueDictionary[str, asyncio.Lock]" = weakref.WeakValueDictionary()
 
 
 def _lock_for(key: str) -> asyncio.Lock:
     lock = _locks.get(key)
     if lock is None:
-        lock = _locks[key] = asyncio.Lock()
+        lock = asyncio.Lock()
+        _locks[key] = lock  # caller holds a strong ref via `async with`, so it survives
     return lock
 
 

--- a/backend/core/providers/model_listing.py
+++ b/backend/core/providers/model_listing.py
@@ -1,0 +1,97 @@
+"""Chatty — shared TTL cache for provider model lists.
+
+Wraps a provider's live "list models" call so the model dropdown doesn't hit
+the provider API on every open, and so tier inference can tell a genuine live
+fetch from a fallback. Only genuine live fetches are allowed to overwrite
+inferred tiers (see tiers.infer_tier_models / model_tiers.set_inferred) — a
+transient API failure returns the stale fallback and must NOT clobber good
+inferred tiers.
+
+Mirrors the existing per-module cache pattern (anthropic_provider._client_cache,
+OllamaProvider._tool_support_cache).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+# 12h — model catalogs change rarely; the price-check skill / connect flow
+# can invalidate explicitly when a fresher read is wanted.
+DEFAULT_TTL = 12 * 60 * 60
+
+# key -> (monotonic_timestamp, models)
+_cache: dict[str, tuple[float, list[str]]] = {}
+
+
+def cache_key(provider: str, *secrets: str) -> str:
+    """Build a cache key from provider + a hash of its credential(s).
+
+    Hashing keeps the secret out of the key while still segmenting the cache
+    per credential, so rotating a key naturally busts the cache.
+    """
+    digest = hashlib.sha256("\x00".join(s or "" for s in secrets).encode()).hexdigest()[:16]
+    return f"{provider}:{digest}"
+
+
+async def cached_models(
+    key: str,
+    fetch_fn: Callable[[], Awaitable[list[str]]],
+    fallback: list[str],
+    ttl: float = DEFAULT_TTL,
+) -> tuple[list[str], bool]:
+    """Return ``(models, is_live)``.
+
+    ``is_live`` is True ONLY when this call performed a genuine, successful
+    live fetch (fresh, non-empty result from ``fetch_fn``). Cache hits,
+    last-good-after-error, and ``fallback`` all return ``is_live=False`` so
+    callers never persist inferred tiers from stale data.
+    """
+    now = time.monotonic()
+    cached = _cache.get(key)
+    if cached is not None and (now - cached[0]) < ttl:
+        return list(cached[1]), False
+
+    try:
+        models = await fetch_fn()
+    except Exception as e:
+        logger.warning("Live model listing for %s failed: %s", key, e)
+        models = None
+
+    if models:
+        _cache[key] = (now, list(models))
+        return list(models), True
+
+    # Empty or errored fetch → last-good cache, else hardcoded fallback.
+    if cached is not None:
+        logger.info("Model listing for %s empty/failed; serving last-good cache", key)
+        return list(cached[1]), False
+    logger.info("Model listing for %s empty/failed; serving hardcoded fallback", key)
+    return list(fallback), False
+
+
+def invalidate(key: str) -> None:
+    """Drop a cached entry (e.g. right after a credential change)."""
+    _cache.pop(key, None)
+
+
+def materialize_inference(provider: str, models: list[str], is_live: bool) -> None:
+    """Persist name-inferred tier defaults for a provider — ONLY on a live fetch.
+
+    Called by each provider's list_models() after cached_models(). Skipping when
+    ``is_live`` is False is what prevents a transient API failure (which returns
+    the stale fallback) from overwriting good inferred tiers in the store.
+    """
+    if not is_live:
+        return
+    try:
+        from core.providers import model_tiers
+        from core.providers.tiers import infer_tier_models
+
+        model_tiers.set_inferred(provider, infer_tier_models(provider, models))
+    except Exception as e:  # never let inference break the dropdown
+        logger.warning("Tier inference/persist for %s failed: %s", provider, e)

--- a/backend/core/providers/model_listing.py
+++ b/backend/core/providers/model_listing.py
@@ -13,6 +13,7 @@ OllamaProvider._tool_support_cache).
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import time
@@ -26,6 +27,15 @@ DEFAULT_TTL = 12 * 60 * 60
 
 # key -> (monotonic_timestamp, models)
 _cache: dict[str, tuple[float, list[str]]] = {}
+# key -> asyncio.Lock for single-flight (avoid concurrent cold fetches per key)
+_locks: dict[str, asyncio.Lock] = {}
+
+
+def _lock_for(key: str) -> asyncio.Lock:
+    lock = _locks.get(key)
+    if lock is None:
+        lock = _locks[key] = asyncio.Lock()
+    return lock
 
 
 def cache_key(provider: str, *secrets: str) -> str:
@@ -56,22 +66,31 @@ async def cached_models(
     if cached is not None and (now - cached[0]) < ttl:
         return list(cached[1]), False
 
-    try:
-        models = await fetch_fn()
-    except Exception as e:
-        logger.warning("Live model listing for %s failed: %s", key, e)
-        models = None
+    # Single-flight: serialize concurrent cold/expired fetches for the same key
+    # so we don't fan out to the provider API (and race set_inferred writes).
+    async with _lock_for(key):
+        # Re-check — another coroutine may have refreshed while we waited.
+        now = time.monotonic()
+        cached = _cache.get(key)
+        if cached is not None and (now - cached[0]) < ttl:
+            return list(cached[1]), False
 
-    if models:
-        _cache[key] = (now, list(models))
-        return list(models), True
+        try:
+            models = await fetch_fn()
+        except Exception as e:
+            logger.warning("Live model listing for %s failed: %s", key, e)
+            models = None
 
-    # Empty or errored fetch → last-good cache, else hardcoded fallback.
-    if cached is not None:
-        logger.info("Model listing for %s empty/failed; serving last-good cache", key)
-        return list(cached[1]), False
-    logger.info("Model listing for %s empty/failed; serving hardcoded fallback", key)
-    return list(fallback), False
+        if models:
+            _cache[key] = (now, list(models))
+            return list(models), True
+
+        # Empty or errored fetch → last-good cache, else hardcoded fallback.
+        if cached is not None:
+            logger.info("Model listing for %s empty/failed; serving last-good cache", key)
+            return list(cached[1]), False
+        logger.info("Model listing for %s empty/failed; serving hardcoded fallback", key)
+        return list(fallback), False
 
 
 def invalidate(key: str) -> None:

--- a/backend/core/providers/model_tiers.py
+++ b/backend/core/providers/model_tiers.py
@@ -1,0 +1,91 @@
+"""Chatty — per-provider tier assignments (inferred defaults + user overrides).
+
+The tier system (top/mid/light) must resolve *synchronously* because
+resolve_tier_model() is called from synchronous code paths (get_ai_provider,
+agents/router). The provider model APIs are async, so we can't list models at
+resolution time. Instead:
+
+  * the async listing path materializes name-based inference into this store
+    (set_inferred), only on a genuine live fetch; and
+  * the user's explicit choices are stored as overrides (set_overrides).
+
+resolve_tier_model() then reads this store synchronously:
+    per-tier override -> inferred -> hardcoded TIER_MODELS fallback.
+
+Stored in plaintext data/model-tiers.json (not a secret). A module-level lock
+guards only the read-modify-write of the JSON file — never held across async
+or network work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+
+from core.storage import atomic_write_json
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).parent.parent.parent / "data"
+TIERS_PATH = DATA_DIR / "model-tiers.json"
+
+TIERS = ("top", "mid", "light")
+_lock = threading.Lock()
+
+
+def _load() -> dict:
+    if TIERS_PATH.exists():
+        try:
+            return json.loads(TIERS_PATH.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.error("Failed to read model-tiers.json: %s", e)
+    return {}
+
+
+def get_resolved(provider: str) -> dict[str, str]:
+    """Return {top, mid, light} using override -> inferred -> hardcoded fallback."""
+    from core.providers.tiers import TIER_MODELS
+
+    entry = _load().get(provider, {}) or {}
+    overrides = entry.get("overrides", {}) or {}
+    inferred = entry.get("inferred", {}) or {}
+    fallback = TIER_MODELS.get(provider, {})
+    return {
+        t: overrides.get(t) or inferred.get(t) or fallback.get(t, "")
+        for t in TIERS
+    }
+
+
+def get_overrides(provider: str) -> dict[str, str]:
+    return (_load().get(provider, {}) or {}).get("overrides", {}) or {}
+
+
+def set_inferred(provider: str, mapping: dict[str, str]) -> None:
+    """Persist the name-inferred tier defaults for a provider (live-fetch only)."""
+    with _lock:
+        data = _load()
+        entry = data.setdefault(provider, {})
+        entry["inferred"] = {t: mapping[t] for t in TIERS if mapping.get(t)}
+        atomic_write_json(TIERS_PATH, data)
+
+
+def set_overrides(provider: str, mapping: dict[str, str | None]) -> None:
+    """Persist user tier overrides. A falsy value for a tier clears that override.
+
+    Only the tier keys present in ``mapping`` are touched; others are left as-is.
+    """
+    with _lock:
+        data = _load()
+        entry = data.setdefault(provider, {})
+        overrides = entry.get("overrides", {}) or {}
+        for t in TIERS:
+            if t in mapping:
+                value = mapping[t]
+                if value:
+                    overrides[t] = value
+                else:
+                    overrides.pop(t, None)
+        entry["overrides"] = overrides
+        atomic_write_json(TIERS_PATH, data)

--- a/backend/core/providers/model_tiers.py
+++ b/backend/core/providers/model_tiers.py
@@ -62,12 +62,21 @@ def get_overrides(provider: str) -> dict[str, str]:
     return (_load().get(provider, {}) or {}).get("overrides", {}) or {}
 
 
+# Sanity cap on persisted model ids — guards against a misbehaving/compromised
+# provider API returning absurd strings (matches the override length check).
+_MAX_MODEL_ID_LEN = 200
+
+
 def set_inferred(provider: str, mapping: dict[str, str]) -> None:
     """Persist the name-inferred tier defaults for a provider (live-fetch only)."""
     with _lock:
         data = _load()
         entry = data.setdefault(provider, {})
-        entry["inferred"] = {t: mapping[t] for t in TIERS if mapping.get(t)}
+        entry["inferred"] = {
+            t: mapping[t]
+            for t in TIERS
+            if mapping.get(t) and len(mapping[t]) <= _MAX_MODEL_ID_LEN
+        }
         atomic_write_json(TIERS_PATH, data)
 
 

--- a/backend/core/providers/openai_provider.py
+++ b/backend/core/providers/openai_provider.py
@@ -30,17 +30,32 @@ def _ensure_array_items(schema: dict) -> dict:
         result["items"] = _ensure_array_items(result["items"])
     return result
 
+# Fallback list only — list_models() fetches live from the OpenAI Models API
+# and this is used when that call fails. Kept current by the price-check skill.
 OPENAI_MODELS = [
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.4-nano",
-    "o3",
-    "o4-mini",
-    "gpt-4o",
-    "gpt-4o-mini",
 ]
 
 CHATGPT_PROXY_URL = "http://127.0.0.1:9877/v1"
+
+# OpenAI's /v1/models exposes no capability flag, so chat-vs-not is heuristic:
+# a conservative prefix allowlist minus obvious non-chat substrings. The
+# hardcoded OPENAI_MODELS fallback is the known-good safety net.
+_OPENAI_CHAT_PREFIXES = ("gpt-", "o1", "o3", "o4", "chatgpt-")
+_OPENAI_EXCLUDE = (
+    "embedding", "tts", "whisper", "audio", "realtime",
+    "image", "moderation", "-instruct", "dall-e", "search", "transcribe",
+)
+
+
+def _is_openai_chat_model(model_id: str) -> bool:
+    low = model_id.lower()
+    if not low.startswith(_OPENAI_CHAT_PREFIXES):
+        return False
+    return not any(token in low for token in _OPENAI_EXCLUDE)
 
 
 class OpenAIProvider(AIProvider):
@@ -221,17 +236,30 @@ class OpenAIProvider(AIProvider):
 
         return messages + [assistant_msg] + result_msgs
 
+    async def _fetch_models(self) -> list[str]:
+        client = openai.AsyncOpenAI(**self._build_client_kwargs())
+        resp = await client.models.list()
+        ids = [m.id for m in resp.data if _is_openai_chat_model(m.id)]
+        # Roughly newest-first (gpt-5.5 > gpt-5.4 > gpt-4o > o3...).
+        return sorted(ids, reverse=True)
+
     async def list_models(self) -> list[str]:
-        return OPENAI_MODELS
+        from core.providers.model_listing import cache_key, cached_models, materialize_inference
+        # use_chatgpt_api routes through a local proxy that may not implement
+        # /v1/models; on failure cached_models falls back to OPENAI_MODELS.
+        key = cache_key("openai", self.access_token, str(self.use_chatgpt_api))
+        models, is_live = await cached_models(key, self._fetch_models, OPENAI_MODELS)
+        materialize_inference("openai", models, is_live)
+        return models
 
     async def validate(self) -> bool:
         try:
             client = openai.OpenAI(**self._build_client_kwargs())
-            model = "gpt-4o-mini"
+            model = "gpt-5.4-nano"
             client.chat.completions.create(
                 model=model,
                 messages=[{"role": "user", "content": "hi"}],
-                max_tokens=1,
+                max_completion_tokens=1,
             )
             return True
         except Exception:

--- a/backend/core/providers/pricing.py
+++ b/backend/core/providers/pricing.py
@@ -1,8 +1,14 @@
 """Chatty — Model pricing definitions and cost estimation.
 
-Static USD-per-million-token prices for known models. Hardcoded,
-updated occasionally when providers change published prices.
-Unknown models (including local/Ollama) estimate to $0.00.
+Static USD-per-million-token prices for known models. This table is the
+runtime source of truth; it is kept current by the `price-check` skill
+(see .claude/skills/price-check/) and mirrored to PRICING.md for review.
+Do NOT hand-edit speculative numbers — run price-check, which pulls from
+official provider pricing pages. Unknown PAID models are flagged by the
+usage dashboard (not silently $0); local/free models (Ollama) are $0.
+
+Pricing tiers used: standard / short-context. Note Gemini 2.5 Pro is the
+<=200K-prompt tier (long prompts bill higher).
 """
 
 from __future__ import annotations
@@ -10,9 +16,44 @@ from __future__ import annotations
 
 # model id -> (input_usd_per_mtok, output_usd_per_mtok)
 MODEL_PRICING: dict[str, tuple[float, float]] = {
+    # Anthropic
+    "claude-fable-5":    (10.00, 50.00),
+    "claude-opus-4-8":   (5.00, 25.00),
+    "claude-opus-4-7":   (5.00, 25.00),
     "claude-opus-4-6":   (5.00, 25.00),
     "claude-sonnet-4-6": (3.00, 15.00),
     "claude-haiku-4-5":  (1.00, 5.00),
+    # OpenAI
+    "gpt-5.5":           (5.00, 30.00),
+    "gpt-5.4":           (2.50, 15.00),
+    "gpt-5.4-mini":      (0.75, 4.50),
+    "gpt-5.4-nano":      (0.20, 1.25),
+    # Google (Gemini 2.5 Pro = standard <=200K-prompt tier)
+    "gemini-2.5-pro":        (1.25, 10.00),
+    "gemini-2.5-flash":      (0.30, 2.50),
+    "gemini-2.5-flash-lite": (0.10, 0.40),
+    "gemini-2.0-flash":      (0.10, 0.40),
+    "gemini-2.0-flash-lite": (0.075, 0.30),
+}
+
+# model id -> (source_url, verified_date). Maintained by the price-check skill;
+# every MODEL_PRICING entry should have a corresponding source here.
+PRICING_SOURCES: dict[str, tuple[str, str]] = {
+    "claude-fable-5":    ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
+    "claude-opus-4-8":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
+    "claude-opus-4-7":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
+    "claude-opus-4-6":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
+    "claude-sonnet-4-6": ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
+    "claude-haiku-4-5":  ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
+    "gpt-5.5":           ("https://developers.openai.com/api/docs/pricing", "2026-06-13"),
+    "gpt-5.4":           ("https://developers.openai.com/api/docs/pricing", "2026-06-13"),
+    "gpt-5.4-mini":      ("https://developers.openai.com/api/docs/pricing", "2026-06-13"),
+    "gpt-5.4-nano":      ("https://developers.openai.com/api/docs/pricing", "2026-06-13"),
+    "gemini-2.5-pro":        ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
+    "gemini-2.5-flash":      ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
+    "gemini-2.5-flash-lite": ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
+    "gemini-2.0-flash":      ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
+    "gemini-2.0-flash-lite": ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
 }
 
 
@@ -42,3 +83,14 @@ def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
         return 0.0
     in_price, out_price = pricing
     return (input_tokens * in_price + output_tokens * out_price) / 1_000_000
+
+
+def is_priced(model: str) -> bool:
+    """True if we have a published price for this model.
+
+    Used by the usage dashboard to flag "pricing unknown" PAID models
+    instead of silently reporting $0.00. Note: a False result for a
+    local/free model (Ollama) is expected and handled by the caller,
+    which keys off the row's provider rather than the model name.
+    """
+    return get_model_pricing(model) is not None

--- a/backend/core/providers/router.py
+++ b/backend/core/providers/router.py
@@ -48,10 +48,11 @@ async def get_tiers(user=Depends(get_current_user)):
     from core.providers.model_tiers import get_resolved
     store = CredentialStore()
     providers = list(TIER_MODELS.keys())
+    tier_models = {p: get_resolved(p) for p in providers}
     return {
         "active_provider": store.data.get("active_provider", ""),
-        "tier_models": {p: get_resolved(p) for p in providers},
-        "tier_labels": {p: derive_tier_labels(p) for p in providers},
+        "tier_models": tier_models,
+        "tier_labels": {p: derive_tier_labels(p, tier_models[p]) for p in providers},
         "auto_triage_providers": [p for p in providers if supports_auto_triage(p)],
     }
 

--- a/backend/core/providers/router.py
+++ b/backend/core/providers/router.py
@@ -102,27 +102,24 @@ async def set_tiers(body: SetTiersRequest, user=Depends(get_current_user)):
 
 # ── Inferred default model after a credential save ────────────────────────────
 
-async def _apply_inferred_default(provider_name: str, fallback_model: str = "") -> str:
-    """After credentials are saved: live-list models (which materializes inferred
-    tiers via list_models) and set active_model to the inferred 'top' model.
+async def _materialize_inferred_tiers(provider_name: str, requested_model: str = "") -> str:
+    """After credentials are saved: live-list models so the inferred tier defaults
+    get materialized into the tier store (list_models persists them on a live fetch),
+    giving the tier picker good defaults.
 
-    Best-effort — if listing/inference fails, active_model keeps whatever value
-    the preceding store.set_*() call assigned (the request default / PROVIDER_DEFAULTS).
-    Returns the chosen model id for the response body.
+    Deliberately does NOT change the user's active model — that was set by the
+    preceding store.set_*() to the requested/curated model. Overriding it with the
+    inferred 'top' would ignore an explicit choice and flip cost-sensitive defaults
+    (e.g. Google → Pro). Returns the model to echo in the response body.
     """
     from core.providers import get_ai_provider
-    from core.providers.tiers import resolve_tier_model
     try:
         provider = get_ai_provider(agent_provider=provider_name)
         if provider is not None:
             await provider.list_models()  # live fetch -> materialize inferred tiers
-            top = resolve_tier_model(provider_name, "top")
-            if top:
-                CredentialStore().set_active_model(top)
-                return top
     except Exception as e:
-        logger.warning("apply_inferred_default(%s) failed: %s", provider_name, e)
-    return fallback_model
+        logger.warning("Tier materialization for %s failed: %s", provider_name, e)
+    return requested_model or CredentialStore().data.get("active_model", "")
 
 
 # ── Connect Anthropic (API key) ───────────────────────────────────────────────
@@ -142,7 +139,7 @@ async def connect_anthropic(body: AnthropicConnectRequest, user=Depends(get_curr
 
     store = CredentialStore()
     store.set_api_key("anthropic", body.api_key, model=body.model)
-    model = await _apply_inferred_default("anthropic", body.model)
+    model = await _materialize_inferred_tiers("anthropic", body.model)
     return {"ok": True, "provider": "anthropic", "model": model}
 
 
@@ -162,7 +159,7 @@ async def connect_anthropic_token(body: SetupTokenRequest, user=Depends(get_curr
 
     store = CredentialStore()
     store.set_setup_token("anthropic", body.token, model=body.model)
-    model = await _apply_inferred_default("anthropic", body.model)
+    model = await _materialize_inferred_tiers("anthropic", body.model)
     return {"ok": True, "provider": "anthropic", "model": model}
 
 
@@ -204,7 +201,7 @@ async def connect_google_complete(body: CompleteOAuthRequest, user=Depends(get_c
         expires_in=tokens["expires_in"],
         model="gemini-2.5-flash",
     )
-    await _apply_inferred_default("google", "gemini-2.5-flash")
+    await _materialize_inferred_tiers("google", "gemini-2.5-flash")
     return {"ok": True, "provider": "google"}
 
 
@@ -223,7 +220,7 @@ async def connect_google_key(body: GoogleKeyRequest, user=Depends(get_current_us
 
     store = CredentialStore()
     store.set_api_key("google", body.api_key, model=body.model)
-    model = await _apply_inferred_default("google", body.model)
+    model = await _materialize_inferred_tiers("google", body.model)
     return {"ok": True, "provider": "google", "model": model}
 
 
@@ -242,7 +239,7 @@ async def connect_openai_key(body: OpenAIKeyRequest, user=Depends(get_current_us
 
     store = CredentialStore()
     store.set_api_key("openai", body.api_key, model=body.model)
-    model = await _apply_inferred_default("openai", body.model)
+    model = await _materialize_inferred_tiers("openai", body.model)
     return {"ok": True, "provider": "openai", "model": model}
 
 
@@ -274,7 +271,7 @@ async def connect_openai_complete(body: CompleteOAuthRequest, user=Depends(get_c
         expires_in=tokens.get("expires_in", 3600),
         model="gpt-5.4",
     )
-    await _apply_inferred_default("openai", "gpt-5.4")
+    await _materialize_inferred_tiers("openai", "gpt-5.4")
     return {"ok": True, "provider": "openai"}
 
 
@@ -337,7 +334,7 @@ async def connect_together(body: TogetherConnectRequest, user=Depends(get_curren
 
     store = CredentialStore()
     store.set_api_key("together", body.api_key, model=body.model)
-    model = await _apply_inferred_default("together", body.model)
+    model = await _materialize_inferred_tiers("together", body.model)
     return {"ok": True, "provider": "together", "model": model}
 
 
@@ -443,7 +440,7 @@ async def sync_openai_cli(user=Depends(get_current_user)):
                 if await provider.validate():
                     store = CredentialStore()
                     store.set_api_key("openai", api_key, model="gpt-5.4")
-                    await _apply_inferred_default("openai", "gpt-5.4")
+                    await _materialize_inferred_tiers("openai", "gpt-5.4")
                     return {"ok": True, "provider": "openai", "source": str(cred_path)}
 
             # ChatGPT mode: validate via the Node.js proxy sidecar
@@ -467,7 +464,7 @@ async def sync_openai_cli(user=Depends(get_current_user)):
                                 refresh_token=refresh_token,
                                 expires_in=864000,  # ~10 days
                             )
-                            await _apply_inferred_default("openai", "gpt-5.4")
+                            await _materialize_inferred_tiers("openai", "gpt-5.4")
                             return {"ok": True, "provider": "openai", "source": str(cred_path), "mode": "chatgpt"}
                         else:
                             raise HTTPException(status_code=400, detail=result.get("error", "Token validation failed"))

--- a/backend/core/providers/router.py
+++ b/backend/core/providers/router.py
@@ -38,22 +38,98 @@ async def get_providers(user=Depends(get_current_user)):
 
 @router.get("/tiers")
 async def get_tiers(user=Depends(get_current_user)):
-    """Return tier configuration for all providers."""
-    from core.providers.tiers import TIER_MODELS, TIER_LABELS, supports_auto_triage
+    """Return resolved tier configuration for all providers.
+
+    Cheap and store-only — does NOT list models live (the tier picker fetches
+    options from GET /{provider}/models, which is cached). tier_models reflect
+    override -> inferred -> hardcoded; tier_labels are always non-empty.
+    """
+    from core.providers.tiers import TIER_MODELS, supports_auto_triage, derive_tier_labels
+    from core.providers.model_tiers import get_resolved
     store = CredentialStore()
+    providers = list(TIER_MODELS.keys())
     return {
         "active_provider": store.data.get("active_provider", ""),
-        "tier_models": TIER_MODELS,
-        "tier_labels": TIER_LABELS,
-        "auto_triage_providers": [p for p in TIER_MODELS if supports_auto_triage(p)],
+        "tier_models": {p: get_resolved(p) for p in providers},
+        "tier_labels": {p: derive_tier_labels(p) for p in providers},
+        "auto_triage_providers": [p for p in providers if supports_auto_triage(p)],
     }
+
+
+class SetTiersRequest(BaseModel):
+    provider: str
+    models: dict[str, str]  # subset of {top,mid,light} -> model id ("" clears the override)
+
+
+@router.put("/tiers")
+async def set_tiers(body: SetTiersRequest, user=Depends(get_current_user)):
+    """Persist user tier overrides for a provider.
+
+    Validates the requested model ids against the provider's current model list
+    BEFORE writing (the model_tiers store lock is held only for the JSON write,
+    never across the async list call)."""
+    from core.providers.tiers import TIER_MODELS
+    from core.providers import model_tiers, get_ai_provider
+
+    if body.provider not in TIER_MODELS:
+        raise HTTPException(status_code=400, detail=f"Unknown provider: {body.provider}")
+    bad_keys = set(body.models) - {"top", "mid", "light"}
+    if bad_keys:
+        raise HTTPException(status_code=400, detail=f"Invalid tier keys: {sorted(bad_keys)}")
+
+    nonempty = {t: m for t, m in body.models.items() if m}
+    if nonempty:
+        provider = get_ai_provider(agent_provider=body.provider)
+        if provider is None:
+            raise HTTPException(status_code=400, detail=f"Provider not configured: {body.provider}")
+        available = await provider.list_models()  # cached; not under the store lock
+        for tier, model in nonempty.items():
+            if len(model) > 200:
+                raise HTTPException(status_code=400, detail=f"Model id too long for tier '{tier}'")
+            if model not in available:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"'{model}' is not an available {body.provider} model",
+                )
+
+    model_tiers.set_overrides(body.provider, body.models)
+    return {
+        "ok": True,
+        "provider": body.provider,
+        "tier_models": model_tiers.get_resolved(body.provider),
+    }
+
+
+# ── Inferred default model after a credential save ────────────────────────────
+
+async def _apply_inferred_default(provider_name: str, fallback_model: str = "") -> str:
+    """After credentials are saved: live-list models (which materializes inferred
+    tiers via list_models) and set active_model to the inferred 'top' model.
+
+    Best-effort — if listing/inference fails, active_model keeps whatever value
+    the preceding store.set_*() call assigned (the request default / PROVIDER_DEFAULTS).
+    Returns the chosen model id for the response body.
+    """
+    from core.providers import get_ai_provider
+    from core.providers.tiers import resolve_tier_model
+    try:
+        provider = get_ai_provider(agent_provider=provider_name)
+        if provider is not None:
+            await provider.list_models()  # live fetch -> materialize inferred tiers
+            top = resolve_tier_model(provider_name, "top")
+            if top:
+                CredentialStore().set_active_model(top)
+                return top
+    except Exception as e:
+        logger.warning("apply_inferred_default(%s) failed: %s", provider_name, e)
+    return fallback_model
 
 
 # ── Connect Anthropic (API key) ───────────────────────────────────────────────
 
 class AnthropicConnectRequest(BaseModel):
     api_key: str
-    model: str = "claude-opus-4-6"
+    model: str = "claude-opus-4-8"
 
 
 @router.post("/anthropic/connect")
@@ -66,12 +142,13 @@ async def connect_anthropic(body: AnthropicConnectRequest, user=Depends(get_curr
 
     store = CredentialStore()
     store.set_api_key("anthropic", body.api_key, model=body.model)
-    return {"ok": True, "provider": "anthropic", "model": body.model}
+    model = await _apply_inferred_default("anthropic", body.model)
+    return {"ok": True, "provider": "anthropic", "model": model}
 
 
 class SetupTokenRequest(BaseModel):
     token: str
-    model: str = "claude-opus-4-6"
+    model: str = "claude-opus-4-8"
 
 
 @router.post("/anthropic/setup-token")
@@ -85,7 +162,8 @@ async def connect_anthropic_token(body: SetupTokenRequest, user=Depends(get_curr
 
     store = CredentialStore()
     store.set_setup_token("anthropic", body.token, model=body.model)
-    return {"ok": True, "provider": "anthropic", "model": body.model}
+    model = await _apply_inferred_default("anthropic", body.model)
+    return {"ok": True, "provider": "anthropic", "model": model}
 
 
 # ── Connect Google / OpenAI (PKCE OAuth) ─────────────────────────────────────
@@ -124,14 +202,15 @@ async def connect_google_complete(body: CompleteOAuthRequest, user=Depends(get_c
         access_token=tokens["access_token"],
         refresh_token=tokens["refresh_token"],
         expires_in=tokens["expires_in"],
-        model="gemini-2.0-flash-exp",
+        model="gemini-2.5-flash",
     )
+    await _apply_inferred_default("google", "gemini-2.5-flash")
     return {"ok": True, "provider": "google"}
 
 
 class GoogleKeyRequest(BaseModel):
     api_key: str
-    model: str = "gemini-2.0-flash-exp"
+    model: str = "gemini-2.5-flash"
 
 
 @router.post("/google/connect-key")
@@ -144,7 +223,8 @@ async def connect_google_key(body: GoogleKeyRequest, user=Depends(get_current_us
 
     store = CredentialStore()
     store.set_api_key("google", body.api_key, model=body.model)
-    return {"ok": True, "provider": "google", "model": body.model}
+    model = await _apply_inferred_default("google", body.model)
+    return {"ok": True, "provider": "google", "model": model}
 
 
 class OpenAIKeyRequest(BaseModel):
@@ -162,7 +242,8 @@ async def connect_openai_key(body: OpenAIKeyRequest, user=Depends(get_current_us
 
     store = CredentialStore()
     store.set_api_key("openai", body.api_key, model=body.model)
-    return {"ok": True, "provider": "openai", "model": body.model}
+    model = await _apply_inferred_default("openai", body.model)
+    return {"ok": True, "provider": "openai", "model": model}
 
 
 @router.post("/openai/connect")
@@ -193,6 +274,7 @@ async def connect_openai_complete(body: CompleteOAuthRequest, user=Depends(get_c
         expires_in=tokens.get("expires_in", 3600),
         model="gpt-5.4",
     )
+    await _apply_inferred_default("openai", "gpt-5.4")
     return {"ok": True, "provider": "openai"}
 
 
@@ -255,7 +337,8 @@ async def connect_together(body: TogetherConnectRequest, user=Depends(get_curren
 
     store = CredentialStore()
     store.set_api_key("together", body.api_key, model=body.model)
-    return {"ok": True, "provider": "together", "model": body.model}
+    model = await _apply_inferred_default("together", body.model)
+    return {"ok": True, "provider": "together", "model": model}
 
 
 # ── Disconnect ────────────────────────────────────────────────────────────────
@@ -325,6 +408,7 @@ async def refresh_google(user=Depends(get_current_user)):
         access_token=tokens["access_token"],
         refresh_token=refresh_token,  # keep existing refresh token
         expires_in=tokens.get("expires_in", 3600),
+        set_active=False,  # token refresh must not reset the active provider/model
     )
     return {"ok": True}
 
@@ -359,6 +443,7 @@ async def sync_openai_cli(user=Depends(get_current_user)):
                 if await provider.validate():
                     store = CredentialStore()
                     store.set_api_key("openai", api_key, model="gpt-5.4")
+                    await _apply_inferred_default("openai", "gpt-5.4")
                     return {"ok": True, "provider": "openai", "source": str(cred_path)}
 
             # ChatGPT mode: validate via the Node.js proxy sidecar
@@ -382,6 +467,7 @@ async def sync_openai_cli(user=Depends(get_current_user)):
                                 refresh_token=refresh_token,
                                 expires_in=864000,  # ~10 days
                             )
+                            await _apply_inferred_default("openai", "gpt-5.4")
                             return {"ok": True, "provider": "openai", "source": str(cred_path), "mode": "chatgpt"}
                         else:
                             raise HTTPException(status_code=400, detail=result.get("error", "Token validation failed"))

--- a/backend/core/providers/tiers.py
+++ b/backend/core/providers/tiers.py
@@ -102,7 +102,8 @@ def infer_tier_models(provider: str, available: list[str]) -> dict[str, str]:
         if sized:
             top = sized[0]
             light = sized[-1]
-            mid = sized[len(sized) // 2]
+            # Avoid mid == light on a 2-model list (len//2 == 1 == last index).
+            mid = sized[len(sized) // 2] if len(sized) > 2 else sized[0]
 
     return {
         "top": top or fb.get("top", ""),
@@ -131,12 +132,14 @@ def _short_label(model_id: str) -> str:
     return model_id.split("/")[-1] if model_id else ""
 
 
-def derive_tier_labels(provider: str) -> dict[str, str]:
+def derive_tier_labels(provider: str, resolved: dict[str, str] | None = None) -> dict[str, str]:
     """Display labels per tier, derived from the resolved model id, with
     TIER_LABELS as fallback. Always non-empty for a known provider so the
-    frontend tier switcher never hides itself."""
-    from core.providers.model_tiers import get_resolved
-    resolved = get_resolved(provider)
+    frontend tier switcher never hides itself. Pass an already-loaded
+    ``resolved`` map to avoid a redundant store read."""
+    if resolved is None:
+        from core.providers.model_tiers import get_resolved
+        resolved = get_resolved(provider)
     fb = TIER_LABELS.get(provider, {})
     return {
         t: _short_label(resolved.get(t, "")) or fb.get(t, t.title())

--- a/backend/core/providers/tiers.py
+++ b/backend/core/providers/tiers.py
@@ -98,18 +98,31 @@ def infer_tier_models(provider: str, available: list[str]) -> dict[str, str]:
         def _params(m: str) -> int:
             nums = re.findall(r"(\d+)\s*b", m.lower())
             return int(nums[-1]) if nums else 0
-        sized = sorted(av, key=_params, reverse=True)
+        # Only rank models with a detectable size — otherwise an unsized,
+        # possibly-large model (e.g. DeepSeek-V3) sorts to the cheap 'light' slot.
+        sized = sorted([m for m in av if _params(m) > 0], key=_params, reverse=True)
         if sized:
             top = sized[0]
             light = sized[-1]
             # Avoid mid == light on a 2-model list (len//2 == 1 == last index).
             mid = sized[len(sized) // 2] if len(sized) > 2 else sized[0]
 
-    return {
+    chosen = {
         "top": top or fb.get("top", ""),
         "mid": mid or fb.get("mid", ""),
         "light": light or fb.get("light", ""),
     }
+    # Never persist a tier whose model isn't actually in the live catalog: the
+    # per-tier hardcoded fallback may name a model this account/catalog doesn't
+    # expose, and auto-triage would then call a nonexistent model. Substitute a
+    # model that IS available (the heuristic picks are members of `av`).
+    if av:
+        present = set(av)
+        substitute = top or mid or light or av[0]
+        for tier in chosen:
+            if chosen[tier] and chosen[tier] not in present:
+                chosen[tier] = substitute if substitute in present else av[0]
+    return chosen
 
 
 def infer_triage_classifier(provider: str, available: list[str]) -> str | None:

--- a/backend/core/providers/tiers.py
+++ b/backend/core/providers/tiers.py
@@ -160,14 +160,6 @@ def derive_tier_labels(provider: str, resolved: dict[str, str] | None = None) ->
     }
 
 
-def get_tier_info(provider: str) -> dict | None:
-    from core.providers.model_tiers import get_resolved
-    models = get_resolved(provider)
-    if not any(models.values()):
-        return None
-    return {"models": models, "labels": derive_tier_labels(provider)}
-
-
 def supports_auto_triage(provider: str) -> bool:
     return provider in TRIAGE_CLASSIFIERS
 

--- a/backend/core/providers/tiers.py
+++ b/backend/core/providers/tiers.py
@@ -1,27 +1,33 @@
-"""Chatty — Model tier definitions and resolution.
+"""Chatty — Model tier definitions, inference, and resolution.
 
-Maps tier labels (top/mid/light) to concrete model IDs per provider.
-Hardcoded, updated occasionally when new models are released.
+Tier labels (top/mid/light) map to concrete model IDs per provider. The
+mapping is resolved synchronously (resolve_tier_model) as override -> inferred
+-> hardcoded fallback; see model_tiers.py. infer_tier_models() produces the
+name-based default from a live model list (called from the async listing path).
 """
 
 from __future__ import annotations
 
+import re
 
+
+# Hardcoded fallback only. Resolution order is override -> inferred -> this map
+# (see resolve_tier_model / model_tiers.py). Kept current by the price-check skill.
 TIER_MODELS: dict[str, dict[str, str]] = {
     "anthropic": {
-        "top":   "claude-opus-4-6",
+        "top":   "claude-opus-4-8",
         "mid":   "claude-sonnet-4-6",
-        "light": "claude-haiku-4-5-20251001",
+        "light": "claude-haiku-4-5",
     },
     "openai": {
-        "top":   "gpt-5.4",
+        "top":   "gpt-5.5",
         "mid":   "gpt-5.4-mini",
         "light": "gpt-5.4-nano",
     },
     "google": {
         "top":   "gemini-2.5-pro",
         "mid":   "gemini-2.5-flash",
-        "light": "gemini-2.0-flash-lite",
+        "light": "gemini-2.5-flash-lite",
     },
     "together": {
         "top":   "Qwen/Qwen3.5-32B",
@@ -30,30 +36,120 @@ TIER_MODELS: dict[str, dict[str, str]] = {
     },
 }
 
+# Fallback display labels. The /tiers endpoint derives labels from the resolved
+# model ids; these are used only when no resolved id is available.
 TIER_LABELS: dict[str, dict[str, str]] = {
     "anthropic": {"top": "Opus", "mid": "Sonnet", "light": "Haiku"},
-    "openai":    {"top": "GPT-5.4", "mid": "Mini", "light": "Nano"},
-    "google":    {"top": "Pro", "mid": "Flash", "light": "Lite"},
+    "openai":    {"top": "GPT-5.5", "mid": "Mini", "light": "Nano"},
+    "google":    {"top": "Pro", "mid": "Flash", "light": "Flash-Lite"},
     "together":  {"top": "32B", "mid": "14B", "light": "7B"},
 }
 
+# Hardcoded fallback for the triage classifier (the cheap "light"-tier model).
+# get_triage_classifier() prefers override/inferred and falls back to this.
 TRIAGE_CLASSIFIERS: dict[str, str] = {
-    "anthropic": "claude-haiku-4-5-20251001",
+    "anthropic": "claude-haiku-4-5",
     "openai":    "gpt-5.4-nano",
-    "google":    "gemini-2.0-flash-lite",
+    "google":    "gemini-2.5-flash-lite",
 }
 
 
+# ── Name-based tier inference (pure; no I/O) ───────────────────────────────────
+
+def _version_key(model: str) -> tuple[int, ...]:
+    return tuple(int(n) for n in re.findall(r"\d+", model))
+
+
+def _best(candidates: list[str]) -> str | None:
+    """Pick the highest-version candidate (ties broken by string)."""
+    if not candidates:
+        return None
+    return max(candidates, key=lambda m: (_version_key(m), m))
+
+
+def infer_tier_models(provider: str, available: list[str]) -> dict[str, str]:
+    """Best-guess {top, mid, light} from a live model list, by naming.
+
+    Pure function — no I/O. Falls back per-tier to the hardcoded TIER_MODELS
+    entry when no candidate matches. The async listing path calls this and
+    persists the result via model_tiers.set_inferred (live fetches only).
+    """
+    fb = TIER_MODELS.get(provider, {})
+    av = [m for m in (available or []) if m]
+    top = mid = light = None
+
+    if provider == "anthropic":
+        top = _best([m for m in av if "opus" in m.lower()])
+        mid = _best([m for m in av if "sonnet" in m.lower()])
+        light = _best([m for m in av if "haiku" in m.lower()])
+    elif provider == "google":
+        top = _best([m for m in av if "pro" in m.lower()])
+        light = _best([m for m in av if "lite" in m.lower()])
+        mid = _best([m for m in av if "flash" in m.lower() and "lite" not in m.lower()])
+    elif provider == "openai":
+        light = _best([m for m in av if "-nano" in m.lower()])
+        mid = _best([m for m in av if "-mini" in m.lower()])
+        top = _best([
+            m for m in av
+            if "-mini" not in m.lower() and "-nano" not in m.lower()
+            and (m.lower().startswith("gpt-") or m.lower().startswith("o"))
+        ])
+    elif provider == "together":
+        def _params(m: str) -> int:
+            nums = re.findall(r"(\d+)\s*b", m.lower())
+            return int(nums[-1]) if nums else 0
+        sized = sorted(av, key=_params, reverse=True)
+        if sized:
+            top = sized[0]
+            light = sized[-1]
+            mid = sized[len(sized) // 2]
+
+    return {
+        "top": top or fb.get("top", ""),
+        "mid": mid or fb.get("mid", ""),
+        "light": light or fb.get("light", ""),
+    }
+
+
+def infer_triage_classifier(provider: str, available: list[str]) -> str | None:
+    """The cheap triage/classifier model = inferred 'light' tier."""
+    return infer_tier_models(provider, available).get("light") or TRIAGE_CLASSIFIERS.get(provider)
+
+
+# ── Synchronous resolution (override -> inferred -> hardcoded) ──────────────────
+
 def resolve_tier_model(provider: str, tier: str) -> str | None:
-    return TIER_MODELS.get(provider, {}).get(tier)
+    """Resolve a tier to a concrete model id. Synchronous by contract —
+    callers (get_ai_provider, agents/router) run in sync context, so this reads
+    the materialized model_tiers store and never lists models live."""
+    from core.providers.model_tiers import get_resolved
+    return get_resolved(provider).get(tier) or None
+
+
+def _short_label(model_id: str) -> str:
+    """Compact display label from a model id (Together 'org/Name' -> 'Name')."""
+    return model_id.split("/")[-1] if model_id else ""
+
+
+def derive_tier_labels(provider: str) -> dict[str, str]:
+    """Display labels per tier, derived from the resolved model id, with
+    TIER_LABELS as fallback. Always non-empty for a known provider so the
+    frontend tier switcher never hides itself."""
+    from core.providers.model_tiers import get_resolved
+    resolved = get_resolved(provider)
+    fb = TIER_LABELS.get(provider, {})
+    return {
+        t: _short_label(resolved.get(t, "")) or fb.get(t, t.title())
+        for t in ("top", "mid", "light")
+    }
 
 
 def get_tier_info(provider: str) -> dict | None:
-    models = TIER_MODELS.get(provider)
-    labels = TIER_LABELS.get(provider)
-    if not models or not labels:
+    from core.providers.model_tiers import get_resolved
+    models = get_resolved(provider)
+    if not any(models.values()):
         return None
-    return {"models": models, "labels": labels}
+    return {"models": models, "labels": derive_tier_labels(provider)}
 
 
 def supports_auto_triage(provider: str) -> bool:
@@ -61,4 +157,7 @@ def supports_auto_triage(provider: str) -> bool:
 
 
 def get_triage_classifier(provider: str) -> str | None:
-    return TRIAGE_CLASSIFIERS.get(provider)
+    """The cheap classifier model: resolved 'light' tier, else hardcoded."""
+    from core.providers.model_tiers import get_resolved
+    light = get_resolved(provider).get("light")
+    return light or TRIAGE_CLASSIFIERS.get(provider)

--- a/backend/core/providers/together_provider.py
+++ b/backend/core/providers/together_provider.py
@@ -34,6 +34,25 @@ TOGETHER_MODELS = [
 
 TOGETHER_DEFAULT_MODEL = "Qwen/Qwen3.5-7B"
 
+# Together's catalog is large and mixes chat, embedding, image, rerank, etc.
+# Prefer the per-model `type` (chat/language) when present; otherwise exclude
+# obvious non-chat ids by name. The curated TOGETHER_MODELS is the fallback.
+_TOGETHER_NON_CHAT = (
+    "embedding", "rerank", "image", "audio", "moderation",
+    "whisper", "guard", "vision", "tts", "flux",
+)
+
+
+def _is_together_chat(model) -> bool:
+    mtype = getattr(model, "type", None)
+    if mtype is None:
+        extra = getattr(model, "model_extra", None) or {}
+        mtype = extra.get("type")
+    if mtype:
+        return mtype in ("chat", "language")
+    low = model.id.lower()
+    return not any(token in low for token in _TOGETHER_NON_CHAT)
+
 
 class TogetherProvider(AIProvider):
     def __init__(self, api_key: str, model: str = TOGETHER_DEFAULT_MODEL):
@@ -82,8 +101,17 @@ class TogetherProvider(AIProvider):
     ) -> list[dict]:
         return build_openai_tool_results(messages, tool_calls, results)
 
+    async def _fetch_models(self) -> list[str]:
+        client = openai.AsyncOpenAI(api_key=self.api_key, base_url=TOGETHER_BASE_URL)
+        resp = await client.models.list()
+        return sorted(m.id for m in resp.data if _is_together_chat(m))
+
     async def list_models(self) -> list[str]:
-        return TOGETHER_MODELS
+        from core.providers.model_listing import cache_key, cached_models, materialize_inference
+        key = cache_key("together", self.api_key)
+        models, is_live = await cached_models(key, self._fetch_models, TOGETHER_MODELS)
+        materialize_inference("together", models, is_live)
+        return models
 
     async def validate(self) -> bool:
         """Validate the API key with a minimal completion."""

--- a/backend/core/providers/triage.py
+++ b/backend/core/providers/triage.py
@@ -12,7 +12,7 @@ import logging
 from collections import OrderedDict
 
 from core.providers.credentials import CredentialStore
-from core.providers.tiers import TRIAGE_CLASSIFIERS
+from core.providers.tiers import get_triage_classifier
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +109,7 @@ async def _classify_anthropic(text: str, creds: dict) -> str:
     import anthropic
     client = anthropic.AsyncAnthropic(api_key=creds["api_key"], timeout=_CLASSIFIER_TIMEOUT)
     response = await client.messages.create(
-        model=TRIAGE_CLASSIFIERS["anthropic"],
+        model=get_triage_classifier("anthropic"),
         max_tokens=5,
         system=_TRIAGE_SYSTEM_PROMPT,
         messages=[{"role": "user", "content": text[:_MAX_INPUT_CHARS]}],
@@ -125,7 +125,7 @@ async def _classify_openai(text: str, creds: dict) -> str:
         kwargs["base_url"] = CHATGPT_PROXY_URL
     client = openai.AsyncOpenAI(**kwargs)
     response = await client.chat.completions.create(
-        model=TRIAGE_CLASSIFIERS["openai"],
+        model=get_triage_classifier("openai"),
         max_completion_tokens=20,
         messages=[
             {"role": "system", "content": _TRIAGE_SYSTEM_PROMPT},
@@ -143,7 +143,7 @@ async def _classify_google(text: str, creds: dict) -> str:
     elif creds.get("access_token"):
         genai.configure(credentials=_google_oauth_creds(creds["access_token"]))
     model = genai.GenerativeModel(
-        TRIAGE_CLASSIFIERS["google"],
+        get_triage_classifier("google"),
         system_instruction=_TRIAGE_SYSTEM_PROMPT,
     )
     response = await asyncio.wait_for(

--- a/backend/tests/test_http_providers.py
+++ b/backend/tests/test_http_providers.py
@@ -1,0 +1,73 @@
+"""HTTP tests for the provider tier endpoints (GET/PUT /api/providers/tiers).
+
+Uses the shared authenticated `client` fixture (FastAPI TestClient) from conftest.
+"""
+
+import pytest
+
+
+class _FakeProvider:
+    """Stands in for a real provider so validation doesn't hit the network."""
+    async def list_models(self):
+        return ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"]
+
+
+@pytest.fixture
+def tiers_isolated(monkeypatch, tmp_path):
+    """Point the tier store at a temp file and stub provider instantiation."""
+    import core.providers as providers_pkg
+    from core.providers import model_tiers
+
+    monkeypatch.setattr(model_tiers, "TIERS_PATH", tmp_path / "model-tiers.json")
+    monkeypatch.setattr(providers_pkg, "get_ai_provider", lambda **kw: _FakeProvider())
+    yield
+
+
+# ── Validation (no provider instantiation needed) ──────────────────────────────
+
+def test_put_tiers_unknown_provider_400(client):
+    r = client.put("/api/providers/tiers", json={"provider": "zzz", "models": {"top": "x"}})
+    assert r.status_code == 400
+
+
+def test_put_tiers_bad_tier_key_400(client):
+    r = client.put("/api/providers/tiers", json={"provider": "anthropic", "models": {"ultra": "claude-opus-4-8"}})
+    assert r.status_code == 400
+
+
+# ── Validation against the live (stubbed) model list ───────────────────────────
+
+def test_put_tiers_model_not_available_400(client, tiers_isolated):
+    r = client.put("/api/providers/tiers", json={"provider": "anthropic", "models": {"top": "gpt-4-not-anthropic"}})
+    assert r.status_code == 400
+
+
+def test_put_tiers_model_id_too_long_400(client, tiers_isolated):
+    r = client.put("/api/providers/tiers", json={"provider": "anthropic", "models": {"top": "x" * 201}})
+    assert r.status_code == 400
+
+
+def test_put_tiers_happy_path_persists_and_reflects(client, tiers_isolated):
+    r = client.put("/api/providers/tiers", json={"provider": "anthropic", "models": {"top": "claude-sonnet-4-6"}})
+    assert r.status_code == 200
+    assert r.json()["tier_models"]["top"] == "claude-sonnet-4-6"
+
+    # GET reflects the override (cheap, store-only).
+    g = client.get("/api/providers/tiers")
+    assert g.status_code == 200
+    assert g.json()["tier_models"]["anthropic"]["top"] == "claude-sonnet-4-6"
+    # Labels are always non-empty.
+    assert all(g.json()["tier_labels"]["anthropic"].values())
+
+
+def test_put_tiers_empty_clears_override(client, tiers_isolated):
+    client.put("/api/providers/tiers", json={"provider": "anthropic", "models": {"top": "claude-sonnet-4-6"}})
+    # Empty string clears the override → resolves back to inferred/hardcoded top.
+    r = client.put("/api/providers/tiers", json={"provider": "anthropic", "models": {"top": ""}})
+    assert r.status_code == 200
+    assert r.json()["tier_models"]["top"] == "claude-opus-4-8"
+
+
+def test_put_tiers_requires_auth(anon_client):
+    r = anon_client.put("/api/providers/tiers", json={"provider": "anthropic", "models": {"top": "claude-opus-4-8"}})
+    assert r.status_code in (401, 403)

--- a/backend/tests/test_model_tiers.py
+++ b/backend/tests/test_model_tiers.py
@@ -214,6 +214,21 @@ class TestInferenceEdges:
         assert out["light"] == "Qwen/Qwen3.5-7B"
         assert out["mid"] != out["light"]
 
+    def test_inferred_tiers_coerced_to_available(self):
+        # OpenAI live list missing -mini/-nano: those tiers must NOT resolve to
+        # the hardcoded (unavailable) models — they collapse to an available one.
+        out = tiers.infer_tier_models("openai", ["gpt-5.5"])
+        assert set(out.values()) == {"gpt-5.5"}
+
+    def test_together_ignores_unsized_model_for_light(self):
+        # DeepSeek-V3 is unsized → must not be chosen as the cheap 'light' tier.
+        out = tiers.infer_tier_models(
+            "together",
+            ["Qwen/Qwen3.5-32B", "Qwen/Qwen3.5-7B", "deepseek-ai/DeepSeek-V3-0324"],
+        )
+        assert out["top"] == "Qwen/Qwen3.5-32B"
+        assert out["light"] == "Qwen/Qwen3.5-7B"
+
 
 class TestLabelsAndTriageFallback:
     def test_derive_labels_strips_together_org(self, tier_store):

--- a/backend/tests/test_model_tiers.py
+++ b/backend/tests/test_model_tiers.py
@@ -87,6 +87,20 @@ class TestResolution:
         assert all(labels[t] for t in ("top", "mid", "light"))
 
 
+class TestResolvedDefaultModel:
+    """Guards the connect-time default resolver against the recursion bug."""
+
+    def test_unknown_provider_returns_empty_without_recursing(self, tier_store):
+        from core.providers.credentials import _resolved_default_model
+        # No inferred entry and no hardcoded TIER_MODELS entry → must return ""
+        # (PROVIDER_DEFAULTS), NOT recurse into itself.
+        assert _resolved_default_model("nonexistent-provider") == ""
+
+    def test_known_provider_falls_back_to_hardcoded_top(self, tier_store):
+        from core.providers.credentials import _resolved_default_model
+        assert _resolved_default_model("anthropic") == tiers.TIER_MODELS["anthropic"]["top"]
+
+
 # ── Listing cache: live-vs-fallback signal ──────────────────────────────────────
 
 

--- a/backend/tests/test_model_tiers.py
+++ b/backend/tests/test_model_tiers.py
@@ -1,0 +1,131 @@
+"""Tests for dynamic model tiers: name inference, sync resolution, and the
+model-listing cache's live-vs-fallback signal."""
+
+import asyncio
+
+import pytest
+
+from core.providers import model_listing, model_tiers, tiers
+
+
+@pytest.fixture
+def tier_store(monkeypatch, tmp_path):
+    """Point the tier store at a temp file so tests don't touch real data/."""
+    monkeypatch.setattr(model_tiers, "TIERS_PATH", tmp_path / "model-tiers.json")
+    yield
+
+
+# ── Inference (pure) ────────────────────────────────────────────────────────────
+
+
+class TestTierInference:
+    def test_anthropic(self):
+        out = tiers.infer_tier_models(
+            "anthropic", ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"]
+        )
+        assert out == {"top": "claude-opus-4-8", "mid": "claude-sonnet-4-6", "light": "claude-haiku-4-5"}
+
+    def test_prefers_highest_version(self):
+        out = tiers.infer_tier_models(
+            "anthropic",
+            ["claude-opus-4-6", "claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
+        )
+        assert out["top"] == "claude-opus-4-8"
+
+    def test_openai_suffixes(self):
+        out = tiers.infer_tier_models("openai", ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"])
+        assert out == {"top": "gpt-5.5", "mid": "gpt-5.4-mini", "light": "gpt-5.4-nano"}
+
+    def test_google_lite_vs_flash(self):
+        out = tiers.infer_tier_models(
+            "google", ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+                       "gemini-2.0-flash", "gemini-2.0-flash-lite"]
+        )
+        assert out == {"top": "gemini-2.5-pro", "mid": "gemini-2.5-flash", "light": "gemini-2.5-flash-lite"}
+
+    def test_together_by_param_count(self):
+        out = tiers.infer_tier_models(
+            "together", ["Qwen/Qwen3.5-32B", "Qwen/Qwen3.5-14B", "Qwen/Qwen3.5-7B"]
+        )
+        assert out["top"] == "Qwen/Qwen3.5-32B"
+        assert out["light"] == "Qwen/Qwen3.5-7B"
+
+    def test_fallback_to_hardcoded_when_empty(self):
+        out = tiers.infer_tier_models("anthropic", [])
+        assert out["top"] == tiers.TIER_MODELS["anthropic"]["top"]
+
+    def test_triage_classifier_is_light(self):
+        assert tiers.infer_triage_classifier("openai", ["gpt-5.5", "gpt-5.4-nano"]) == "gpt-5.4-nano"
+
+
+# ── Synchronous resolution (override → inferred → hardcoded) ─────────────────────
+
+
+class TestResolution:
+    def test_precedence(self, tier_store):
+        # No store yet → hardcoded fallback
+        assert tiers.resolve_tier_model("anthropic", "top") == tiers.TIER_MODELS["anthropic"]["top"]
+
+        # Inferred beats hardcoded
+        model_tiers.set_inferred("anthropic", {"top": "claude-opus-4-7", "mid": "claude-sonnet-4-6", "light": "claude-haiku-4-5"})
+        assert tiers.resolve_tier_model("anthropic", "top") == "claude-opus-4-7"
+
+        # Override beats inferred
+        model_tiers.set_overrides("anthropic", {"top": "claude-opus-4-6"})
+        assert tiers.resolve_tier_model("anthropic", "top") == "claude-opus-4-6"
+
+        # Clearing the override falls back to inferred
+        model_tiers.set_overrides("anthropic", {"top": ""})
+        assert tiers.resolve_tier_model("anthropic", "top") == "claude-opus-4-7"
+
+    def test_get_triage_classifier_uses_resolved_light(self, tier_store):
+        model_tiers.set_inferred("openai", {"top": "gpt-5.5", "mid": "gpt-5.4-mini", "light": "gpt-5.4-nano"})
+        assert tiers.get_triage_classifier("openai") == "gpt-5.4-nano"
+
+    def test_derive_labels_always_nonempty(self, tier_store):
+        labels = tiers.derive_tier_labels("anthropic")
+        assert all(labels[t] for t in ("top", "mid", "light"))
+
+
+# ── Listing cache: live-vs-fallback signal ──────────────────────────────────────
+
+
+class TestCachedModels:
+    def test_live_then_cached(self):
+        calls = {"n": 0}
+
+        async def fetch():
+            calls["n"] += 1
+            return ["a", "b"]
+
+        async def run():
+            m1, live1 = await model_listing.cached_models("k-live", fetch, ["fb"], ttl=100)
+            m2, live2 = await model_listing.cached_models("k-live", fetch, ["fb"], ttl=100)
+            return m1, live1, m2, live2
+
+        m1, live1, m2, live2 = asyncio.run(run())
+        assert (m1, live1) == (["a", "b"], True)
+        assert (m2, live2) == (["a", "b"], False)  # served from cache, not a live fetch
+        assert calls["n"] == 1
+
+    def test_error_uses_fallback_and_is_not_live(self):
+        async def boom():
+            raise RuntimeError("network down")
+
+        async def run():
+            return await model_listing.cached_models("k-err", boom, ["fb1", "fb2"], ttl=100)
+
+        models, is_live = asyncio.run(run())
+        assert models == ["fb1", "fb2"]
+        assert is_live is False  # crucial: fallback must NOT trigger tier inference
+
+    def test_empty_result_uses_fallback_and_is_not_live(self):
+        async def empty():
+            return []
+
+        async def run():
+            return await model_listing.cached_models("k-empty", empty, ["fb"], ttl=100)
+
+        models, is_live = asyncio.run(run())
+        assert models == ["fb"]
+        assert is_live is False

--- a/backend/tests/test_model_tiers.py
+++ b/backend/tests/test_model_tiers.py
@@ -143,3 +143,117 @@ class TestCachedModels:
         models, is_live = asyncio.run(run())
         assert models == ["fb"]
         assert is_live is False
+
+    def test_error_falls_back_to_last_good_cache(self):
+        async def good():
+            return ["live-x"]
+
+        async def boom():
+            raise RuntimeError("provider down")
+
+        async def run():
+            m1, l1 = await model_listing.cached_models("k-stale", good, ["fb"], ttl=100)
+            # Expire the entry, then fail the next fetch.
+            ts, models = model_listing._cache["k-stale"]
+            model_listing._cache["k-stale"] = (ts - 10_000, models)
+            m2, l2 = await model_listing.cached_models("k-stale", boom, ["fb"], ttl=100)
+            return m1, l1, m2, l2
+
+        m1, l1, m2, l2 = asyncio.run(run())
+        assert (m1, l1) == (["live-x"], True)
+        # On error with a prior cache, serve last-good — NOT the hardcoded fallback.
+        assert m2 == ["live-x"]
+        assert l2 is False
+
+
+class TestModelFilters:
+    @pytest.mark.parametrize("model_id,expected", [
+        ("gpt-5.5", True), ("gpt-5.4-nano", True), ("o3", True), ("o4-mini", True),
+        ("chatgpt-4o", True),
+        ("text-embedding-3-large", False), ("whisper-1", False),
+        ("gpt-4o-realtime-preview", False), ("dall-e-3", False), ("tts-1", False),
+        ("gpt-3.5-turbo-instruct", False), ("gpt-image-1", False),
+        ("gpt-4o-search-preview", False),
+    ])
+    def test_openai_chat_filter(self, model_id, expected):
+        from core.providers.openai_provider import _is_openai_chat_model
+        assert _is_openai_chat_model(model_id) is expected
+
+    def test_together_filter_by_type(self):
+        from core.providers.together_provider import _is_together_chat
+
+        class M:
+            def __init__(self, id, type=None):
+                self.id = id
+                self.type = type
+
+        assert _is_together_chat(M("x", "chat")) is True
+        assert _is_together_chat(M("x", "language")) is True
+        assert _is_together_chat(M("x", "embedding")) is False
+
+    def test_together_filter_name_fallback(self):
+        from core.providers.together_provider import _is_together_chat
+
+        class M:
+            def __init__(self, id):
+                self.id = id
+                self.type = None
+
+        assert _is_together_chat(M("Qwen/Qwen3.5-32B")) is True
+        assert _is_together_chat(M("BAAI/bge-large-embedding")) is False
+        assert _is_together_chat(M("black-forest-labs/flux")) is False
+
+
+class TestInferenceEdges:
+    def test_unknown_provider_returns_empty(self):
+        assert tiers.infer_tier_models("ollama", ["llama3.2"]) == {"top": "", "mid": "", "light": ""}
+
+    def test_together_two_models_mid_not_equal_light(self):
+        out = tiers.infer_tier_models("together", ["Qwen/Qwen3.5-32B", "Qwen/Qwen3.5-7B"])
+        assert out["top"] == "Qwen/Qwen3.5-32B"
+        assert out["light"] == "Qwen/Qwen3.5-7B"
+        assert out["mid"] != out["light"]
+
+
+class TestLabelsAndTriageFallback:
+    def test_derive_labels_strips_together_org(self, tier_store):
+        model_tiers.set_inferred("together", {
+            "top": "Qwen/Qwen3.5-32B", "mid": "Qwen/Qwen3.5-14B", "light": "Qwen/Qwen3.5-7B",
+        })
+        assert tiers.derive_tier_labels("together")["top"] == "Qwen3.5-32B"
+
+    def test_triage_falls_back_to_hardcoded(self, tier_store):
+        # Empty store → resolved 'light' is the hardcoded tier, matching TRIAGE_CLASSIFIERS.
+        assert tiers.get_triage_classifier("anthropic") == tiers.TRIAGE_CLASSIFIERS["anthropic"]
+
+    def test_triage_unknown_provider_is_none(self, tier_store):
+        assert tiers.get_triage_classifier("nonexistent") is None
+
+
+class TestMaterializeDoesNotOverrideActiveModel:
+    def test_active_model_preserved(self, monkeypatch, tmp_path, tier_store):
+        import asyncio
+        import core.providers as providers_pkg
+        import core.providers.credentials as creds
+
+        monkeypatch.setattr(creds, "PROFILES_PATH", tmp_path / "auth-profiles.json")
+        store = creds.CredentialStore()
+        store.data = {
+            "active_provider": "google",
+            "active_model": "gemini-2.5-flash",
+            "profiles": {"google:default": {"type": "api_key", "key": "x"}},
+        }
+        store._save()
+
+        class FakeProvider:
+            async def list_models(self):
+                return ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"]
+
+        monkeypatch.setattr(providers_pkg, "get_ai_provider", lambda **kw: FakeProvider())
+
+        from core.providers.router import _materialize_inferred_tiers
+        returned = asyncio.run(_materialize_inferred_tiers("google", "gemini-2.5-flash"))
+
+        # The inferred top is gemini-2.5-pro, but active_model must NOT be flipped.
+        assert returned == "gemini-2.5-flash"
+        assert creds.CredentialStore().data["active_model"] == "gemini-2.5-flash"

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -93,6 +93,26 @@ class TestPricing:
         assert is_priced("llama3.2") is False
         assert is_priced("") is False
 
+    def test_pricing_md_in_sync_with_pricing_py(self):
+        # Guards against PRICING.md (the reviewable report) drifting from the
+        # runtime MODEL_PRICING source of truth — the price-check skill must
+        # regenerate both together.
+        import re
+        from pathlib import Path
+        from core.providers.pricing import MODEL_PRICING
+
+        md = (Path(__file__).resolve().parent.parent
+              / "core" / "providers" / "PRICING.md").read_text(encoding="utf-8")
+        rows = {
+            m.group(1): (float(m.group(2)), float(m.group(3)))
+            for m in re.finditer(r"\|\s*`([^`]+)`\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|", md)
+        }
+        for model, prices in MODEL_PRICING.items():
+            assert model in rows, f"{model} priced in pricing.py but missing from PRICING.md"
+            assert rows[model] == prices, (
+                f"{model} price mismatch: pricing.py={prices} PRICING.md={rows[model]}"
+            )
+
 
 # ── Provider-aware unknown pricing ──────────────────────────────────────────────
 

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -35,6 +35,7 @@ def _insert_event(
     status="ok",
     started_at=None,
     model="claude-sonnet-4-6",
+    provider=None,
     input_tokens=0,
     output_tokens=0,
     result_full=None,
@@ -46,12 +47,12 @@ def _insert_event(
     conn.execute(
         """INSERT INTO execution_history
            (id, action_id, agent, action_type, event_type, started_at,
-            completed_at, status, result_full, tool_calls, model_used,
+            completed_at, status, result_full, tool_calls, model_used, provider,
             input_tokens, output_tokens)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (eid, eid, agent, "chat" if event_type == "chat" else "heartbeat",
          event_type, started, started, status, result_full, tool_calls,
-         model, input_tokens, output_tokens),
+         model, provider, input_tokens, output_tokens),
     )
     conn.commit()
     return eid
@@ -81,6 +82,60 @@ class TestPricing:
         # 1M input + 1M output on sonnet = $3 + $15
         assert estimate_cost("claude-sonnet-4-6", 1_000_000, 1_000_000) == pytest.approx(18.0)
         assert estimate_cost("claude-haiku-4-5-20251001", 2_000_000, 0) == pytest.approx(2.0)
+
+    def test_current_models_priced(self):
+        from core.providers.pricing import is_priced
+        assert is_priced("claude-opus-4-8") is True
+        assert is_priced("gpt-5.5") is True
+        assert is_priced("gemini-2.5-flash-lite") is True
+        # Together is paid but not priced yet; local models unpriced
+        assert is_priced("Qwen/Qwen3.5-32B") is False
+        assert is_priced("llama3.2") is False
+        assert is_priced("") is False
+
+
+# ── Provider-aware unknown pricing ──────────────────────────────────────────────
+
+
+class TestUnknownPricing:
+    def test_ollama_row_is_free_not_flagged(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+        _insert_event(reminders_db, agent="local", model="llama3.2",
+                      provider="ollama", input_tokens=1_000_000, output_tokens=1_000_000)
+        s = get_usage_summary(days=7, tz="UTC")
+        assert s["totals"]["cost"] == 0.0
+        assert s["unknown_pricing_models"] == []
+        assert s["agents"][0]["has_unknown_pricing"] is False
+        assert s["agents"][0]["unknown_pricing_models"] == []
+
+    def test_unpriced_paid_model_is_flagged(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+        _insert_event(reminders_db, agent="t", model="Qwen/Qwen3.5-32B",
+                      provider="together", input_tokens=1_000_000, output_tokens=0)
+        s = get_usage_summary(days=7, tz="UTC")
+        assert s["totals"]["cost"] == 0.0  # unknown → 0 but FLAGGED, not silent
+        assert "Qwen/Qwen3.5-32B" in s["unknown_pricing_models"]
+        assert s["agents"][0]["has_unknown_pricing"] is True
+        assert "Qwen/Qwen3.5-32B" in s["agents"][0]["unknown_pricing_models"]
+
+    def test_priced_paid_model_not_flagged(self, reminders_db):
+        from core.agents.usage.service import get_usage_summary
+        _insert_event(reminders_db, agent="a", model="claude-opus-4-8",
+                      provider="anthropic", input_tokens=1_000_000, output_tokens=0)
+        s = get_usage_summary(days=7, tz="UTC")
+        assert s["totals"]["cost"] == pytest.approx(5.0)
+        assert s["unknown_pricing_models"] == []
+        assert s["agents"][0]["has_unknown_pricing"] is False
+
+    def test_legacy_null_provider_unpriced_flagged_not_free(self, reminders_db):
+        # Pre-migration rows have provider=NULL; an unpriced model must be
+        # flagged (conservative), never silently treated as free $0.
+        from core.agents.usage.service import get_usage_summary
+        _insert_event(reminders_db, agent="legacy", model="mystery-model-x",
+                      provider=None, input_tokens=1_000_000, output_tokens=0)
+        s = get_usage_summary(days=7, tz="UTC")
+        assert "mystery-model-x" in s["unknown_pricing_models"]
+        assert s["agents"][0]["has_unknown_pricing"] is True
 
 
 # ── Aggregation ───────────────────────────────────────────────────────────────

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -127,6 +127,24 @@ class TestUnknownPricing:
         assert s["unknown_pricing_models"] == []
         assert s["agents"][0]["has_unknown_pricing"] is False
 
+    def test_empty_model_not_flagged(self, reminders_db):
+        # A paid-provider row with no model id can't be priced OR flagged.
+        from core.agents.usage.service import get_usage_summary
+        _insert_event(reminders_db, agent="t", model="", provider="together",
+                      input_tokens=1_000_000, output_tokens=0)
+        s = get_usage_summary(days=7, tz="UTC")
+        assert s["unknown_pricing_models"] == []
+        assert s["agents"][0]["has_unknown_pricing"] is False
+
+    def test_explicit_anthropic_provider_priced(self, reminders_db):
+        # Exercises the provider column read on the priced path (not just NULL rows).
+        from core.agents.usage.service import get_usage_summary
+        _insert_event(reminders_db, agent="a", model="claude-opus-4-8",
+                      provider="anthropic", input_tokens=1_000_000, output_tokens=0)
+        s = get_usage_summary(days=7, tz="UTC")
+        assert s["totals"]["cost"] == pytest.approx(5.0)
+        assert s["agents"][0]["has_unknown_pricing"] is False
+
     def test_legacy_null_provider_unpriced_flagged_not_free(self, reminders_db):
         # Pre-migration rows have provider=NULL; an unpriced model must be
         # flagged (conservative), never silently treated as free $0.

--- a/frontend/src/setup/ProviderSetup.tsx
+++ b/frontend/src/setup/ProviderSetup.tsx
@@ -4,6 +4,7 @@ import type { ProviderStatus } from '../core/types';
 import { ApiKeyEntry } from './ApiKeyEntry';
 import { SetupTokenEntry } from './SetupTokenEntry';
 import { ModelSelector } from './ModelSelector';
+import { TierPicker } from './TierPicker';
 import { OllamaSetup } from './OllamaSetup';
 import { TogetherSetup } from './TogetherSetup';
 import { IconBrain, IconZap, IconSparkle, IconGlobe, IconHome } from '../shared/icons';
@@ -131,6 +132,7 @@ export function ProviderSetup() {
             {!isConnected ? renderConnectUI(p) : (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 <ModelSelector provider={p.id} currentModel={currentModel} onChanged={reload} />
+                {p.id !== 'ollama' && <TierPicker provider={p.id} onChanged={reload} />}
                 {!isActive && (
                   <button onClick={async () => {
                     await api('/api/providers/active', { method: 'PUT', body: JSON.stringify({ provider: p.id, model: currentModel || '' }) });

--- a/frontend/src/setup/TierPicker.tsx
+++ b/frontend/src/setup/TierPicker.tsx
@@ -44,8 +44,9 @@ export function TierPicker({ provider, onChanged }: Props) {
   }, [provider]);
 
   async function save(tier: string, model: string) {
+    const previous = tiers[tier] ?? '';
     setSaving(true);
-    setTiers(prev => ({ ...prev, [tier]: model }));
+    setTiers(prev => ({ ...prev, [tier]: model }));  // optimistic
     try {
       await api('/api/providers/tiers', {
         method: 'PUT',
@@ -54,6 +55,7 @@ export function TierPicker({ provider, onChanged }: Props) {
       onChanged?.();
     } catch (err) {
       console.error('Failed to set tier:', err);
+      setTiers(prev => ({ ...prev, [tier]: previous }));  // roll back on failure
     } finally {
       setSaving(false);
     }
@@ -80,6 +82,7 @@ export function TierPicker({ provider, onChanged }: Props) {
               disabled={saving}
               style={{ ...selectStyle, opacity: saving ? 0.5 : 1 }}
             >
+              <option value="">Use inferred default</option>
               {optionsFor(tiers[t.key] || '').map(m => (
                 <option key={m} value={m}>{m}</option>
               ))}

--- a/frontend/src/setup/TierPicker.tsx
+++ b/frontend/src/setup/TierPicker.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+import { api } from '../core/api/client';
+
+interface Props {
+  provider: string;
+  onChanged?: () => void;
+}
+
+const TIERS: Array<{ key: 'top' | 'mid' | 'light'; label: string }> = [
+  { key: 'top', label: 'Top' },
+  { key: 'mid', label: 'Mid' },
+  { key: 'light', label: 'Light' },
+];
+
+const selectStyle: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box',
+  background: 'rgba(34,40,48,0.55)', border: '1px solid rgba(230,235,242,0.14)',
+  color: '#EDF0F4', borderRadius: 4, padding: '6px 8px', fontSize: 12, outline: 'none',
+};
+
+const captionStyle: React.CSSProperties = {
+  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+  fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
+  color: 'rgba(237,240,244,0.38)',
+};
+
+/**
+ * Lets the user override which concrete model each tier (top/mid/light) maps to.
+ * Options come from the (cached) live model list; defaults are the inferred
+ * values returned by /api/providers/tiers. Saving PUTs a single-tier override.
+ */
+export function TierPicker({ provider, onChanged }: Props) {
+  const [models, setModels] = useState<string[]>([]);
+  const [tiers, setTiers] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    api<{ models: string[] }>(`/api/providers/${provider}/models`)
+      .then(d => setModels(d.models))
+      .catch(console.error);
+    api<{ tier_models: Record<string, Record<string, string>> }>('/api/providers/tiers')
+      .then(d => setTiers(d.tier_models?.[provider] || {}))
+      .catch(console.error);
+  }, [provider]);
+
+  async function save(tier: string, model: string) {
+    setSaving(true);
+    setTiers(prev => ({ ...prev, [tier]: model }));
+    try {
+      await api('/api/providers/tiers', {
+        method: 'PUT',
+        body: JSON.stringify({ provider, models: { [tier]: model } }),
+      });
+      onChanged?.();
+    } catch (err) {
+      console.error('Failed to set tier:', err);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!models.length) return null;
+
+  // Keep the current resolved value selectable even if it's not in the live list.
+  const optionsFor = (current: string) =>
+    !current || models.includes(current) ? models : [current, ...models];
+
+  return (
+    <div>
+      <label style={{ ...captionStyle, display: 'block', marginBottom: 6 }}>
+        Tiers (used by auto-triage &amp; per-agent top/mid/light)
+      </label>
+      <div style={{ display: 'flex', gap: 8 }}>
+        {TIERS.map(t => (
+          <div key={t.key} style={{ flex: 1, minWidth: 0 }}>
+            <span style={{ ...captionStyle, display: 'block', marginBottom: 4 }}>{t.label}</span>
+            <select
+              value={tiers[t.key] || ''}
+              onChange={e => save(t.key, e.target.value)}
+              disabled={saving}
+              style={{ ...selectStyle, opacity: saving ? 0.5 : 1 }}
+            >
+              {optionsFor(tiers[t.key] || '').map(m => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/usage/UsagePage.tsx
+++ b/frontend/src/usage/UsagePage.tsx
@@ -43,6 +43,8 @@ interface AgentUsage {
   chat_events: number;
   background_events: number;
   cost: number;
+  has_unknown_pricing?: boolean;
+  unknown_pricing_models?: string[];
 }
 
 interface UsageSummary {
@@ -325,6 +327,18 @@ export function UsagePage() {
                           fontFamily: FONT_MONO, fontSize: 11,
                         }}>
                           {a.primary_model || '—'}
+                          {a.has_unknown_pricing && (
+                            <span
+                              title={`No published price for: ${(a.unknown_pricing_models || []).join(', ')}. Run the price-check skill to add it to pricing.py.`}
+                              style={{
+                                marginLeft: 8, padding: '1px 6px', borderRadius: 3, fontSize: 9,
+                                fontFamily: FONT_MONO, letterSpacing: '0.08em', textTransform: 'uppercase',
+                                color: '#D4A85A', border: '1px solid rgba(212,168,90,0.4)', whiteSpace: 'nowrap',
+                              }}
+                            >
+                              pricing unknown
+                            </span>
+                          )}
                         </td>
                         <td style={{
                           padding: '11px 16px', textAlign: 'right', color: INK_MUTE,
@@ -360,7 +374,9 @@ export function UsagePage() {
         padding: `8px ${px} 28px`,
         fontFamily: FONT_SANS, fontSize: 11, color: 'rgba(237,240,244,0.38)',
       }}>
-        Costs are estimates based on published API prices. Unpriced and local models show $0.00.
+        Costs are estimates based on published API prices. Local models (Ollama) are free ($0.00).
+        A “pricing unknown” tag means a paid model has no entry in pricing.py yet — run the price-check
+        skill to refresh rates; until then its cost is shown as $0.00 but excluded from accuracy.
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Dynamic model lists**: each provider's `list_models()` now fetches live from the provider API (Anthropic/OpenAI/Google/Together) behind a shared TTL cache with the hardcoded `*_MODELS` as fallback — new models appear in the selector automatically. The cache reports live-vs-fallback so a transient failure never poisons tier inference.
- **Inferred + user-overridable tiers**: name-based inference is materialized into `data/model-tiers.json` on live fetches; `resolve_tier_model` stays synchronous (override → inferred → hardcoded). New `TierPicker` UI + validated `PUT /api/providers/tiers`. Triage unified through `get_triage_classifier` (removed the duplicate `_TRIAGE_MODELS`). Centralized `apply_inferred_default` across all connect paths; `refresh_google` no longer resets the active model.
- **Provider-aware pricing**: `execution_history` gains a `provider` column threaded through all writers; the usage dashboard treats only Ollama as free and flags unpriced paid models (incl. Together) as "pricing unknown" instead of silently $0.
- **Data refresh**: `MODEL_PRICING` + `PRICING_SOURCES`, fallback lists, tiers, and defaults updated to current models (Opus 4.8 / gpt-5.x / Gemini 2.5), pulled from official pricing pages.
- **`price-check` skill** (`.claude/skills/price-check/`) + generated `PRICING.md` + CLAUDE.md rule: PRs touching providers/usage run it to keep `pricing.py` current; it never fabricates rates and skips if already run in-chat.

## Test plan
- [x] Full backend suite: `cd backend && ../.venv/bin/python -m pytest -q` → 829 passed
- [x] New tests: tier inference per provider, `resolve_tier_model` override→inferred→hardcoded precedence, `cached_models` live/fallback signal, Ollama-free / unpriced-paid-flagged pricing rule
- [x] All touched modules import (no circular imports); `PUT /api/providers/tiers` registered
- [x] Frontend: changed files (`TierPicker`, `ProviderSetup`, `UsagePage`) typecheck clean
- [ ] Manual: connect a provider with a real key → dropdown shows live models incl. `claude-opus-4-8`; reassign a tier and confirm it persists; usage dashboard flags an unpriced model