### PR TITLE
Fix context chat meter: cache-inclusive tokens + per-provider window

### DIFF
--- a/.claude/coach-lessons.md
+++ b/.claude/coach-lessons.md
@@ -5,7 +5,7 @@
 
 ## Deploy & Infrastructure
 
-- `[0.90]` **When** running the backend from a git worktree → **do** use the absolute venv path (`/Users/willwilson/ai/chatty/.venv/bin/python`), not relative (`../../.venv/bin/python`) → **because** worktrees live under `.claude/worktrees/<name>/backend/` and the relative path resolves to a nonexistent location
+- `[0.95]` **When** running the backend from a git worktree → **do** use the absolute venv path (`/Users/willwilson/ai/chatty/.venv/bin/python`), not relative (`../../.venv/bin/python`) → **because** worktrees live under `.claude/worktrees/<name>/backend/` and the relative path resolves to a nonexistent location
 
 ## Git & Workflow
 
@@ -30,4 +30,5 @@
 - `[0.70]` **When** replacing `getattr(obj, "attr", fallback)` with an explicit parameter → **do** verify every call site passes the parameter, or keep the `getattr` fallback at the entry point → **because** the `_slug` UnboundLocalError was introduced by removing `getattr` in the outer function without ensuring callers pass the new arg
 - `[0.70]` **When** building a feature that reads historical data from an existing table → **do** check for retention/cleanup jobs that prune old rows → **because** the usage dashboard would have been silently capped at 30 days without discovering `cleanup_old()`'s pruning; the fresh-eyes agent caught this but the original plan missed it entirely
 - `[0.70]` **When** injecting stored user/legacy content into prompts via `sanitize_memory_content` → **do** check the content for legitimate `{{...}}`/`${...}` syntax first → **because** the sanitizer redacts template syntax to `[REDACTED]` at injection time — migrated skill-pack `{{param}}` playbooks were silently corrupted for the model while looking fine in the editor
+- `[0.70]` **When** changing a field on the chat SSE `usage` event (or any `ai_service` SSE event) → **do** account for BOTH consumers — the React `useAgentChat` hook AND the terminal CLI `StreamRenderer` (`backend/cli/output.py`), which sums every `usage` event's `input_tokens`/`output_tokens` into the session total → **because** redefining `input_tokens` to a cache-inclusive value silently inflated the CLI's running count; the fix was a `meter_only` flag that zeros raw fields on display-only emits plus a separate `context_tokens` field for the meter
 - `[0.60]` **When** adding a new FastAPI route that performs synchronous SQLite I/O → **do** use `def`, not `async def` → **because** FastAPI only offloads sync work to a thread pool for plain `def` routes; `async def` with blocking SQLite calls freezes the entire event loop for the duration of the query

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -1333,9 +1333,11 @@ async def chat(
                         accumulated_text += event["text"]
                         yield _sse({"type": "text", "text": event["text"]})
                     elif etype == "_turn_complete":
-                        # Update the meter for this wrap-up turn (raw totals are
-                        # intentionally left untouched here, as before).
-                        usage_event = context_usage_event(event.get("usage", {}), provider.context_window)
+                        # Meter-only: this wrap-up turn is excluded from token/
+                        # cost accounting (raw totals untouched), so emit with
+                        # meter_only=True so the CLI session total ignores it too.
+                        usage_event = context_usage_event(
+                            event.get("usage", {}), provider.context_window, meter_only=True)
                         if usage_event:
                             yield _sse(usage_event)
                         break
@@ -1457,9 +1459,11 @@ async def chat(
                     accumulated_text += event["text"]
                     yield _sse({"type": "text", "text": event["text"]})
                 elif etype == "_turn_complete":
-                    # Update the meter for this wrap-up turn (raw totals are
-                    # intentionally left untouched here, as before).
-                    usage_event = context_usage_event(event.get("usage", {}), provider.context_window)
+                    # Meter-only: this wrap-up turn is excluded from token/cost
+                    # accounting (raw totals untouched), so emit with
+                    # meter_only=True so the CLI session total ignores it too.
+                    usage_event = context_usage_event(
+                        event.get("usage", {}), provider.context_window, meter_only=True)
                     if usage_event:
                         yield _sse(usage_event)
                     break

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -1198,8 +1198,8 @@ async def chat(
                 # Track raw token totals for the activity/cost log.
                 usage = event.get("usage", {})
                 if usage:
-                    total_input_tokens += usage.get("input_tokens", 0)
-                    total_output_tokens += usage.get("output_tokens", 0)
+                    total_input_tokens += usage.get("input_tokens") or 0
+                    total_output_tokens += usage.get("output_tokens") or 0
                 # Emit the context-meter usage event (cache-inclusive total over
                 # the model's real window). None when usage/window unavailable.
                 usage_event = context_usage_event(usage, provider.context_window)
@@ -1662,8 +1662,8 @@ async def run_sync(
                 tool_calls_this_turn = event.get("tool_calls", [])
                 stop_reason = event.get("stop_reason", "stop")
                 usage = event.get("usage", {})
-                total_input_tokens += usage.get("input_tokens", 0)
-                total_output_tokens += usage.get("output_tokens", 0)
+                total_input_tokens += usage.get("input_tokens") or 0
+                total_output_tokens += usage.get("output_tokens") or 0
 
             elif etype == "error":
                 logger.error("run_sync: provider error: %s", event.get("error"))

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -12,7 +12,9 @@ SSE event types emitted:
   tool_end         — tool result          {tool, tool_use_id, result, elapsed_ms}
   confirm          — write tool needs approval {tool, args, tool_use_id, description}
   plan_ready       — plan mode completed  {plan_text, status}
-  usage            — token usage          {input_tokens, output_tokens, context_window}
+  usage            — token usage          {input_tokens, output_tokens, context_tokens, context_window}
+                     input_tokens/output_tokens are RAW (CLI + cost log);
+                     context_tokens is the cache-inclusive total for the meter
   title_update     — AI-generated title   {title, conversation_id}
   done             — stream complete
   error            — error message
@@ -33,6 +35,7 @@ from zoneinfo import ZoneInfo
 
 from core.storage import upload_config, delete_config
 from core.providers.base import AIProvider, _sse
+from core.providers.windows import context_usage_event
 from .config import AgentConfig
 from .context_manager import ContextManager, is_social_closer, _tokenize
 from .tool_registry import ToolRegistry
@@ -1192,17 +1195,16 @@ async def chat(
                 tool_calls_this_turn = event.get("tool_calls", [])
                 stop_reason = event.get("stop_reason", "stop")
 
-                # Emit usage event and track totals
+                # Track raw token totals for the activity/cost log.
                 usage = event.get("usage", {})
                 if usage:
                     total_input_tokens += usage.get("input_tokens", 0)
                     total_output_tokens += usage.get("output_tokens", 0)
-                    yield _sse({
-                        "type": "usage",
-                        "input_tokens": usage.get("input_tokens", 0),
-                        "output_tokens": usage.get("output_tokens", 0),
-                        "context_window": 200000,  # Default context window
-                    })
+                # Emit the context-meter usage event (cache-inclusive total over
+                # the model's real window). None when usage/window unavailable.
+                usage_event = context_usage_event(usage, provider.context_window)
+                if usage_event:
+                    yield _sse(usage_event)
 
                 # Save assistant turn to history (with tool calls if any)
                 if persist and turn_text and conversation_id:
@@ -1331,6 +1333,11 @@ async def chat(
                         accumulated_text += event["text"]
                         yield _sse({"type": "text", "text": event["text"]})
                     elif etype == "_turn_complete":
+                        # Update the meter for this wrap-up turn (raw totals are
+                        # intentionally left untouched here, as before).
+                        usage_event = context_usage_event(event.get("usage", {}), provider.context_window)
+                        if usage_event:
+                            yield _sse(usage_event)
                         break
                 _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                     accumulated_text, all_tool_calls, model_used,
@@ -1450,6 +1457,11 @@ async def chat(
                     accumulated_text += event["text"]
                     yield _sse({"type": "text", "text": event["text"]})
                 elif etype == "_turn_complete":
+                    # Update the meter for this wrap-up turn (raw totals are
+                    # intentionally left untouched here, as before).
+                    usage_event = context_usage_event(event.get("usage", {}), provider.context_window)
+                    if usage_event:
+                        yield _sse(usage_event)
                     break
             _log_chat_completion(config.slug, conversation_id, "chat", "ok",
                                 accumulated_text, all_tool_calls, model_used,

--- a/backend/core/providers/anthropic_provider.py
+++ b/backend/core/providers/anthropic_provider.py
@@ -13,6 +13,7 @@ from typing import AsyncGenerator
 import anthropic
 
 from core.providers.base import AIProvider
+from core.providers.windows import get_context_window
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,16 @@ class AnthropicProvider(AIProvider):
     @property
     def provider_name(self) -> str:
         return "anthropic"
+
+    @property
+    def context_window(self) -> "int | None":
+        win = get_context_window(self.model)
+        if win is not None:
+            return win
+        # 200K is the documented floor for every current Claude model; apply it
+        # only to recognizably-Anthropic ids so a newly-released Claude model
+        # still shows a (correct-to-floor) meter instead of vanishing.
+        return 200_000 if self.model.startswith("claude-") else None
 
     def _format_tools(self, tools: list[dict]) -> list[dict]:
         """Convert internal tool format to Anthropic format (same schema)."""

--- a/backend/core/providers/base.py
+++ b/backend/core/providers/base.py
@@ -97,3 +97,17 @@ class AIProvider(ABC):
     def provider_name(self) -> str:
         """e.g. "anthropic", "openai", "google" """
         ...
+
+    @property
+    def context_window(self) -> "int | None":
+        """Model's context window in tokens, or None if unknown.
+
+        Drives the chat composer's context-fullness meter. The default is None
+        (window unknown → meter hidden); providers that know their model's
+        window override this. When a turn's usage and this window are both
+        available, ai_service emits a `usage` SSE event whose `context_tokens`
+        is the cache-inclusive total the model read (input + cache_creation +
+        cache_read) and `context_window` is this value. The event's
+        `input_tokens` / `output_tokens` stay RAW for the CLI and cost log.
+        """
+        return None

--- a/backend/core/providers/windows.py
+++ b/backend/core/providers/windows.py
@@ -36,7 +36,8 @@ def get_context_window(model: str) -> int | None:
     return MODEL_CONTEXT_WINDOWS[best_key] if best_key else None
 
 
-def context_usage_event(usage: dict, context_window: int | None) -> dict | None:
+def context_usage_event(usage: dict, context_window: int | None,
+                        meter_only: bool = False) -> dict | None:
     """Build the 'usage' SSE payload, or None when the meter can't be shown.
 
     The composer meter shows how full the context window is, so it needs the
@@ -50,10 +51,18 @@ def context_usage_event(usage: dict, context_window: int | None) -> dict | None:
     the activity/cost log sums them. Only `context_tokens` is cache-inclusive,
     and it is emit-only (never accumulated).
 
-    Returns None when there's no usage data or no known window, so the caller
-    simply emits nothing and the frontend keeps the meter hidden.
+    `meter_only=True` is used for the plan-mode / pending-confirmation wrap-up
+    turns. Those turns are deliberately excluded from token/cost accounting (the
+    backend cost log never accumulates them), so we zero the raw
+    input_tokens/output_tokens to keep the CLI session total — which sums every
+    usage event it sees — from picking them up. The meter still updates from
+    `context_tokens`.
+
+    Returns None when there's no usage data, no known window, or no usable
+    input-side count — so the caller emits nothing and the meter stays hidden
+    rather than rendering a misleading 0% / negative.
     """
-    if not usage or not context_window:
+    if not usage or context_window is None:
         return None
     # `or 0` guards a provider that supplies an explicit None for any field
     # (this helper is provider-generic; Anthropic returns ints today).
@@ -62,10 +71,15 @@ def context_usage_event(usage: dict, context_window: int | None) -> dict | None:
         + (usage.get("cache_creation_input_tokens") or 0)
         + (usage.get("cache_read_input_tokens") or 0)
     )
+    if context_tokens <= 0:
+        # No usable input-side count (e.g. output-only or malformed usage, or a
+        # negative from a buggy provider) — hide the meter instead of showing a
+        # bogus 0% / negative reading.
+        return None
     return {
         "type": "usage",
-        "input_tokens": usage.get("input_tokens") or 0,    # raw — CLI + cost log
-        "output_tokens": usage.get("output_tokens") or 0,  # raw
+        "input_tokens": 0 if meter_only else (usage.get("input_tokens") or 0),
+        "output_tokens": 0 if meter_only else (usage.get("output_tokens") or 0),
         "context_tokens": context_tokens,                  # cache-inclusive — meter
         "context_window": context_window,
     }

--- a/backend/core/providers/windows.py
+++ b/backend/core/providers/windows.py
@@ -1,0 +1,71 @@
+"""Chatty — Model context-window sizes and context-usage event building.
+
+Static per-model context-window sizes (in tokens) for known models, used to
+drive the chat composer's "context fullness" meter. Mirrors the resolution
+pattern in pricing.py: exact match first, then longest-prefix match so dated
+snapshots (e.g. claude-haiku-4-5-20251001) resolve to their base model.
+Unknown models return None — the meter is hidden rather than guessed.
+"""
+
+from __future__ import annotations
+
+
+# model id -> context window in tokens
+MODEL_CONTEXT_WINDOWS: dict[str, int] = {
+    "claude-opus-4-6":   200_000,
+    "claude-sonnet-4-6": 200_000,
+    "claude-haiku-4-5":  200_000,
+}
+
+
+def get_context_window(model: str) -> int | None:
+    """Resolve the context-window size (tokens) for a model id.
+
+    Exact match first, then longest-prefix match so dated snapshots resolve
+    to their base model. Returns None for unknown models.
+    """
+    if not model:
+        return None
+    exact = MODEL_CONTEXT_WINDOWS.get(model)
+    if exact is not None:
+        return exact
+    best_key = None
+    for key in MODEL_CONTEXT_WINDOWS:
+        if model.startswith(key) and (best_key is None or len(key) > len(best_key)):
+            best_key = key
+    return MODEL_CONTEXT_WINDOWS[best_key] if best_key else None
+
+
+def context_usage_event(usage: dict, context_window: int | None) -> dict | None:
+    """Build the 'usage' SSE payload, or None when the meter can't be shown.
+
+    The composer meter shows how full the context window is, so it needs the
+    cache-inclusive total input the model actually read this turn — with prompt
+    caching active most of that lives in cache_read/cache_creation, not in the
+    plain input_tokens field. That cache-inclusive total is emitted as
+    `context_tokens`.
+
+    `input_tokens` / `output_tokens` stay RAW: other consumers depend on them —
+    the CLI accumulates them into its session total (backend/cli/output.py) and
+    the activity/cost log sums them. Only `context_tokens` is cache-inclusive,
+    and it is emit-only (never accumulated).
+
+    Returns None when there's no usage data or no known window, so the caller
+    simply emits nothing and the frontend keeps the meter hidden.
+    """
+    if not usage or not context_window:
+        return None
+    # `or 0` guards a provider that supplies an explicit None for any field
+    # (this helper is provider-generic; Anthropic returns ints today).
+    context_tokens = (
+        (usage.get("input_tokens") or 0)
+        + (usage.get("cache_creation_input_tokens") or 0)
+        + (usage.get("cache_read_input_tokens") or 0)
+    )
+    return {
+        "type": "usage",
+        "input_tokens": usage.get("input_tokens") or 0,    # raw — CLI + cost log
+        "output_tokens": usage.get("output_tokens") or 0,  # raw
+        "context_tokens": context_tokens,                  # cache-inclusive — meter
+        "context_window": context_window,
+    }

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -303,6 +303,24 @@ class TestContextUsageMeter:
         )
         assert not [e for e in events if e["type"] == "usage"]
 
+    async def test_none_token_fields_do_not_crash(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        # A provider returning an explicit None token must not crash the
+        # raw-total accumulation path (regression for the `+= None` TypeError).
+        mock_prov.set_responses([[
+            {"type": "text", "text": "hi"},
+            {"type": "_turn_complete", "tool_calls": [], "stop_reason": "stop",
+             "usage": {"input_tokens": None, "output_tokens": 5,
+                       "cache_read_input_tokens": 1_000}},
+        ]])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "hi"}], tool_mode="power")
+        )
+        assert events[-1]["type"] == "done"
+        usage = [e for e in events if e["type"] == "usage"]
+        assert len(usage) == 1
+        assert usage[0]["context_tokens"] == 1_000     # 0 + 0 + 1000
+
 
 class TestToolExecution:
     async def test_tool_call_executes_and_continues(self, fake_config, mock_prov, mock_registry, mock_ctx):

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -245,6 +245,63 @@ class TestContextUsageMeter:
         assert len(usage) == 1
         assert usage[0]["context_tokens"] == 5_100     # 100 + 5000
         assert usage[0]["context_window"] == 200_000
+        # meter-only: raw tokens zeroed so the CLI session total ignores them.
+        assert usage[0]["input_tokens"] == 0
+        assert usage[0]["output_tokens"] == 0
+
+    async def test_meter_updates_on_plan_mode_exit(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        # The exit_plan_mode wrap-up turn must also emit a (meter-only) usage event.
+        mock_prov.set_responses([
+            [
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "exit_plan_mode", "id": "tu1", "args": {"plan": "Do the thing."}}
+                ], "stop_reason": "tool_use", "usage": {}},
+            ],
+            [
+                {"type": "text", "text": "Plan ready for your review."},
+                {"type": "_turn_complete", "tool_calls": [], "stop_reason": "stop",
+                 "usage": {"input_tokens": 200, "output_tokens": 30,
+                           "cache_read_input_tokens": 9_800}},
+            ],
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "make a plan"}],
+                 tool_mode="power", plan_mode=True)
+        )
+        assert "plan_ready" in [e["type"] for e in events]
+        usage = [e for e in events if e["type"] == "usage"]
+        assert len(usage) == 1
+        assert usage[0]["context_tokens"] == 10_000     # 200 + 9800
+        assert usage[0]["input_tokens"] == 0            # meter-only
+        assert usage[0]["context_window"] == 200_000
+
+    async def test_no_usage_event_at_continuation_when_window_unknown(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        # Even with real wrap-up usage, an unknown window keeps the meter hidden.
+        mock_prov.context_window_value = None
+        mock_prov.set_responses([
+            [
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "send_email", "id": "tu1", "args": {}}
+                ], "stop_reason": "tool_use", "usage": {}},
+            ],
+            [
+                {"type": "text", "text": "I'll send that once you confirm."},
+                {"type": "_turn_complete", "tool_calls": [], "stop_reason": "stop",
+                 "usage": {"input_tokens": 100, "cache_read_input_tokens": 5_000}},
+            ],
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "send email"}],
+                 tool_mode="normal",
+                 integration_tool_defs=[{
+                     "name": "send_email", "kind": "gmail",
+                     "writes": True, "input_schema": {"type": "object", "properties": {}},
+                     "description": "Send an email",
+                 }])
+        )
+        assert not [e for e in events if e["type"] == "usage"]
 
 
 class TestToolExecution:

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -22,6 +22,8 @@ class MockAIProvider(AIProvider):
         super().__init__(model="mock-model")
         self._responses = responses or [self._default_response()]
         self._call_index = 0
+        # Drives the context meter; set to None to simulate an unknown window.
+        self.context_window_value = 200_000
 
     @staticmethod
     def _default_response():
@@ -66,6 +68,10 @@ class MockAIProvider(AIProvider):
     @property
     def provider_name(self):
         return "mock"
+
+    @property
+    def context_window(self):
+        return self.context_window_value
 
 
 # ---------------------------------------------------------------------------
@@ -170,8 +176,75 @@ class TestSingleTurn:
         )
         usage = [e for e in events if e["type"] == "usage"]
         assert len(usage) == 1
-        assert usage[0]["input_tokens"] == 10
-        assert usage[0]["output_tokens"] == 5
+        assert usage[0]["input_tokens"] == 10        # raw
+        assert usage[0]["output_tokens"] == 5         # raw
+        assert usage[0]["context_tokens"] == 10       # cache-inclusive (no cache here)
+        assert usage[0]["context_window"] == 200_000
+
+
+class TestContextUsageMeter:
+    """The 'usage' SSE event that drives the composer context-fullness meter."""
+
+    async def test_context_tokens_is_cache_inclusive(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        # With prompt caching, the bulk of the prompt lives in cache_* fields;
+        # context_tokens must sum all three while input_tokens stays raw.
+        mock_prov.set_responses([[
+            {"type": "text", "text": "hi"},
+            {"type": "_turn_complete", "tool_calls": [], "stop_reason": "stop",
+             "usage": {"input_tokens": 300, "output_tokens": 50,
+                       "cache_creation_input_tokens": 1_000,
+                       "cache_read_input_tokens": 48_700}},
+        ]])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "hi"}], tool_mode="power")
+        )
+        usage = next(e for e in events if e["type"] == "usage")
+        assert usage["input_tokens"] == 300            # raw uncached delta
+        assert usage["context_tokens"] == 50_000       # 300 + 1000 + 48700
+        assert usage["context_window"] == 200_000
+
+    async def test_no_usage_event_when_window_unknown(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        # Provider can't report a window (e.g. non-Anthropic, follow-up PR) →
+        # meter stays hidden, no 'usage' event at all.
+        mock_prov.context_window_value = None
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "hi"}], tool_mode="power")
+        )
+        assert not [e for e in events if e["type"] == "usage"]
+
+    async def test_meter_updates_on_pending_confirmation_continuation(self, fake_config, mock_prov, mock_registry, mock_ctx):
+        # A write tool in normal mode emits a confirm and runs a wrap-up turn;
+        # that continuation turn must still emit the meter usage event.
+        mock_prov.set_responses([
+            [
+                {"type": "_turn_complete", "tool_calls": [
+                    {"name": "send_email", "id": "tu1", "args": {}}
+                ], "stop_reason": "tool_use", "usage": {}},
+            ],
+            [
+                {"type": "text", "text": "I'll send that once you confirm."},
+                {"type": "_turn_complete", "tool_calls": [], "stop_reason": "stop",
+                 "usage": {"input_tokens": 100, "output_tokens": 20,
+                           "cache_read_input_tokens": 5_000}},
+            ],
+        ])
+        events = await collect_events(
+            chat(fake_config, mock_prov, mock_registry, mock_ctx,
+                 [{"role": "user", "content": "send email"}],
+                 tool_mode="normal",
+                 integration_tool_defs=[{
+                     "name": "send_email", "kind": "gmail",
+                     "writes": True, "input_schema": {"type": "object", "properties": {}},
+                     "description": "Send an email",
+                 }])
+        )
+        assert "confirm" in [e["type"] for e in events]
+        usage = [e for e in events if e["type"] == "usage"]
+        assert len(usage) == 1
+        assert usage[0]["context_tokens"] == 5_100     # 100 + 5000
+        assert usage[0]["context_window"] == 200_000
 
 
 class TestToolExecution:

--- a/backend/tests/test_windows.py
+++ b/backend/tests/test_windows.py
@@ -53,6 +53,25 @@ class TestContextUsageEvent:
         assert ev["context_tokens"] == 15          # 10 + 0 + 5
         assert ev["output_tokens"] == 0
 
+    def test_none_when_only_output_tokens(self):
+        # Output-only usage (no input-side tokens) -> hidden, not a bogus 0%.
+        assert context_usage_event({"output_tokens": 50}, 200_000) is None
+
+    def test_none_when_all_tokens_zero(self):
+        assert context_usage_event({"input_tokens": 0, "output_tokens": 0}, 200_000) is None
+
+    def test_meter_only_zeros_raw_tokens(self):
+        # Wrap-up turns emit meter_only so the CLI session total ignores them,
+        # while context_tokens stays accurate for the meter.
+        ev = context_usage_event(
+            {"input_tokens": 100, "output_tokens": 20, "cache_read_input_tokens": 5_000},
+            200_000, meter_only=True,
+        )
+        assert ev["input_tokens"] == 0
+        assert ev["output_tokens"] == 0
+        assert ev["context_tokens"] == 5_100
+        assert ev["context_window"] == 200_000
+
 
 class TestAnthropicContextWindow:
     def test_known_model(self):
@@ -70,3 +89,13 @@ class TestAnthropicContextWindow:
     def test_non_claude_model_returns_none(self):
         prov = AnthropicProvider(api_key="x", model="some-other-model")
         assert prov.context_window is None
+
+
+class TestAnthropicModelsCoverage:
+    def test_all_listed_models_resolve_to_a_window(self):
+        # Guards against drift: every model the provider offers must resolve to a
+        # known window (or the claude- family floor), never None.
+        from core.providers.anthropic_provider import ANTHROPIC_MODELS
+        for model in ANTHROPIC_MODELS:
+            prov = AnthropicProvider(api_key="x", model=model)
+            assert prov.context_window == 200_000, f"{model} window drifted"

--- a/backend/tests/test_windows.py
+++ b/backend/tests/test_windows.py
@@ -1,0 +1,72 @@
+"""Tests for context-window resolution and the context-usage SSE payload."""
+
+from core.providers.windows import get_context_window, context_usage_event
+from core.providers.anthropic_provider import AnthropicProvider
+
+
+class TestGetContextWindow:
+    def test_exact_match(self):
+        assert get_context_window("claude-opus-4-6") == 200_000
+
+    def test_longest_prefix_match_for_dated_snapshot(self):
+        # claude-haiku-4-5-20251001 resolves to the claude-haiku-4-5 base.
+        assert get_context_window("claude-haiku-4-5-20251001") == 200_000
+
+    def test_unknown_model_returns_none(self):
+        assert get_context_window("gpt-4o") is None
+
+    def test_empty_model_returns_none(self):
+        assert get_context_window("") is None
+
+
+class TestContextUsageEvent:
+    def test_cache_inclusive_total(self):
+        ev = context_usage_event(
+            {"input_tokens": 300, "output_tokens": 50,
+             "cache_creation_input_tokens": 1_000,
+             "cache_read_input_tokens": 48_700},
+            200_000,
+        )
+        assert ev["type"] == "usage"
+        assert ev["input_tokens"] == 300            # raw stays raw
+        assert ev["output_tokens"] == 50
+        assert ev["context_tokens"] == 50_000       # 300 + 1000 + 48700
+        assert ev["context_window"] == 200_000
+
+    def test_no_cache_fields_falls_back_to_input(self):
+        ev = context_usage_event({"input_tokens": 10, "output_tokens": 5}, 200_000)
+        assert ev["context_tokens"] == 10
+
+    def test_none_when_usage_empty(self):
+        assert context_usage_event({}, 200_000) is None
+
+    def test_none_when_window_unknown(self):
+        assert context_usage_event({"input_tokens": 10}, None) is None
+
+    def test_coerces_explicit_none_fields(self):
+        # A provider that supplies an explicit None must not raise.
+        ev = context_usage_event(
+            {"input_tokens": 10, "output_tokens": None,
+             "cache_creation_input_tokens": None, "cache_read_input_tokens": 5},
+            200_000,
+        )
+        assert ev["context_tokens"] == 15          # 10 + 0 + 5
+        assert ev["output_tokens"] == 0
+
+
+class TestAnthropicContextWindow:
+    def test_known_model(self):
+        prov = AnthropicProvider(api_key="x", model="claude-sonnet-4-6")
+        assert prov.context_window == 200_000
+
+    def test_dated_snapshot_resolves_via_prefix(self):
+        prov = AnthropicProvider(api_key="x", model="claude-haiku-4-5-20251001")
+        assert prov.context_window == 200_000
+
+    def test_unknown_claude_model_uses_family_floor(self):
+        prov = AnthropicProvider(api_key="x", model="claude-opus-9-9")
+        assert prov.context_window == 200_000
+
+    def test_non_claude_model_returns_none(self):
+        prov = AnthropicProvider(api_key="x", model="some-other-model")
+        assert prov.context_window is None

--- a/docs/solutions/logic-errors/context-meter-cache-token-accounting.md
+++ b/docs/solutions/logic-errors/context-meter-cache-token-accounting.md
@@ -1,0 +1,55 @@
+---
+title: Context-fullness meter stuck at 0% — Anthropic prompt-cache token accounting
+date: 2026-06-15
+category: logic-errors
+module: core/agents/ai_service, core/providers/windows
+tags: [anthropic, prompt-caching, sse, token-accounting, context-window, cli]
+problem_type: bug
+---
+
+## Problem
+The agent chat "context fullness" meter always showed 0%, even in long
+conversations that clearly filled much of the model's context window.
+
+## Symptoms
+- Composer hint rendered `0% ctx · ⏎ send` on essentially every Anthropic turn.
+- Backend emitted a `usage` SSE event with a small `input_tokens` over a
+  hardcoded `200000` window → `~300 / 200000 ≈ 0%`.
+
+## What Didn't Work
+- **Naively summing the cache tokens into `input_tokens`** (redefining the
+  field to be cache-inclusive). This fixed the meter but silently broke the
+  CLI: `backend/cli/output.py` accumulates every `usage` event's `input_tokens`
+  into the session total, so re-read cache tokens got summed every turn and
+  inflated the count. The same field is consumed by two different clients (the
+  React hook and the terminal harness).
+
+## Solution
+1. Emit a NEW `context_tokens` field = `input_tokens +
+   cache_creation_input_tokens + cache_read_input_tokens` for the meter; leave
+   `input_tokens`/`output_tokens` RAW for the CLI + cost log.
+2. Source the window per-model from the provider (`AIProvider.context_window`;
+   Anthropic reports its real window) instead of a hardcoded 200000. `None`
+   hides the meter (graceful for providers not yet wired).
+3. Plan-mode-exit and pending-confirmation wrap-up turns emit `meter_only=True`
+   events (raw token fields zeroed) so the meter updates without the CLI
+   double-counting those extra API calls.
+4. Frontend reads `context_tokens`, guards divide-by-zero, clamps 0–100%, and
+   clears the meter on conversation switch.
+
+## Why This Works
+Anthropic reports cached prompt tokens under `cache_read_input_tokens` /
+`cache_creation_input_tokens`, NOT under `input_tokens`. With aggressive prompt
+caching (system + tools + conversation prefix all cache-controlled),
+`input_tokens` is only the uncached delta — a few hundred tokens — so it never
+reflects true window occupancy. The fix measures the full prompt the model
+actually read while keeping the raw billing fields intact for other consumers.
+
+## Prevention
+- Treat the chat SSE stream as having MULTIPLE consumers (web hook + CLI
+  StreamRenderer). Before changing a `usage` field's meaning, check every
+  consumer.
+- When a single event serves both "display" and "accounting", separate the
+  concerns (distinct fields / a `meter_only` flag) rather than overloading one.
+- Reset per-conversation derived UI state in the conversation-load handler, not
+  only in `clear()`, or it shows a stale reading from the previous conversation.

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -488,9 +488,11 @@ export function AgentChatPanel({
           fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
           color: 'rgba(237,240,244,0.38)',
         }}>
-          {contextUsage ? (() => {
-            const pct = Math.round((contextUsage.inputTokens / contextUsage.contextWindow) * 100);
-            return `${pct}% ctx · ⏎ send`;
+          {contextUsage && contextUsage.contextWindow > 0 ? (() => {
+            const pct = Math.min(100, Math.round((contextUsage.contextTokens / contextUsage.contextWindow) * 100));
+            // Neutral < 75%, amber 75–90%, red > 90%.
+            const color = pct > 90 ? '#e0524d' : pct >= 75 ? '#d9a441' : 'rgba(237,240,244,0.38)';
+            return <span style={{ color }}>{`${pct}% ctx · ⏎ send`}</span>;
           })() : '⏎ send'}
         </div>
       </div>

--- a/frontend/src/agent/components/AgentChatPanel.tsx
+++ b/frontend/src/agent/components/AgentChatPanel.tsx
@@ -489,7 +489,7 @@ export function AgentChatPanel({
           color: 'rgba(237,240,244,0.38)',
         }}>
           {contextUsage && contextUsage.contextWindow > 0 ? (() => {
-            const pct = Math.min(100, Math.round((contextUsage.contextTokens / contextUsage.contextWindow) * 100));
+            const pct = Math.max(0, Math.min(100, Math.round((contextUsage.contextTokens / contextUsage.contextWindow) * 100)));
             // Neutral < 75%, amber 75–90%, red > 90%.
             const color = pct > 90 ? '#e0524d' : pct >= 75 ? '#d9a441' : 'rgba(237,240,244,0.38)';
             return <span style={{ color }}>{`${pct}% ctx · ⏎ send`}</span>;

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -77,7 +77,7 @@ export interface ChatMessage {
 }
 
 export interface ContextUsage {
-  inputTokens: number;
+  contextTokens: number;
   contextWindow: number;
 }
 
@@ -324,9 +324,9 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
                   status: 'pending',
                 },
               }));
-            } else if (event.type === 'usage' && event.input_tokens != null && event.context_window != null) {
+            } else if (event.type === 'usage' && event.context_tokens != null && event.context_window != null) {
               setContextUsage({
-                inputTokens: event.input_tokens,
+                contextTokens: event.context_tokens,
                 contextWindow: event.context_window,
               });
             } else if (event.type === 'report' && event.report) {

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -13,6 +13,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { getToken } from '../../core/auth/tokenUtils';
+import type { ContextUsage } from '../../core/types';
 
 function uuid(): string {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
@@ -76,10 +77,9 @@ export interface ChatMessage {
   playbook?: { slug: string; name: string };
 }
 
-export interface ContextUsage {
-  contextTokens: number;
-  contextWindow: number;
-}
+// ContextUsage lives in core/types as the single source of truth; re-exported
+// here so existing importers (AgentChatPanel) keep their import path.
+export type { ContextUsage };
 
 interface Options {
   onTitleUpdate?: (convId: string, title: string) => void;

--- a/frontend/src/agent/hooks/useAgentChat.ts
+++ b/frontend/src/agent/hooks/useAgentChat.ts
@@ -521,6 +521,10 @@ export function useAgentChat(apiPrefix: string, options?: Options) {
       streamInIntervalRef.current = null;
     }
 
+    // New conversation loaded — clear the previous conversation's context meter
+    // so it doesn't keep showing a stale fullness % until the next turn updates it.
+    setContextUsage(null);
+
     if (!streamIn || !msgs.length || msgs[msgs.length - 1].role !== 'assistant') {
       setMessages(msgs);
       setConversationId(id);

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -236,8 +236,10 @@ export interface ProviderStatus {
 }
 
 // Context usage (returned from SSE 'usage' event)
+// contextTokens is the cache-inclusive total the model read this turn (how full
+// the context window is); contextWindow is the model's window size.
 export interface ContextUsage {
-  inputTokens: number;
+  contextTokens: number;
   contextWindow: number;
 }
 
@@ -256,7 +258,7 @@ export type SSEEvent =
   | { type: 'tool_end'; tool: string; tool_use_id: string; result: unknown; elapsed_ms?: number; duration_ms?: number }
   | { type: 'confirm'; tool: string; args: Record<string, unknown>; tool_use_id: string; description: string }
   | { type: 'plan_ready'; plan: string }
-  | { type: 'usage'; input_tokens: number; context_window: number }
+  | { type: 'usage'; input_tokens: number; output_tokens: number; context_tokens: number; context_window: number }
   | { type: 'report'; report: { id: string; title: string; subtitle?: string; sections: unknown[]; created_at: string } }
   | { type: 'title_update'; title: string; conversation_id: string }
   | { type: 'done'; model?: string; tier?: string }


### PR DESCRIPTION
## Summary
- **Fixes the agent chat context meter always showing 0%.** Root cause: with prompt caching the bulk of the prompt is reported under `cache_read_input_tokens`/`cache_creation_input_tokens`, but the backend forwarded only the tiny uncached `input_tokens` over a hardcoded `200000` window → `~300/200000 ≈ 0%` every turn.
- Backend now emits a cache-inclusive `context_tokens` (`input + cache_creation + cache_read`) over the model's **real** window (provider-reported via a new `windows.py`, mirroring `pricing.py`'s resolution). Raw `input_tokens`/`output_tokens` stay untouched for the CLI session total and cost log.
- Plan-mode-exit and pending-confirmation wrap-up turns emit `meter_only` usage events (zeroed raw tokens) so the meter updates without polluting token/cost accounting.
- Frontend reads `context_tokens`, guards divide-by-zero, clamps `0–100%`, clears the meter on conversation switch, and colors it by fullness (neutral `<75%`, amber `75–90%`, red `>90%`).
- Scope is **Anthropic-only**; other providers report no window today and the meter stays hidden (graceful) until a follow-up PR.

Hardened through a grill-me design pass, a 2-round plan review (Codex), and a multi-stage code review (4 Sonnet personas + 2 Codex rounds): fixed a CLI/cost-log divergence, a stale cross-conversation meter, a `+= None` crash, guard precision (`is None`, `context_tokens<=0`), and consolidated a duplicate `ContextUsage` type.

## Test plan
- [x] `windows.py` units — window resolution (exact/prefix/unknown), `context_usage_event` (cache-inclusive sum, raw passthrough, meter_only zeroing, None-coercion, zero/output-only guards)
- [x] Anthropic `context_window` (known/dated/family-floor/non-claude) + `ANTHROPIC_MODELS` drift guard
- [x] Handler-level SSE: cache-inclusive `context_tokens` + raw `input_tokens`, plan-mode-exit and pending-confirmation continuation emits, window-unknown hidden, None-token no-crash
- [x] Full backend suite green (833 passed)
- [ ] `npm run build` (frontend typecheck) — not run locally (broken `node@24`/simdjson); please verify in CI
- [ ] Manual: Anthropic chat shows a non-zero %, climbs, recolors near 75/90%, updates after plan-mode exit; OpenAI shows just `⏎ send`