### PR TITLE
Guarantee scheduled-action delivery (cron + heartbeat) as a system step

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ You can tailor the export to fit the new agent's purpose. For example, if your e
 
 **No existing agent? Use any AI chat.** Open ChatGPT, Claude, or any AI assistant and ask it something like: *"Search your memory and our conversation history, then create a markdown knowledge file I can give to a new AI agent that explains who I am, what I do, what's important to me, and how I like to work."* Paste the result into Chatty and you've got a head start.
 
+## Scheduled Actions & Heartbeat
+
+Your agents can work on their own on a schedule. There are two kinds of background work, and they deliver results differently — by design:
+
+- **Scheduled actions (cron)** — *report* tasks, like a 5:15 AM "morning brief." These run on a cron schedule and their output is **always delivered to you** — via browser push, Telegram, WhatsApp, and the in-app notification log. Delivery is **guaranteed by Chatty itself, not by the model**: the agent just writes its report as its final response and the system sends it. (If a run genuinely has nothing to report, the agent can reply with exactly `[SILENT]` to skip that one delivery.)
+- **Heartbeat** — a *monitor* task that runs periodically (e.g. every 30 minutes) against a checklist in the agent's `HEARTBEAT.md`. It uses the **same delivery guarantee**: if the heartbeat finds something (`ACTION_TAKEN: …`), Chatty delivers it; if nothing new needs attention the agent replies `HEARTBEAT_OK` and stays silent. Cheap triage and the checklist skip most ticks before they ever run, and the agent reports only what's *new* — so you're not spammed.
+- **Reminders** — one-time or recurring nudges that trigger the agent to act or notify you.
+
+> **Why the guarantee matters:** a scheduled task's whole purpose is to reach you. Earlier versions relied on the AI choosing to call a notification tool, so a model change could silently swallow a brief. Chatty now delivers a scheduled action's output (cron *and* heartbeat) as a system step regardless of model behavior — the only suppressor is the agent explicitly going silent (`[SILENT]` / `HEARTBEAT_OK`). **Contributors:** keep delivery in the processor (`backend/core/agents/scheduled_actions/processor.py`) — don't move it back into model-prompt instructions. See `docs/solutions/architecture-patterns/scheduled-action-guaranteed-delivery.md`.
+
 ## Integrations
 
 Chatty connects to your existing business tools so your agents can answer questions, look up data, and take action on your behalf.

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -5,6 +5,7 @@ Uses a ThreadPoolExecutor for parallel execution with atomic claim/lease
 to prevent duplicate work across overlapping ticks.
 """
 
+import json
 import logging
 import os
 import threading
@@ -31,6 +32,49 @@ _AGENT_TURN_ERRORS = frozenset({
     "(no response)",
     "(max iterations reached)",
 })
+
+# Marker the model emits to suppress auto-delivery of a cron run's output
+# (Hermes-style). When a cron's final response is exactly this, nothing is sent.
+SILENT_MARKER = "[SILENT]"
+
+
+def _delivered_via_tool(tool_log: list) -> bool:
+    """True only if a notify_user/post_message call actually SUCCEEDED this run.
+
+    Checks the tool RESULT, not just the tool name: a notify_user entry can be a
+    failure — rejected by the write budget / hourly rate limit (background_runner)
+    or an arg/error return (tool_registry). Conservative on unparseable results:
+    treat as NOT delivered so the auto-fallback fires (a possible duplicate beats
+    a silent miss). Both notify_user and post_message return {"ok": True, ...} on
+    success and {"error": ...} on failure.
+    """
+    for tc in tool_log:
+        if tc.get("tool") not in ("notify_user", "post_message"):
+            continue
+        try:
+            res = json.loads(tc.get("result") or "")
+        except (ValueError, TypeError):
+            continue
+        if isinstance(res, dict) and res.get("ok") is True:
+            return True
+    return False
+
+
+# Status marker a heartbeat emits when it has something to report. HEARTBEAT_OK is
+# its silent marker (OpenClaw uses the same token). Delivery is guaranteed unless
+# the run went silent — see scheduled-action-guaranteed-delivery solution doc.
+_ACTION_MARKER = "ACTION_TAKEN:"
+
+
+def _strip_action_marker(text: str) -> str:
+    """Return the heartbeat report body with the ACTION_TAKEN: marker removed, so
+    the delivered notification reads cleanly (mirrors OpenClaw's stripHeartbeatToken).
+    Falls back to the full text if nothing follows the marker."""
+    s = text.strip()
+    idx = s.upper().find(_ACTION_MARKER)
+    if idx == -1:
+        return s
+    return s[idx + len(_ACTION_MARKER):].strip() or s
 
 # Triage classifier model is resolved via tiers.get_triage_classifier()
 # (override -> inferred -> hardcoded), unifying what used to be a separate,
@@ -567,10 +611,10 @@ def _process_heartbeat(action: dict) -> None:
                 f"- Time: {time_str}\n\n"
                 + (f"{followups_block}\n\n" if followups_block else "")
                 + "## Rules\n\n"
-                "- If everything is normal and no action is needed, respond with exactly: HEARTBEAT_OK\n"
-                "- If something needs attention, take action using your tools.\n"
-                "- Use `notify_user` to alert the user about important findings or actions taken — this sends push notifications to their devices. Only call it when you have something genuinely worth alerting about.\n"
-                "- After completing your checks, respond with: ACTION_TAKEN: <brief description of what you found/did>\n"
+                "- If nothing NEW needs attention since your last check, respond with exactly: HEARTBEAT_OK (this suppresses any notification).\n"
+                "- If something needs attention, take action using your tools, then respond with: ACTION_TAKEN: <concise summary of what you found/did>.\n"
+                "- That ACTION_TAKEN summary is delivered to the user automatically (push, Telegram, WhatsApp, in-app log) — you do NOT need to call `notify_user`.\n"
+                "- Only report what is NEW since your last check — do not re-report standing conditions you already reported, or you will spam the user.\n"
                 "- Be concise. This is an automated check, not a conversation.\n"
                 f"{error_context}"
             ),
@@ -617,10 +661,38 @@ def _process_heartbeat(action: dict) -> None:
                 )
             return
 
-        notified = any(
-            tc.get("tool") in ("notify_user", "post_message")
-            for tc in result.tool_log
-        )
+        model_notified = _delivered_via_tool(result.tool_log)
+
+        # Guaranteed delivery, same model as cron and OpenClaw's heartbeat: the
+        # run's report is delivered unless the model went silent with HEARTBEAT_OK
+        # (status "ok"). status == "action_taken" means a real report → deliver it,
+        # unless the model already delivered (avoids a double-send). Triage and the
+        # empty-checklist early-returns above keep most ticks from ever getting
+        # here, and the prompt tells the model to report only what is NEW.
+        auto_delivered = False
+        delivery_marker = None
+        if status == "action_taken" and not model_notified:
+            body = _strip_action_marker(result.text)
+            if body:
+                try:
+                    from core.agents.notifications.delivery import deliver_notification
+                    title = action.get("name") or "Heartbeat update"
+                    report = deliver_notification(agent_slug, title, body[:4000])
+                    auto_delivered = bool(report.get("ok"))
+                    channels = report.get("channels_sent", [])
+                    delivery_marker = {"tool": "auto_deliver", "ok": auto_delivered, "channels": channels}
+                    if auto_delivered:
+                        logger.info("Heartbeat %s: auto-delivered action report (channels=%s)", agent_slug, channels or ["in-app log"])
+                    else:
+                        logger.warning("Heartbeat %s: auto-delivery returned not-ok: %s", agent_slug, report)
+                except Exception as e:
+                    delivery_marker = {"tool": "auto_deliver", "ok": False, "error": str(e)[:200]}
+                    logger.warning("Heartbeat %s: auto-delivery failed: %s", agent_slug, e)
+
+        notification_sent = model_notified or auto_delivered
+        # Prepend the marker so it survives history's 10 KB tool_calls truncation.
+        if delivery_marker:
+            full_tool_log = [delivery_marker] + full_tool_log
 
         if execution_id:
             history.record_complete(
@@ -632,9 +704,12 @@ def _process_heartbeat(action: dict) -> None:
                 input_tokens=total_inp,
                 output_tokens=total_out,
                 duration_ms=duration_ms,
-                notification_sent=notified,
+                notification_sent=notification_sent,
             )
-        logger.info("Heartbeat %s: %s (%dms, tools: %d)", agent_slug, status, duration_ms, len(result.tool_log))
+        logger.info(
+            "Heartbeat %s: %s (%dms, tools: %d, notified=%s, auto=%s)",
+            agent_slug, status, duration_ms, len(result.tool_log), model_notified, auto_delivered,
+        )
 
     except Exception as e:
         duration_ms = int((time.monotonic() - start_time) * 1000)
@@ -697,7 +772,10 @@ def _process_cron(action: dict) -> None:
             f"- Date: {date_str}\n"
             f"- Time: {time_str}\n\n"
             f"Take appropriate action using your tools. Be concise.\n"
-            f"Use `notify_user` to alert the user about important findings or completed actions."
+            f"Your final response will be delivered to the user automatically — just "
+            f"produce your report as your final response. You do not need to call "
+            f"`notify_user`. If there is genuinely nothing to report, respond with "
+            f"exactly [SILENT] and nothing else."
         ),
     )
 
@@ -737,24 +815,60 @@ def _process_cron(action: dict) -> None:
                 )
             return
 
-        notified = any(
-            tc.get("tool") in ("notify_user", "post_message")
-            for tc in result.tool_log
-        )
+        model_notified = _delivered_via_tool(result.tool_log)
+
+        # Model-independent delivery guarantee: a cron action's whole purpose is
+        # to report back, so if the run produced output but the model didn't
+        # deliver it (and didn't explicitly go silent), the system delivers it
+        # via the same path notify_user uses. Best-effort against MODEL behavior
+        # (a model swap / a skipped tool call) — not crash-proof; see the
+        # scheduled-action-guaranteed-delivery solution doc.
+        text = result.text.strip()
+        is_silent = text.upper() == SILENT_MARKER
+        auto_delivered = False
+        delivery_marker = None
+        if status == "ok" and text and not is_silent and not model_notified:
+            try:
+                from core.agents.notifications.delivery import deliver_notification
+                title = action.get("name") or "Scheduled update"
+                report = deliver_notification(agent_slug, title, result.text[:4000])
+                auto_delivered = bool(report.get("ok"))
+                channels = report.get("channels_sent", [])
+                delivery_marker = {"tool": "auto_deliver", "ok": auto_delivered, "channels": channels}
+                if auto_delivered:
+                    # Empty channels just means "in-app log only" (no push sub /
+                    # external channels off) — a valid state, not an error.
+                    logger.info("Cron %s: auto-delivered result (channels=%s)", agent_slug, channels or ["in-app log"])
+                else:
+                    logger.warning("Cron %s: auto-delivery returned not-ok: %s", agent_slug, report)
+            except Exception as e:
+                delivery_marker = {"tool": "auto_deliver", "ok": False, "error": str(e)[:200]}
+                logger.warning("Cron %s: auto-delivery failed: %s", agent_slug, e)
+        elif is_silent:
+            logger.info("Cron %s: model returned [SILENT] — skipping delivery", agent_slug)
+
+        notification_sent = model_notified or auto_delivered
+        # Prepend the marker so it survives history.record_complete's 10 KB
+        # tool_calls truncation. The durable signal is the notification_sent
+        # column; status=ok + notification_sent=False flags "ran but not notified".
+        tool_calls = ([delivery_marker] + result.tool_log) if delivery_marker else result.tool_log
 
         if completed and execution_id:
             history.record_complete(
                 execution_id, status=status,
                 result_summary=result.text[:500],
                 result_full=result.text,
-                tool_calls=result.tool_log,
+                tool_calls=tool_calls,
                 model_used=result.model_used, provider=result.provider,
                 input_tokens=result.input_tokens,
                 output_tokens=result.output_tokens,
                 duration_ms=duration_ms,
-                notification_sent=notified,
+                notification_sent=notification_sent,
             )
-        logger.info("Cron %s/%s: %s (%dms, notified=%s)", agent_slug, action["id"][:8], status, duration_ms, notified)
+        logger.info(
+            "Cron %s/%s: %s (%dms, notified=%s, auto=%s)",
+            agent_slug, action["id"][:8], status, duration_ms, model_notified, auto_delivered,
+        )
     except Exception as e:
         duration_ms = int((time.monotonic() - start_time) * 1000)
         logger.error("Cron %s failed: %s", agent_slug, e)

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1393,7 +1393,9 @@ Use `create_scheduled_action` only when you need a task with its own independent
 - Your heartbeat runs 24/7 by default (`always_on`). Time-gating belongs in your HEARTBEAT.md checklist items (e.g., "Only on weekdays before 10 AM: ..."), not on the heartbeat's active hours.
 
 ### Notifying the User
-During background execution (heartbeat, scheduled actions, reminders), use `notify_user` to alert the user about important findings or completed actions. This sends push notifications to their devices and appears in their notification log. Only call it when you have something genuinely worth alerting about — routine "all clear" results don't need a notification.
+- **Cron scheduled actions** (a `cron`-type action with a schedule): your final response is delivered to the user automatically — just write your report as your final response. You do NOT need to call `notify_user`. If there is genuinely nothing to report on a given run, respond with exactly `[SILENT]` and nothing else to suppress that delivery.
+- **Heartbeat**: your report is also delivered automatically. If something needs attention, respond with `ACTION_TAKEN: <summary>` and that summary is sent to the user. If nothing NEW needs attention, respond with exactly `HEARTBEAT_OK` to stay silent. You do NOT need to call `notify_user`; report only what is NEW since your last check so you don't spam the user.
+- **Reminders**: use `notify_user` to alert the user about important findings or completed actions. This sends push notifications to their devices and appears in their notification log. Only call it when you have something genuinely worth alerting about — routine "all clear" results don't need a notification.
 
 ### Guidelines
 - Always confirm with the user before creating scheduled actions

--- a/backend/core/providers/PRICING.md
+++ b/backend/core/providers/PRICING.md
@@ -1,6 +1,6 @@
 # Model Pricing
 
-Last verified: 2026-06-13 (price-check)
+Last verified: 2026-06-16 (price-check)
 
 USD per 1M tokens, standard / short-context tier. Generated from `pricing.py`
 (`MODEL_PRICING` + `PRICING_SOURCES`) by the `price-check` skill — do not hand-edit;
@@ -11,35 +11,36 @@ entry here are flagged "pricing unknown" by the usage dashboard, never silently 
 
 | Model | Input $/M | Output $/M | Source | Verified |
 |---|---|---|---|---|
-| `claude-fable-5` | 10.00 | 50.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
-| `claude-opus-4-8` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
-| `claude-opus-4-7` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
-| `claude-opus-4-6` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
-| `claude-sonnet-4-6` | 3.00 | 15.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
-| `claude-haiku-4-5` | 1.00 | 5.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-05-26 |
+| `claude-fable-5` | 10.00 | 50.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-06-16 |
+| `claude-opus-4-8` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-06-16 |
+| `claude-opus-4-7` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-06-16 |
+| `claude-opus-4-6` | 5.00 | 25.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-06-16 |
+| `claude-sonnet-4-6` | 3.00 | 15.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-06-16 |
+| `claude-haiku-4-5` | 1.00 | 5.00 | [overview](https://platform.claude.com/docs/en/about-claude/models/overview) | 2026-06-16 |
 
 ## OpenAI
 
 | Model | Input $/M | Output $/M | Source | Verified |
 |---|---|---|---|---|
-| `gpt-5.5` | 5.00 | 30.00 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-13 |
-| `gpt-5.4` | 2.50 | 15.00 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-13 |
-| `gpt-5.4-mini` | 0.75 | 4.50 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-13 |
-| `gpt-5.4-nano` | 0.20 | 1.25 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-13 |
+| `gpt-5.5` | 5.00 | 30.00 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-16 |
+| `gpt-5.4` | 2.50 | 15.00 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-16 |
+| `gpt-5.4-mini` | 0.75 | 4.50 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-16 |
+| `gpt-5.4-nano` | 0.20 | 1.25 | [pricing](https://developers.openai.com/api/docs/pricing) | 2026-06-16 |
 
 ## Google
 
 | Model | Input $/M | Output $/M | Source | Verified |
 |---|---|---|---|---|
-| `gemini-2.5-pro` | 1.25 | 10.00 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
-| `gemini-2.5-flash` | 0.30 | 2.50 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
-| `gemini-2.5-flash-lite` | 0.10 | 0.40 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
-| `gemini-2.0-flash` | 0.10 | 0.40 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
-| `gemini-2.0-flash-lite` | 0.075 | 0.30 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-13 |
+| `gemini-2.5-pro` | 1.25 | 10.00 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-16 |
+| `gemini-2.5-flash` | 0.30 | 2.50 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-16 |
+| `gemini-2.5-flash-lite` | 0.10 | 0.40 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-16 |
+| `gemini-2.0-flash` | 0.10 | 0.40 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-16 |
+| `gemini-2.0-flash-lite` | 0.075 | 0.30 | [pricing](https://ai.google.dev/gemini-api/docs/pricing) | 2026-06-16 |
 
 > `gemini-2.5-pro` is the standard ≤200K-prompt tier; long prompts bill higher.
+> `gemini-2.0-*` models were shut down 2026-06-01 but are retained to price historical usage rows.
 
 ## Not yet priced
 
-- **Together AI** (paid, Qwen/Llama/etc.) — pull from <https://www.together.ai/pricing> via `price-check`. Until added, Together rows are flagged "pricing unknown" in the usage dashboard (never $0).
+- **Together AI** (paid, Qwen/Llama/etc.) — pull from <https://www.together.ai/pricing> via `price-check`. The tier models (`Qwen/Qwen3.5-32B/14B/7B`) are not listed on the current pricing page, so Together rows are flagged "pricing unknown" in the usage dashboard (never $0).
 - **Legacy OpenAI** (`o3`, `o4-mini`, `gpt-4o`, `gpt-4o-mini`) — removed from OpenAI's current pricing page; historical usage rows referencing them flag as unknown.

--- a/backend/core/providers/__init__.py
+++ b/backend/core/providers/__init__.py
@@ -33,14 +33,24 @@ def get_ai_provider(
     # Resolve model: agent_model > tier > global active_model
     if agent_model:
         raw_model = agent_model
-    elif agent_model_tier and agent_model_tier != "auto":
+    elif agent_model_tier:
+        from core.providers.model_tiers import has_explicit_tier
         from core.providers.tiers import resolve_tier_model
         provider_key = agent_provider or store.data.get("active_provider", "")
-        raw_model = resolve_tier_model(provider_key, agent_model_tier) or ""
-    elif agent_model_tier == "auto":
-        from core.providers.tiers import resolve_tier_model
-        provider_key = agent_provider or store.data.get("active_provider", "")
-        raw_model = resolve_tier_model(provider_key, "top") or ""
+        tier = "top" if agent_model_tier == "auto" else agent_model_tier
+        active_model = store.data.get("active_model", "")
+        active_provider = store.data.get("active_provider", "")
+        if has_explicit_tier(provider_key, tier):
+            raw_model = resolve_tier_model(provider_key, tier) or ""
+        elif tier == "top" and active_model and provider_key == active_provider:
+            # Fresh deploy / no tiers materialized yet: respect the user's
+            # configured active_model instead of the hardcoded TIER_MODELS
+            # constant, so a PR that bumps the constant can't silently swap the
+            # model used by background runs. mid/light keep the hardcoded
+            # fallback (they were never the user's explicit pick).
+            raw_model = active_model
+        else:
+            raw_model = resolve_tier_model(provider_key, tier) or ""
     else:
         raw_model = store.data.get("active_model", "")
     model = raw_model if raw_model and raw_model != "default" else ""

--- a/backend/core/providers/model_tiers.py
+++ b/backend/core/providers/model_tiers.py
@@ -62,6 +62,21 @@ def get_overrides(provider: str) -> dict[str, str]:
     return (_load().get(provider, {}) or {}).get("overrides", {}) or {}
 
 
+def has_explicit_tier(provider: str, tier: str) -> bool:
+    """True if a user override or live-inferred value exists for this tier — i.e.
+    resolution would NOT fall through to the hardcoded TIER_MODELS constant.
+
+    Inspects the raw store directly (not get_resolved, which always returns a
+    hardcoded fallback). Used so background runs prefer the user's configured
+    active_model over a baked-in constant on a fresh deploy with no tiers file.
+    """
+    entry = _load().get(provider, {}) or {}
+    return bool(
+        (entry.get("overrides", {}) or {}).get(tier)
+        or (entry.get("inferred", {}) or {}).get(tier)
+    )
+
+
 # Sanity cap on persisted model ids — guards against a misbehaving/compromised
 # provider API returning absurd strings (matches the override length check).
 _MAX_MODEL_ID_LEN = 200

--- a/backend/core/providers/pricing.py
+++ b/backend/core/providers/pricing.py
@@ -28,7 +28,9 @@ MODEL_PRICING: dict[str, tuple[float, float]] = {
     "gpt-5.4":           (2.50, 15.00),
     "gpt-5.4-mini":      (0.75, 4.50),
     "gpt-5.4-nano":      (0.20, 1.25),
-    # Google (Gemini 2.5 Pro = standard <=200K-prompt tier)
+    # Google (Gemini 2.5 Pro = standard <=200K-prompt tier).
+    # Gemini 2.0 models were shut down 2026-06-01 but are retained here so the
+    # usage dashboard can still price historical rows by model id.
     "gemini-2.5-pro":        (1.25, 10.00),
     "gemini-2.5-flash":      (0.30, 2.50),
     "gemini-2.5-flash-lite": (0.10, 0.40),
@@ -39,21 +41,21 @@ MODEL_PRICING: dict[str, tuple[float, float]] = {
 # model id -> (source_url, verified_date). Maintained by the price-check skill;
 # every MODEL_PRICING entry should have a corresponding source here.
 PRICING_SOURCES: dict[str, tuple[str, str]] = {
-    "claude-fable-5":    ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
-    "claude-opus-4-8":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
-    "claude-opus-4-7":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
-    "claude-opus-4-6":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
-    "claude-sonnet-4-6": ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
-    "claude-haiku-4-5":  ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-05-26"),
-    "gpt-5.5":           ("https://developers.openai.com/api/docs/pricing", "2026-06-13"),
-    "gpt-5.4":           ("https://developers.openai.com/api/docs/pricing", "2026-06-13"),
-    "gpt-5.4-mini":      ("https://developers.openai.com/api/docs/pricing", "2026-06-13"),
-    "gpt-5.4-nano":      ("https://developers.openai.com/api/docs/pricing", "2026-06-13"),
-    "gemini-2.5-pro":        ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
-    "gemini-2.5-flash":      ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
-    "gemini-2.5-flash-lite": ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
-    "gemini-2.0-flash":      ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
-    "gemini-2.0-flash-lite": ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-13"),
+    "claude-fable-5":    ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-06-16"),
+    "claude-opus-4-8":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-06-16"),
+    "claude-opus-4-7":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-06-16"),
+    "claude-opus-4-6":   ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-06-16"),
+    "claude-sonnet-4-6": ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-06-16"),
+    "claude-haiku-4-5":  ("https://platform.claude.com/docs/en/about-claude/models/overview", "2026-06-16"),
+    "gpt-5.5":           ("https://developers.openai.com/api/docs/pricing", "2026-06-16"),
+    "gpt-5.4":           ("https://developers.openai.com/api/docs/pricing", "2026-06-16"),
+    "gpt-5.4-mini":      ("https://developers.openai.com/api/docs/pricing", "2026-06-16"),
+    "gpt-5.4-nano":      ("https://developers.openai.com/api/docs/pricing", "2026-06-16"),
+    "gemini-2.5-pro":        ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-16"),
+    "gemini-2.5-flash":      ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-16"),
+    "gemini-2.5-flash-lite": ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-16"),
+    "gemini-2.0-flash":      ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-16"),
+    "gemini-2.0-flash-lite": ("https://ai.google.dev/gemini-api/docs/pricing", "2026-06-16"),
 }
 
 

--- a/backend/tests/test_model_tiers.py
+++ b/backend/tests/test_model_tiers.py
@@ -245,6 +245,86 @@ class TestLabelsAndTriageFallback:
         assert tiers.get_triage_classifier("nonexistent") is None
 
 
+class TestGetAiProviderActiveModelFallback:
+    """Fix C: background runs must use the user's configured active_model — not a
+    hardcoded TIER_MODELS constant — on a fresh deploy with no materialized tiers,
+    so a PR that bumps TIER_MODELS can't silently swap the background model."""
+
+    @pytest.fixture
+    def creds_env(self, monkeypatch, tmp_path, encryption_env):
+        import core.providers.credentials as creds
+
+        monkeypatch.setattr(creds, "PROFILES_PATH", tmp_path / "auth-profiles.json")
+        store = creds.CredentialStore()
+        store.data = {
+            "active_provider": "anthropic",
+            "active_model": "claude-opus-4-6",
+            "profiles": {
+                "anthropic:default": {"type": "api_key", "key": "sk-ant-x"},
+                "openai:default": {"type": "api_key", "key": "sk-oai-x"},
+            },
+        }
+        store._save()
+        yield
+
+    def test_top_tier_uses_active_model_when_no_tiers_file(self, creds_env, tier_store):
+        from core.providers import get_ai_provider
+        prov = get_ai_provider(agent_model_tier="top")
+        assert prov is not None
+        # NOT the hardcoded TIER_MODELS["anthropic"]["top"] (claude-opus-4-8)
+        assert prov.model == "claude-opus-4-6"
+
+    def test_auto_tier_uses_active_model_when_no_tiers_file(self, creds_env, tier_store):
+        from core.providers import get_ai_provider
+        prov = get_ai_provider(agent_model_tier="auto")
+        assert prov.model == "claude-opus-4-6"
+
+    def test_inferred_tier_wins_over_active_model(self, creds_env, tier_store):
+        from core.providers import get_ai_provider
+        model_tiers.set_inferred(
+            "anthropic",
+            {"top": "claude-opus-4-8", "mid": "claude-sonnet-4-6", "light": "claude-haiku-4-5"},
+        )
+        prov = get_ai_provider(agent_model_tier="top")
+        assert prov.model == "claude-opus-4-8"
+
+    def test_override_wins_over_active_model(self, creds_env, tier_store):
+        from core.providers import get_ai_provider
+        model_tiers.set_overrides("anthropic", {"top": "claude-opus-4-7"})
+        prov = get_ai_provider(agent_model_tier="top")
+        assert prov.model == "claude-opus-4-7"
+
+    def test_provider_mismatch_does_not_borrow_active_model(self, creds_env, tier_store):
+        # active is anthropic; requesting an openai tier with no openai tier source
+        # must use the hardcoded openai top, NOT the anthropic active_model.
+        from core.providers import get_ai_provider
+        prov = get_ai_provider(agent_provider="openai", agent_model_tier="top")
+        assert prov is not None
+        assert prov.model == tiers.TIER_MODELS["openai"]["top"]
+
+    def test_mid_tier_uses_hardcoded_not_active_model(self, creds_env, tier_store):
+        # Only top/auto borrow active_model; mid/light keep the hardcoded fallback.
+        from core.providers import get_ai_provider
+        prov = get_ai_provider(agent_model_tier="mid")
+        assert prov.model == tiers.TIER_MODELS["anthropic"]["mid"]
+
+
+class TestHasExplicitTier:
+    def test_false_when_empty(self, tier_store):
+        assert model_tiers.has_explicit_tier("anthropic", "top") is False
+
+    def test_true_for_inferred(self, tier_store):
+        model_tiers.set_inferred(
+            "anthropic",
+            {"top": "claude-opus-4-8", "mid": "claude-sonnet-4-6", "light": "claude-haiku-4-5"},
+        )
+        assert model_tiers.has_explicit_tier("anthropic", "top") is True
+
+    def test_true_for_override(self, tier_store):
+        model_tiers.set_overrides("anthropic", {"top": "claude-opus-4-7"})
+        assert model_tiers.has_explicit_tier("anthropic", "top") is True
+
+
 class TestMaterializeDoesNotOverrideActiveModel:
     def test_active_model_preserved(self, monkeypatch, tmp_path, tier_store):
         import asyncio

--- a/backend/tests/test_scheduled_actions_delivery.py
+++ b/backend/tests/test_scheduled_actions_delivery.py
@@ -1,0 +1,305 @@
+"""Tests for the cron auto-delivery guarantee in scheduled_actions/processor.
+
+A cron action's whole purpose is to report back, so its output must reach the
+user even if the model never calls notify_user (the morning-brief silent-failure
+bug). These tests drive _process_cron with its boundaries mocked, plus one
+real-DB test that the observability marker survives history's 10 KB truncation.
+"""
+
+import json
+import types
+
+import pytest
+
+from core.agents.scheduled_actions import processor
+
+
+def _fake_result(text="", tool_log=None, error=False):
+    return types.SimpleNamespace(
+        text=text,
+        tool_log=tool_log or [],
+        error=error,
+        input_tokens=10,
+        output_tokens=20,
+        model_used="claude-opus-4-6",
+        provider="anthropic",
+    )
+
+
+def _action():
+    return {
+        "id": "act-123456",
+        "agent": "tom",
+        "lease_id": "lease-1",
+        "prompt": "Generate the morning brief.",
+        "name": "Morning Brief",
+        "max_tool_iterations": 10,
+        "active_hours_tz": "America/Chicago",
+        "model_override": None,
+    }
+
+
+@pytest.fixture
+def cron_env(monkeypatch):
+    """Patch every boundary _process_cron touches; capture deliver + history calls."""
+    captures = {"deliver": [], "record_complete": [], "deliver_should_raise": False, "result": None}
+
+    monkeypatch.setattr(processor, "_resolve_agent", lambda slug: {
+        "slug": slug, "agent_name": "Tom", "provider_override": None, "model_override": None,
+    })
+    monkeypatch.setattr(processor, "_build_tools", lambda *a, **k: ([], None, None))
+    monkeypatch.setattr(processor, "_make_lease_renewer", lambda *a, **k: (lambda *_a, **_k: None))
+    monkeypatch.setattr(processor, "_mark_and_alert", lambda *a, **k: True)
+
+    monkeypatch.setattr(processor.history, "record_start", lambda *a, **k: "exec-1")
+    monkeypatch.setattr(
+        processor.history, "record_complete",
+        lambda execution_id, **kwargs: captures["record_complete"].append(kwargs),
+    )
+
+    import agents.engine as engine_mod
+    import agents.tool_loader as tool_loader_mod
+    import core.agents.ai_service as ai_service_mod
+    monkeypatch.setattr(engine_mod, "get_context_manager",
+                        lambda slug: types.SimpleNamespace(load_all_context=lambda: ""))
+    monkeypatch.setattr(engine_mod, "build_agent_config",
+                        lambda agent: types.SimpleNamespace(model_tier="top", google_accounts=[]))
+    monkeypatch.setattr(tool_loader_mod, "format_current_time", lambda tz: ("2026-06-16", "05:15"))
+    monkeypatch.setattr(ai_service_mod, "_google_accounts_context", lambda aim, accts: "")
+
+    import core.agents.notifications.delivery as delivery_mod
+
+    def _deliver(agent_slug, title, message):
+        captures["deliver"].append({"agent": agent_slug, "title": title, "message": message})
+        if captures["deliver_should_raise"]:
+            raise RuntimeError("telegram down")
+        return {"ok": True, "notification_id": "n1", "channels_sent": ["telegram"]}
+
+    monkeypatch.setattr(delivery_mod, "deliver_notification", _deliver)
+    monkeypatch.setattr(processor, "run_background_turn", lambda **k: captures["result"])
+
+    return captures
+
+
+class TestCronAutoDelivery:
+    def test_delivers_when_model_did_not_notify(self, cron_env):
+        cron_env["result"] = _fake_result(text="Here is your brief: 3 meetings today.")
+        processor._process_cron(_action())
+
+        assert len(cron_env["deliver"]) == 1
+        assert cron_env["deliver"][0]["title"] == "Morning Brief"
+        assert "brief" in cron_env["deliver"][0]["message"]
+        rc = cron_env["record_complete"][-1]
+        assert rc["notification_sent"] is True
+        # Marker is prepended so it survives history's tool_calls truncation.
+        assert rc["tool_calls"][0]["tool"] == "auto_deliver"
+        assert rc["tool_calls"][0]["ok"] is True
+
+    def test_silent_marker_suppresses_delivery(self, cron_env):
+        cron_env["result"] = _fake_result(text="[SILENT]")
+        processor._process_cron(_action())
+
+        assert cron_env["deliver"] == []
+        rc = cron_env["record_complete"][-1]
+        assert rc["notification_sent"] is False
+        assert all(tc.get("tool") != "auto_deliver" for tc in rc["tool_calls"])
+
+    def test_empty_text_no_delivery(self, cron_env):
+        cron_env["result"] = _fake_result(text="   ")
+        processor._process_cron(_action())
+
+        assert cron_env["deliver"] == []
+        assert cron_env["record_complete"][-1]["notification_sent"] is False
+
+    def test_no_double_send_when_model_notified_successfully(self, cron_env):
+        tool_log = [{"tool": "notify_user",
+                     "result": json.dumps({"ok": True, "notification_id": "x", "channels_sent": ["web_push"]})}]
+        cron_env["result"] = _fake_result(text="Brief body", tool_log=tool_log)
+        processor._process_cron(_action())
+
+        assert cron_env["deliver"] == []  # model already delivered → no double-send
+        assert cron_env["record_complete"][-1]["notification_sent"] is True
+
+    def test_delivers_when_notify_user_errored(self, cron_env):
+        # The bug guard: a notify_user that ERRORED (e.g. missing args) must NOT
+        # count as delivered — the auto-fallback still fires.
+        tool_log = [{"tool": "notify_user",
+                     "result": json.dumps({"error": "Both title and message are required"})}]
+        cron_env["result"] = _fake_result(text="Brief body", tool_log=tool_log)
+        processor._process_cron(_action())
+
+        assert len(cron_env["deliver"]) == 1
+        assert cron_env["record_complete"][-1]["notification_sent"] is True
+
+    def test_delivers_when_notify_user_budget_rejected(self, cron_env):
+        # background_runner logs write-budget rejects under the same tool name.
+        tool_log = [{"tool": "notify_user",
+                     "result": json.dumps({"error": "Write budget exceeded (5 writes per turn). This write was rejected."})}]
+        cron_env["result"] = _fake_result(text="Brief body", tool_log=tool_log)
+        processor._process_cron(_action())
+
+        assert len(cron_env["deliver"]) == 1
+        assert cron_env["record_complete"][-1]["notification_sent"] is True
+
+    def test_delivery_exception_recorded_not_crashing(self, cron_env):
+        cron_env["deliver_should_raise"] = True
+        cron_env["result"] = _fake_result(text="Brief body")
+        processor._process_cron(_action())  # must not raise
+
+        rc = cron_env["record_complete"][-1]
+        assert rc["notification_sent"] is False
+        marker = rc["tool_calls"][0]
+        assert marker["tool"] == "auto_deliver"
+        assert marker["ok"] is False
+        assert "error" in marker
+
+    def test_error_status_skips_delivery(self, cron_env):
+        cron_env["result"] = _fake_result(text="boom", error=True)
+        processor._process_cron(_action())
+
+        assert cron_env["deliver"] == []
+
+
+@pytest.fixture
+def hb_env(monkeypatch, tmp_path):
+    """Patch _process_heartbeat boundaries; bypass triage (off + triage_enabled
+    False) and the lease re-check (lease_id None) to reach the full-run delivery."""
+    captures = {"deliver": [], "record_complete": [], "deliver_should_raise": False, "result": None}
+
+    (tmp_path / "HEARTBEAT.md").write_text("- Check the calendar each morning.\n", encoding="utf-8")
+
+    monkeypatch.setattr(processor, "_resolve_agent", lambda slug: {
+        "slug": slug, "agent_name": "Tom", "provider_override": None, "model_override": None,
+    })
+    monkeypatch.setattr(processor, "_build_tools", lambda *a, **k: ([], None, None))
+    monkeypatch.setattr(processor, "_make_lease_renewer", lambda *a, **k: (lambda *_a, **_k: None))
+    monkeypatch.setattr(processor, "_mark_and_alert", lambda *a, **k: True)
+    monkeypatch.setattr(processor, "_build_error_context", lambda *a, **k: "")
+
+    monkeypatch.setattr(processor.history, "record_start", lambda *a, **k: "exec-h")
+    monkeypatch.setattr(
+        processor.history, "record_complete",
+        lambda execution_id, **kwargs: captures["record_complete"].append(kwargs),
+    )
+
+    import agents.engine as engine_mod
+    import agents.tool_loader as tool_loader_mod
+    import core.admin_settings as admin_mod
+    import core.agents.ai_service as ai_service_mod
+    import core.agents.memory.commitments as commitments_mod
+    monkeypatch.setattr(engine_mod, "get_context_manager",
+                        lambda slug: types.SimpleNamespace(data_dir=tmp_path, load_all_context=lambda: ""))
+    monkeypatch.setattr(engine_mod, "build_agent_config",
+                        lambda agent: types.SimpleNamespace(model_tier="top", google_accounts=[]))
+    monkeypatch.setattr(tool_loader_mod, "format_current_time", lambda tz: ("2026-06-16", "05:15"))
+    monkeypatch.setattr(ai_service_mod, "_google_accounts_context", lambda aim, accts: "")
+    monkeypatch.setattr(admin_mod, "load_admin_settings", lambda: {"triage_mode": "off"})
+    monkeypatch.setattr(commitments_mod, "peek_due_followups", lambda slug: [])
+
+    import core.agents.notifications.delivery as delivery_mod
+
+    def _deliver(agent_slug, title, message):
+        captures["deliver"].append({"agent": agent_slug, "title": title, "message": message})
+        if captures["deliver_should_raise"]:
+            raise RuntimeError("telegram down")
+        return {"ok": True, "notification_id": "n1", "channels_sent": ["telegram"]}
+
+    monkeypatch.setattr(delivery_mod, "deliver_notification", _deliver)
+    monkeypatch.setattr(processor, "run_background_turn", lambda **k: captures["result"])
+
+    return captures
+
+
+def _hb_action():
+    return {
+        "id": "hb-123456",
+        "agent": "tom",
+        "lease_id": None,
+        "name": "Daily Heartbeat",
+        "max_tool_iterations": 10,
+        "active_hours_tz": "America/Chicago",
+        "model_override": None,
+        "triage_enabled": False,
+    }
+
+
+class TestHeartbeatAutoDelivery:
+    """Heartbeat now matches OpenClaw: deliver the ACTION_TAKEN report unless the
+    model went silent with HEARTBEAT_OK (or already delivered)."""
+
+    def test_delivers_action_taken_report_with_marker_stripped(self, hb_env):
+        hb_env["result"] = _fake_result(text="ACTION_TAKEN: Invoice #123 is 30 days overdue.")
+        processor._process_heartbeat(_hb_action())
+
+        assert len(hb_env["deliver"]) == 1
+        assert hb_env["deliver"][0]["title"] == "Daily Heartbeat"
+        assert hb_env["deliver"][0]["message"] == "Invoice #123 is 30 days overdue."
+        rc = hb_env["record_complete"][-1]
+        assert rc["notification_sent"] is True
+        assert rc["tool_calls"][0]["tool"] == "auto_deliver"
+
+    def test_heartbeat_ok_suppresses_delivery(self, hb_env):
+        hb_env["result"] = _fake_result(text="HEARTBEAT_OK")
+        processor._process_heartbeat(_hb_action())
+
+        assert hb_env["deliver"] == []
+        assert hb_env["record_complete"][-1]["notification_sent"] is False
+
+    def test_no_double_send_when_model_notified(self, hb_env):
+        tool_log = [{"tool": "notify_user", "result": json.dumps({"ok": True, "notification_id": "x"})}]
+        hb_env["result"] = _fake_result(text="ACTION_TAKEN: Something", tool_log=tool_log)
+        processor._process_heartbeat(_hb_action())
+
+        assert hb_env["deliver"] == []
+        assert hb_env["record_complete"][-1]["notification_sent"] is True
+
+    def test_delivery_exception_recorded_not_crashing(self, hb_env):
+        hb_env["deliver_should_raise"] = True
+        hb_env["result"] = _fake_result(text="ACTION_TAKEN: Something urgent")
+        processor._process_heartbeat(_hb_action())  # must not raise
+
+        rc = hb_env["record_complete"][-1]
+        assert rc["notification_sent"] is False
+        assert rc["tool_calls"][0] == {"tool": "auto_deliver", "ok": False, "error": "telegram down"}
+
+
+class TestStripActionMarker:
+    def test_strips_prefix(self):
+        assert processor._strip_action_marker("ACTION_TAKEN: foo bar") == "foo bar"
+
+    def test_no_marker_returns_full(self):
+        assert processor._strip_action_marker("just a report") == "just a report"
+
+    def test_case_insensitive(self):
+        assert processor._strip_action_marker("action_taken: hi") == "hi"
+
+    def test_empty_after_marker_falls_back_to_full(self):
+        assert processor._strip_action_marker("ACTION_TAKEN:") == "ACTION_TAKEN:"
+
+
+class TestMarkerSurvivesTruncation:
+    @pytest.fixture
+    def reminders_env(self, monkeypatch, tmp_path):
+        import core.agents.reminders.db as rdb
+
+        monkeypatch.setattr(rdb, "DATA_DIR", tmp_path / "reminders")
+        monkeypatch.setattr(rdb, "DB_PATH", tmp_path / "reminders" / "reminders.db")
+        (tmp_path / "reminders").mkdir(parents=True, exist_ok=True)
+        rdb.close_db()
+        rdb._setup_connection()
+        yield rdb
+        rdb.close_db()
+
+    def test_prepended_marker_survives_10kb_truncation(self, reminders_env):
+        from core.agents.scheduled_actions import history
+
+        eid = history.record_start("act-x", "tom", "cron")
+        big = [{"tool": f"t{i}", "args": "x" * 200, "result": "y" * 200} for i in range(200)]
+        tool_calls = [{"tool": "auto_deliver", "ok": True, "channels": ["telegram"]}] + big
+        history.record_complete(eid, status="ok", tool_calls=tool_calls, notification_sent=True)
+
+        stored = reminders_env.get_db().execute(
+            "SELECT tool_calls FROM execution_history WHERE id = ?", (eid,)
+        ).fetchone()[0]
+        assert len(stored) <= 10240          # truncation happened
+        assert "auto_deliver" in stored      # ...but the prepended marker survived

--- a/backend/tests/test_scheduled_actions_delivery.py
+++ b/backend/tests/test_scheduled_actions_delivery.py
@@ -120,6 +120,19 @@ class TestCronAutoDelivery:
         assert cron_env["deliver"] == []  # model already delivered → no double-send
         assert cron_env["record_complete"][-1]["notification_sent"] is True
 
+    def test_no_double_send_when_model_used_post_message(self, cron_env):
+        # post_message is the other tool _delivered_via_tool() honors; it returns
+        # {"ok": True, "notification_created": True, ...} on success (tool_registry
+        # _execute_post_message). A successful post_message must suppress the
+        # auto-fallback exactly like notify_user.
+        tool_log = [{"tool": "post_message",
+                     "result": json.dumps({"ok": True, "notification_created": True, "external_sent": True})}]
+        cron_env["result"] = _fake_result(text="Brief body", tool_log=tool_log)
+        processor._process_cron(_action())
+
+        assert cron_env["deliver"] == []  # model already delivered → no double-send
+        assert cron_env["record_complete"][-1]["notification_sent"] is True
+
     def test_delivers_when_notify_user_errored(self, cron_env):
         # The bug guard: a notify_user that ERRORED (e.g. missing args) must NOT
         # count as delivered — the auto-fallback still fires.

--- a/docs/solutions/architecture-patterns/scheduled-action-guaranteed-delivery.md
+++ b/docs/solutions/architecture-patterns/scheduled-action-guaranteed-delivery.md
@@ -1,0 +1,109 @@
+---
+title: Guaranteed delivery for cron scheduled actions (don't bet on the model calling notify_user)
+date: 2026-06-16
+category: architecture-patterns
+module: core/agents/scheduled_actions/processor, core/agents/notifications/delivery, core/providers
+tags: [heartbeat, cron, scheduled-actions, notifications, delivery, model-tiers, silent-failure]
+problem_type: pattern
+---
+
+## Context
+
+Cron scheduled actions (e.g. a 5:15 AM "morning brief") exist to *report back* to the
+user. Their output reaches the user only through a notification. Originally
+`_process_cron` told the model to "Use `notify_user` to alert the user…" and then,
+after the run, computed a `notified` flag (`any(tc.get("tool") in
+("notify_user","post_message") …)`) — but **did nothing when it was false**.
+Delivery was a bet on model behavior.
+
+## Symptom
+
+After PR #127 (dynamic model selection by tier), the morning brief ran every day,
+generated full output, used its tools — but stopped sending notifications. The brief
+just sat in `execution_history`.
+
+Two layers:
+
+1. **Trigger.** #127 made `get_ai_provider()` resolve the model from the agent's
+   `model_tier`. On the production deploy `data/model-tiers.json` didn't exist, so
+   tier resolution fell through to the hardcoded
+   `TIER_MODELS["anthropic"]["top"] = claude-opus-4-8`, silently replacing the user's
+   configured `active_model` (`claude-opus-4-6`). The new model simply chose not to
+   call the notification tool.
+2. **Root cause.** Delivery depended on the model. *Any* change — a model swap, a
+   prompt tweak, a model "mood" — could drop the report silently. This is why
+   "the heartbeat didn't send" recurred.
+
+## Resolution — make delivery a system step, not a model choice
+
+This mirrors how OpenClaw (`src/cron/isolated-agent/delivery-dispatch.ts`) and Hermes
+(`cron/scheduler.py`) handle it: the background run produces its report as its
+*final response*, and the **system delivers that text** afterward. The model is told
+*not* to call a send tool. The only suppressor is an explicit model-emitted silent
+marker. **Neither uses a "playbook" for delivery** — a playbook is still
+model-followed instructions and shares the same failure mode.
+
+Implemented in `_process_cron` (`core/agents/scheduled_actions/processor.py`):
+
+1. **Inverted prompt.** "Your final response will be delivered automatically… you do
+   not need to call `notify_user`. If there is genuinely nothing to report, respond
+   with exactly `[SILENT]`."
+2. **Auto-delivery fallback.** When `status == "ok"`, the final text is non-empty, it
+   isn't `[SILENT]`, and the model didn't already deliver, call the existing
+   `deliver_notification(agent_slug, title, message)` (the same path `notify_user`
+   uses — web push + Telegram + WhatsApp + in-app log).
+3. **Detect *successful* delivery, not a tool call.** `_delivered_via_tool()` parses
+   each `notify_user`/`post_message` `tool_log` result and only counts `{"ok": true}`.
+   This is critical: `background_runner` records write-budget / hourly-rate rejections
+   under the same tool name with an `{"error": …}` result, and `notify_user` can error
+   on bad args. A name-only guard would treat those failures as "delivered" and
+   re-drop the report. Bias is conservative — anything unparseable/ambiguous falls
+   through to auto-delivery (a possible duplicate beats a silent miss).
+
+### Model-resolution fix (prevents the trigger from recurring)
+
+`get_ai_provider()` now prefers the user's configured `active_model` over the
+hardcoded `TIER_MODELS` fallback for the **top/auto** tier when no override/inferred
+value exists (`model_tiers.has_explicit_tier()` checks the raw store, not
+`get_resolved()` which always returns a fallback). So a fresh deploy — or a PR that
+bumps `TIER_MODELS` — can't silently change the model background runs use.
+mid/light keep the hardcoded fallback (they were never the user's explicit pick).
+
+## Cron and heartbeat — one rule, two silent markers
+
+Both use the same rule: **deliver the run's output unless the model emits the silent
+marker.** This matches OpenClaw, which applies guaranteed delivery to its heartbeat
+too — `shouldSkipHeartbeatOnlyDelivery()` in `src/cron/heartbeat-policy.ts` suppresses
+delivery only when the payload is the `HEARTBEAT_OK` token (with a ~300-char ack
+tolerance); anything else is delivered. Neither relies on a notify tool.
+
+- **Cron = report:** silent marker `[SILENT]`; delivers the final response.
+- **Heartbeat = monitor:** silent marker `HEARTBEAT_OK`; delivers the `ACTION_TAKEN:`
+  report with the marker stripped from the body (`_strip_action_marker`, mirroring
+  OpenClaw's `stripHeartbeatToken`). If the model already delivered via `notify_user`,
+  the double-send guard skips the fallback.
+
+**Spam control for the frequent (~30 min) heartbeat** is not a code judgment gate —
+it's (a) the cheap triage + empty-checklist early-returns that skip most ticks before
+any full run, and (b) the prompt instructing the model to report only what is NEW
+since the last check (OpenClaw uses the same "do not repeat old tasks" discipline).
+The model cannot silently swallow a finding: if the response isn't `HEARTBEAT_OK`,
+it's delivered.
+
+## Gotchas
+
+- **Observability:** the durable signal is the `execution_history.notification_sent`
+  **column** (`status == "ok"` + `notification_sent == False` = "ran but not
+  notified"). The supplementary `{"tool": "auto_deliver", …}` marker must be
+  **prepended** to `tool_calls`, because `history.record_complete` truncates the
+  serialized `tool_calls` to 10 KB — an appended marker can be lost on a busy run.
+- **Empty `channels_sent` is NOT an error** — `deliver_notification` always writes the
+  in-app log, so empty channels just means "in-app only" (no push sub / external
+  channels off). Log it at `info`; reserve `warning` for `ok is not True` / exceptions.
+- **Scope:** this guarantees delivery against *model behavior*, not a process crash in
+  the narrow window between `_mark_and_alert` advancing `next_run` and the delivery
+  call. No pending-delivery/idempotency table was added (single-user SQLite app;
+  keep it simple). Call it "model-independent best-effort," not "crash-proof."
+- **Agent-authored prompts:** the tool guidance in `tool_definitions.py` ("Notifying
+  the User") was split so agents creating cron actions don't re-encode the old
+  notify-or-nothing behavior.


### PR DESCRIPTION
## Summary

- **Delivery is now a system step, not a model choice.** Cron and heartbeat runs produce their report as the final response, and the processor delivers it via `deliver_notification` (web push + Telegram + WhatsApp + in-app log). The model is told *not* to call `notify_user`. The only suppressor is an explicit silent marker: `[SILENT]` for cron, `HEARTBEAT_OK` for heartbeat.
- **`_delivered_via_tool()` counts only successful sends.** It parses each `notify_user`/`post_message` result and requires `{"ok": true}`, so write-budget / hourly-rate-limit rejections (recorded under the same tool name with an `{"error": …}` result) can't masquerade as "delivered" and re-drop the report. A double-send guard skips the fallback when the model already delivered.
- **Fix C — model-resolution.** `get_ai_provider()` now prefers the user's configured `active_model` over the hardcoded `TIER_MODELS` fallback for the `top`/`auto` tier when no override/inferred tier exists (`model_tiers.has_explicit_tier()`). This prevents a fresh deploy — or a PR that bumps `TIER_MODELS` — from silently swapping the background model, which was the original trigger of the dropped morning brief after #127. `mid`/`light` keep the hardcoded fallback.
- **Pricing refresh** (`price-check`, 2026-06-16): verified dates bumped; notes that Gemini 2.0 models were shut down 2026-06-01 (retained to price historical rows) and that the Together tier models aren't on the current pricing page.
- Adds `test_scheduled_actions_delivery.py` and a solution doc (`docs/solutions/architecture-patterns/scheduled-action-guaranteed-delivery.md`).

## Test plan

- [x] `pytest tests/test_scheduled_actions_delivery.py tests/test_model_tiers.py` — 65 passed
- [x] Full backend suite — 891 passed
- [ ] Verify on a deploy: a cron action with output delivers without calling `notify_user`; `[SILENT]` suppresses; heartbeat `ACTION_TAKEN:` delivers with marker stripped, `HEARTBEAT_OK` stays silent.
- [ ] Confirm `execution_history.notification_sent` reflects auto-delivery (status `ok` + `notification_sent=false` flags "ran but not notified").