### PR TITLE
Full CRUD for Google Docs, Sheets & Slides (bundled Workspace service)

### DIFF
--- a/backend/agents/db.py
+++ b/backend/agents/db.py
@@ -138,7 +138,8 @@ def _normalize_agent(row: dict) -> dict:
     except (json.JSONDecodeError, TypeError):
         logger.warning("Malformed google_accounts for agent %s, treating as empty", d.get("id"))
         parsed = {}
-    for svc in ("gmail", "calendar", "drive"):
+    from integrations.google.policy import GOOGLE_SERVICES
+    for svc in GOOGLE_SERVICES:
         val = parsed.get(svc)
         if isinstance(val, str):
             parsed[svc] = [val] if val else []

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -265,9 +265,10 @@ async def update_agent(agent_id: str, body: UpdateAgentRequest, user=Depends(get
 
     if "google_accounts" in updates:
         ga = updates["google_accounts"]
-        _ALLOWED_GA_KEYS = {"gmail", "calendar", "drive"}
+        from integrations.google.policy import GOOGLE_SERVICES
+        _ALLOWED_GA_KEYS = set(GOOGLE_SERVICES)
         if not isinstance(ga, dict) or not set(ga.keys()).issubset(_ALLOWED_GA_KEYS):
-            raise HTTPException(status_code=400, detail="google_accounts keys must be a subset of {gmail, calendar, drive}")
+            raise HTTPException(status_code=400, detail=f"google_accounts keys must be a subset of {{{', '.join(GOOGLE_SERVICES)}}}")
         for svc, ids in ga.items():
             if not isinstance(ids, list) or not all(isinstance(i, str) and i for i in ids):
                 raise HTTPException(status_code=400, detail=f"google_accounts[{svc}] must be a list of non-empty strings")
@@ -520,7 +521,8 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
     gmail_ids = ga.get("gmail", [])
     calendar_ids = ga.get("calendar", [])
     drive_ids = ga.get("drive", [])
-    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+    workspace_ids = ga.get("workspace", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
 
     from integrations.registry import list_google_accounts as _list_ga
     all_ga = _list_ga()
@@ -545,6 +547,7 @@ def _stream_chat(agent: dict, messages: list, training_mode: bool, conversation_
         gmail_account_ids=gmail_ids,
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
+        workspace_account_ids=workspace_ids,
         account_info_map=account_info_map,
         integration_executors=integration_executors,
         agent_slug=agent["slug"],
@@ -1048,7 +1051,8 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
     gmail_ids = ga.get("gmail", [])
     calendar_ids = ga.get("calendar", [])
     drive_ids = ga.get("drive", [])
-    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+    workspace_ids = ga.get("workspace", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
 
     from integrations.registry import list_google_accounts as _list_ga
     all_ga = _list_ga()
@@ -1067,6 +1071,7 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
         gmail_account_ids=gmail_ids,
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
+        workspace_account_ids=workspace_ids,
         account_info_map=account_info_map,
         integration_executors=integration_executors,
         agent_slug=agent["slug"],
@@ -1075,18 +1080,14 @@ async def tool_execute(agent_id: str, req: ToolExecuteRequest, user=Depends(get_
     )
 
     from core.agents.tool_definitions import get_tool_definitions, build_writes_map
-    from integrations.google.policy import google_capabilities_union
-    gmail_caps = google_capabilities_union(gmail_ids)
-    cal_caps = google_capabilities_union(calendar_ids)
-    drive_caps = google_capabilities_union(drive_ids)
+    from integrations.google.policy import google_tool_flags
+    google_flags = google_tool_flags({
+        "gmail": gmail_ids, "calendar": calendar_ids,
+        "drive": drive_ids, "workspace": workspace_ids,
+    })
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
-        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
-        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
-        calendar_read_enabled=cal_caps["calendar_read_enabled"],
-        calendar_write_enabled=cal_caps["calendar_write_enabled"],
-        drive_read_enabled=drive_caps["drive_read_enabled"],
-        drive_write_enabled=drive_caps["drive_write_enabled"],
+        **google_flags,
     )
     writes_map = build_writes_map(tool_defs)
     if not writes_map.get(req.tool, False):

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -266,8 +266,7 @@ async def update_agent(agent_id: str, body: UpdateAgentRequest, user=Depends(get
     if "google_accounts" in updates:
         ga = updates["google_accounts"]
         from integrations.google.policy import GOOGLE_SERVICES
-        _ALLOWED_GA_KEYS = set(GOOGLE_SERVICES)
-        if not isinstance(ga, dict) or not set(ga.keys()).issubset(_ALLOWED_GA_KEYS):
+        if not isinstance(ga, dict) or not set(ga.keys()).issubset(GOOGLE_SERVICES):
             raise HTTPException(status_code=400, detail=f"google_accounts keys must be a subset of {{{', '.join(GOOGLE_SERVICES)}}}")
         for svc, ids in ga.items():
             if not isinstance(ids, list) or not all(isinstance(i, str) and i for i in ids):

--- a/backend/cli/session.py
+++ b/backend/cli/session.py
@@ -74,7 +74,8 @@ def create_session(slug: str, tool_mode: str = "normal",
     gmail_ids = ga.get("gmail", [])
     calendar_ids = ga.get("calendar", [])
     drive_ids = ga.get("drive", [])
-    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+    workspace_ids = ga.get("workspace", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
 
     from integrations.registry import list_google_accounts as _list_ga
     all_ga = _list_ga()
@@ -100,6 +101,7 @@ def create_session(slug: str, tool_mode: str = "normal",
         gmail_account_ids=gmail_ids,
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
+        workspace_account_ids=workspace_ids,
         account_info_map=account_info_map,
         integration_executors=integration_executors,
         agent_slug=slug,

--- a/backend/cli/session.py
+++ b/backend/cli/session.py
@@ -44,7 +44,7 @@ def create_session(slug: str, tool_mode: str = "normal",
     from core.providers.credentials import CredentialStore
     from agents.tool_loader import load_integration_tools, build_agent_handlers, INTEGRATION_MODULES
     from integrations.registry import get_tool_mode
-    from integrations.google.policy import google_capabilities
+    from integrations.google.policy import google_tool_flags
     from core.agents.tool_definitions import get_tool_definitions, build_writes_map
     from core.agents.ai_service import _build_kind_map
     from core.agents.tools.real_tools import load_all_real_tools
@@ -116,11 +116,14 @@ def create_session(slug: str, tool_mode: str = "normal",
 
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
-    google_caps = google_capabilities()
+    google_flags = google_tool_flags({
+        "gmail": gmail_ids, "calendar": calendar_ids,
+        "drive": drive_ids, "workspace": workspace_ids,
+    })
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs or None,
         dynamic_real_tools=dynamic_real_tools or None,
-        **google_caps,
+        **google_flags,
     )
     kind_map = _build_kind_map(tool_defs)
     writes_map = build_writes_map(tool_defs)
@@ -163,15 +166,19 @@ async def execute_approved_tool(session: Session, tool_name: str,
     from core.agents.ai_service import _sync_context_after_tool, _build_kind_map
     from core.agents.tool_definitions import get_tool_definitions, build_writes_map
     from core.agents.tools.real_tools import load_all_real_tools
-    from integrations.google.policy import google_capabilities
+    from integrations.google.policy import google_tool_flags
 
     real_tools_dir = str(Path(session.config.context_dir).parent / "real_tools")
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
-    google_caps = google_capabilities()
+    _ga = session.config.google_accounts
+    google_flags = google_tool_flags({
+        "gmail": _ga.get("gmail", []), "calendar": _ga.get("calendar", []),
+        "drive": _ga.get("drive", []), "workspace": _ga.get("workspace", []),
+    })
     tool_defs = get_tool_definitions(
         integration_tools=session.integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
-        **google_caps,
+        **google_flags,
     )
     session.kind_map = _build_kind_map(tool_defs)
     session.writes_map = build_writes_map(tool_defs)

--- a/backend/core/agents/ai_service.py
+++ b/backend/core/agents/ai_service.py
@@ -256,10 +256,11 @@ When you've naturally covered the key topics:
 
 def _google_accounts_context(account_info_map: dict[str, dict], google_accounts: dict) -> str:
     """Build system prompt section listing available and broken Google accounts."""
+    from integrations.google.policy import GOOGLE_SERVICES
     # Collect broken accounts across all assigned services
     broken_emails = []
     seen_broken = set()
-    for svc in ("gmail", "calendar", "drive"):
+    for svc in GOOGLE_SERVICES:
         for aid in google_accounts.get(svc, []):
             if aid in seen_broken:
                 continue
@@ -270,7 +271,7 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
 
     # Multi-account context (existing behavior)
     sections = []
-    for service in ("gmail", "calendar", "drive"):
+    for service in GOOGLE_SERVICES:
         ids = google_accounts.get(service, [])
         if len(ids) <= 1:
             continue
@@ -289,7 +290,7 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
         parts.append(
             "## Google Accounts\n\n"
             "You have multiple Google accounts available. Use the `account` parameter "
-            "in Gmail/Calendar/Drive tools to specify which account to use.\n"
+            "in Gmail/Calendar/Drive/Workspace tools to specify which account to use.\n"
             "- For read operations: the first listed connected account is used by default.\n"
             "- For write operations (send email, create event, etc.): the first connected "
             "account with write access is used by default.\n"
@@ -301,7 +302,7 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
         parts.append(
             "## Google Connection Issues\n\n"
             "The following Google accounts have broken connections. "
-            "Their tools (Gmail, Calendar, Drive) are unavailable until reconnected. "
+            "Their tools (Gmail, Calendar, Drive, Workspace) are unavailable until reconnected. "
             "If the user asks, direct them to Settings → Integrations → Google to reconnect.\n\n"
             + "\n".join(f"- {email}" for email in broken_emails)
         )
@@ -316,7 +317,7 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
         email = info.get("email", aid)
         grants = info.get("scope_grants", {})
         missing_services = []
-        for svc in ("gmail", "calendar", "drive"):
+        for svc in GOOGLE_SERVICES:
             has_grant = grants.get(svc, "none") != "none"
             is_assigned = aid in google_accounts.get(svc, [])
             if has_grant and not is_assigned:
@@ -331,7 +332,7 @@ def _google_accounts_context(account_info_map: dict[str, dict], google_accounts:
             "have assigned, let them know it's available and how to assign it:\n\n"
             "**How to assign:** Go to Settings (gear icon) → Integrations tab → "
             "scroll down to the Google card → under \"Agent Assignments\" check the boxes "
-            "next to your name for each service (Gmail, Calendar, Drive) they want you to have.\n\n"
+            "next to your name for each service (Gmail, Calendar, Drive, Workspace) they want you to have.\n\n"
             + "\n".join(unassigned)
         )
 
@@ -868,27 +869,19 @@ async def chat(
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
 
-    from integrations.google.policy import google_capabilities_union
+    from integrations.google.policy import google_tool_flags
     ga = config.google_accounts
-    gmail_ids = ga.get("gmail", [])
-    cal_ids = ga.get("calendar", [])
-    drive_ids = ga.get("drive", [])
-    gmail_caps = google_capabilities_union(gmail_ids)
-    cal_caps = google_capabilities_union(cal_ids)
-    drive_caps = google_capabilities_union(drive_ids)
+    google_flags = google_tool_flags({
+        "gmail": ga.get("gmail", []),
+        "calendar": ga.get("calendar", []),
+        "drive": ga.get("drive", []),
+        "workspace": ga.get("workspace", []),
+    })
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
         import_mode=import_mode,
-        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
-        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
-        calendar_read_enabled=cal_caps["calendar_read_enabled"],
-        calendar_write_enabled=cal_caps["calendar_write_enabled"],
-        drive_read_enabled=drive_caps["drive_read_enabled"],
-        drive_write_enabled=drive_caps["drive_write_enabled"],
-        multi_gmail=len(gmail_ids) > 1,
-        multi_calendar=len(cal_ids) > 1,
-        multi_drive=len(drive_ids) > 1,
+        **google_flags,
     )
     kind_map = _build_kind_map(tool_defs)
     writes_map = build_writes_map(tool_defs)
@@ -1698,26 +1691,18 @@ async def run_sync(
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
     dynamic_real_tools = load_all_real_tools(real_tools_dir)
 
-    from integrations.google.policy import google_capabilities_union
+    from integrations.google.policy import google_tool_flags
     ga = config.google_accounts
-    gmail_ids = ga.get("gmail", [])
-    cal_ids = ga.get("calendar", [])
-    drive_ids = ga.get("drive", [])
-    gmail_caps = google_capabilities_union(gmail_ids)
-    cal_caps = google_capabilities_union(cal_ids)
-    drive_caps = google_capabilities_union(drive_ids)
+    google_flags = google_tool_flags({
+        "gmail": ga.get("gmail", []),
+        "calendar": ga.get("calendar", []),
+        "drive": ga.get("drive", []),
+        "workspace": ga.get("workspace", []),
+    })
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
-        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
-        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
-        calendar_read_enabled=cal_caps["calendar_read_enabled"],
-        calendar_write_enabled=cal_caps["calendar_write_enabled"],
-        drive_read_enabled=drive_caps["drive_read_enabled"],
-        drive_write_enabled=drive_caps["drive_write_enabled"],
-        multi_gmail=len(gmail_ids) > 1,
-        multi_calendar=len(cal_ids) > 1,
-        multi_drive=len(drive_ids) > 1,
+        **google_flags,
     )
 
     # Apply integration permission ceilings — messaging channels have no approval UI,

--- a/backend/core/agents/reminders/heartbeat.py
+++ b/backend/core/agents/reminders/heartbeat.py
@@ -77,7 +77,7 @@ def _process_self_reminder(reminder: dict) -> None:
     from agents.tool_loader import load_integration_tools, build_agent_handlers, INTEGRATION_MODULES
     from agents.engine import build_agent_config
     from integrations.registry import get_tool_mode, list_google_accounts as _list_ga
-    from integrations.google.policy import google_capabilities_union
+    from integrations.google.policy import google_tool_flags
     from core.agents.tool_registry import ToolRegistry
     from core.agents.tool_definitions import get_tool_definitions
     from core.agents.tools.real_tools import load_all_real_tools
@@ -88,7 +88,12 @@ def _process_self_reminder(reminder: dict) -> None:
     gmail_ids = ga.get("gmail", [])
     calendar_ids = ga.get("calendar", [])
     drive_ids = ga.get("drive", [])
-    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+    workspace_ids = ga.get("workspace", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
+    google_flags = google_tool_flags({
+        "gmail": gmail_ids, "calendar": calendar_ids,
+        "drive": drive_ids, "workspace": workspace_ids,
+    })
 
     all_ga = _list_ga()
     account_info_map = {
@@ -97,9 +102,6 @@ def _process_self_reminder(reminder: dict) -> None:
     }
 
     integration_tool_defs, integration_executors = load_integration_tools()
-    gmail_caps = google_capabilities_union(gmail_ids)
-    cal_caps = google_capabilities_union(calendar_ids)
-    drive_caps = google_capabilities_union(drive_ids)
     reminder_handlers, sa_handlers = build_agent_handlers(agent["slug"])
 
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
@@ -109,15 +111,7 @@ def _process_self_reminder(reminder: dict) -> None:
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
         web_enabled=True,
-        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
-        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
-        calendar_read_enabled=cal_caps["calendar_read_enabled"],
-        calendar_write_enabled=cal_caps["calendar_write_enabled"],
-        drive_read_enabled=drive_caps["drive_read_enabled"],
-        drive_write_enabled=drive_caps["drive_write_enabled"],
-        multi_gmail=len(gmail_ids) > 1,
-        multi_calendar=len(calendar_ids) > 1,
-        multi_drive=len(drive_ids) > 1,
+        **google_flags,
         background_mode=True,
     )
 
@@ -140,6 +134,7 @@ def _process_self_reminder(reminder: dict) -> None:
         gmail_account_ids=gmail_ids,
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
+        workspace_account_ids=workspace_ids,
         account_info_map=account_info_map,
     )
 

--- a/backend/core/agents/router_factory.py
+++ b/backend/core/agents/router_factory.py
@@ -85,7 +85,8 @@ def create_agent_router(
         gmail_ids = ga.get("gmail", [])
         calendar_ids = ga.get("calendar", [])
         drive_ids = ga.get("drive", [])
-        google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+        workspace_ids = ga.get("workspace", [])
+        google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
 
         from integrations.registry import list_google_accounts as _list_ga
         all_ga = _list_ga()
@@ -100,6 +101,7 @@ def create_agent_router(
             gmail_account_ids=gmail_ids,
             calendar_account_ids=calendar_ids,
             drive_account_ids=drive_ids,
+            workspace_account_ids=workspace_ids,
             account_info_map=account_info_map,
         )
 

--- a/backend/core/agents/scheduled_actions/processor.py
+++ b/backend/core/agents/scheduled_actions/processor.py
@@ -214,7 +214,7 @@ def _build_tools(agent_slug: str, agent: dict, *, background_mode: bool = False)
     from agents.tool_loader import load_integration_tools, build_agent_handlers, INTEGRATION_MODULES
     from agents.engine import build_agent_config
     from integrations.registry import get_tool_mode, list_google_accounts as _list_ga
-    from integrations.google.policy import google_capabilities_union
+    from integrations.google.policy import google_tool_flags
     from core.agents.tools.real_tools import load_all_real_tools
 
     config = build_agent_config(agent)
@@ -222,7 +222,12 @@ def _build_tools(agent_slug: str, agent: dict, *, background_mode: bool = False)
     gmail_ids = ga.get("gmail", [])
     calendar_ids = ga.get("calendar", [])
     drive_ids = ga.get("drive", [])
-    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+    workspace_ids = ga.get("workspace", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
+    google_flags = google_tool_flags({
+        "gmail": gmail_ids, "calendar": calendar_ids,
+        "drive": drive_ids, "workspace": workspace_ids,
+    })
 
     all_ga = _list_ga()
     account_info_map = {
@@ -231,9 +236,6 @@ def _build_tools(agent_slug: str, agent: dict, *, background_mode: bool = False)
     }
 
     integration_tool_defs, integration_executors = load_integration_tools()
-    gmail_caps = google_capabilities_union(gmail_ids)
-    cal_caps = google_capabilities_union(calendar_ids)
-    drive_caps = google_capabilities_union(drive_ids)
     reminder_handlers, sa_handlers = build_agent_handlers(agent_slug)
 
     real_tools_dir = str(Path(config.context_dir).parent / "real_tools")
@@ -243,15 +245,7 @@ def _build_tools(agent_slug: str, agent: dict, *, background_mode: bool = False)
         integration_tools=integration_tool_defs,
         dynamic_real_tools=dynamic_real_tools or None,
         web_enabled=True,
-        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
-        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
-        calendar_read_enabled=cal_caps["calendar_read_enabled"],
-        calendar_write_enabled=cal_caps["calendar_write_enabled"],
-        drive_read_enabled=drive_caps["drive_read_enabled"],
-        drive_write_enabled=drive_caps["drive_write_enabled"],
-        multi_gmail=len(gmail_ids) > 1,
-        multi_calendar=len(calendar_ids) > 1,
-        multi_drive=len(drive_ids) > 1,
+        **google_flags,
         background_mode=background_mode,
     )
 
@@ -274,6 +268,7 @@ def _build_tools(agent_slug: str, agent: dict, *, background_mode: bool = False)
         gmail_account_ids=gmail_ids,
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
+        workspace_account_ids=workspace_ids,
         account_info_map=account_info_map,
     )
 

--- a/backend/core/agents/security/delimiters.py
+++ b/backend/core/agents/security/delimiters.py
@@ -8,7 +8,7 @@ inside these tags as untrusted data that may contain adversarial instructions.
 import secrets
 
 _EXTERNAL_KINDS: frozenset[str] = frozenset({
-    "gmail", "calendar", "drive", "web",
+    "gmail", "calendar", "drive", "workspace", "web",
 })
 
 _UNWRAPPED_INTEGRATION_PREFIXES: tuple[str, ...] = ("crm_",)

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1018,6 +1018,286 @@ DRIVE_WRITE_TOOLS = [
         "kind": "drive",
         "writes": True,
     },
+    {
+        "name": "delete_drive_file",
+        "description": "Delete a Google Drive file (including a Google Doc, Sheet, or Slides deck) by ID. Moves it to Trash (recoverable) by default; set permanent=true for an irreversible hard delete. To delete an arbitrary existing file the Drive scope must be 'full' (the 'app files only' scope can only delete files this app created).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "file_id": {"type": "string", "description": "ID of the file to delete"},
+                "permanent": {"type": "boolean", "description": "True to permanently delete instead of trashing (default false)"},
+            },
+            "required": ["file_id"],
+        },
+        "kind": "drive",
+        "writes": True,
+    },
+]
+
+
+# ── Workspace tools (Docs / Sheets / Slides) ──────────────────────────────────
+# Bundled "workspace" service. Reads/edits operate on a known file ID; find a
+# file's ID with search_drive_files and delete it with delete_drive_file.
+
+WORKSPACE_READ_TOOLS = [
+    {
+        "name": "read_google_doc",
+        "description": "Read the title and plain-text body of a Google Doc by document ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "document_id": {"type": "string", "description": "Google Doc document ID"},
+                "max_chars": {"type": "integer", "description": "Max characters of body to return (default 50000)"},
+            },
+            "required": ["document_id"],
+        },
+        "kind": "workspace",
+        "writes": False,
+    },
+    {
+        "name": "read_sheet_range",
+        "description": "Read cell values from a Google Sheet over an A1 range, e.g. \"Sheet1!A1:D20\". Returns a 2D array of rows.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {"type": "string", "description": "Google Sheets spreadsheet ID"},
+                "range": {"type": "string", "description": "A1 notation range, e.g. 'Sheet1!A1:D20'"},
+            },
+            "required": ["spreadsheet_id", "range"],
+        },
+        "kind": "workspace",
+        "writes": False,
+    },
+    {
+        "name": "read_sheet_metadata",
+        "description": "Get a spreadsheet's title and the list of its sheets/tabs (name, sheetId, dimensions). Use before reading/writing to discover tab names.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {"type": "string", "description": "Google Sheets spreadsheet ID"},
+            },
+            "required": ["spreadsheet_id"],
+        },
+        "kind": "workspace",
+        "writes": False,
+    },
+    {
+        "name": "read_presentation",
+        "description": "Read a Google Slides presentation's title and the plain text of each slide, by presentation ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "presentation_id": {"type": "string", "description": "Google Slides presentation ID"},
+                "max_chars": {"type": "integer", "description": "Max characters of text to return (default 50000)"},
+            },
+            "required": ["presentation_id"],
+        },
+        "kind": "workspace",
+        "writes": False,
+    },
+]
+
+_SHEET_VALUES_SCHEMA = {
+    "type": "array",
+    "description": "2D array of rows; each row is an array of cell values",
+    "items": {
+        "type": "array",
+        "items": {"type": ["string", "number", "boolean", "null"]},
+    },
+}
+
+WORKSPACE_WRITE_TOOLS = [
+    # Docs
+    {
+        "name": "create_google_doc",
+        "description": "Create a new Google Doc, optionally seeded with initial body text. Returns the new document ID and web link.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Title for the new document"},
+                "content": {"type": "string", "description": "Optional initial body text"},
+            },
+            "required": ["title"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "insert_doc_text",
+        "description": "Insert text into a Google Doc at a 1-based character index (default 1 = start of the body).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "document_id": {"type": "string", "description": "Google Doc document ID"},
+                "text": {"type": "string", "description": "Text to insert"},
+                "index": {"type": "integer", "description": "1-based insertion index (default 1)"},
+            },
+            "required": ["document_id", "text"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "append_doc_text",
+        "description": "Append text to the end of a Google Doc's body (adds a leading newline if the text does not start with one).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "document_id": {"type": "string", "description": "Google Doc document ID"},
+                "text": {"type": "string", "description": "Text to append"},
+            },
+            "required": ["document_id", "text"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "replace_doc_text",
+        "description": "Find and replace all occurrences of a string in a Google Doc. Returns how many occurrences changed. Great for filling templates.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "document_id": {"type": "string", "description": "Google Doc document ID"},
+                "find": {"type": "string", "description": "Text to find"},
+                "replace": {"type": "string", "description": "Replacement text"},
+                "match_case": {"type": "boolean", "description": "Case-sensitive match (default false)"},
+            },
+            "required": ["document_id", "find", "replace"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    # Sheets
+    {
+        "name": "write_sheet_range",
+        "description": "Overwrite a Google Sheet A1 range with a 2D array of values (USER_ENTERED, so formulas and dates are parsed).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {"type": "string", "description": "Google Sheets spreadsheet ID"},
+                "range": {"type": "string", "description": "A1 range to write, e.g. 'Sheet1!A1'"},
+                "values": _SHEET_VALUES_SCHEMA,
+            },
+            "required": ["spreadsheet_id", "range", "values"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "append_sheet_rows",
+        "description": "Append rows after the last row of data in a Google Sheet (INSERT_ROWS, USER_ENTERED).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {"type": "string", "description": "Google Sheets spreadsheet ID"},
+                "range": {"type": "string", "description": "A1 range identifying the table, e.g. 'Sheet1!A:C'"},
+                "values": _SHEET_VALUES_SCHEMA,
+            },
+            "required": ["spreadsheet_id", "range", "values"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "clear_sheet_range",
+        "description": "Clear all values in a Google Sheet A1 range (keeps formatting).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {"type": "string", "description": "Google Sheets spreadsheet ID"},
+                "range": {"type": "string", "description": "A1 range to clear, e.g. 'Sheet1!A2:Z'"},
+            },
+            "required": ["spreadsheet_id", "range"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "create_spreadsheet",
+        "description": "Create a new Google Sheets spreadsheet. Returns the new spreadsheet ID and web link.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Title for the new spreadsheet"},
+            },
+            "required": ["title"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "add_sheet_tab",
+        "description": "Add a new sheet/tab to an existing Google Sheets spreadsheet.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "spreadsheet_id": {"type": "string", "description": "Google Sheets spreadsheet ID"},
+                "title": {"type": "string", "description": "Title for the new tab"},
+            },
+            "required": ["spreadsheet_id", "title"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    # Slides
+    {
+        "name": "create_presentation",
+        "description": "Create a new Google Slides presentation. Returns the presentation ID, first slide object ID, and web link.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Title for the new presentation"},
+            },
+            "required": ["title"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "add_slide",
+        "description": "Add a new slide to a Google Slides presentation using a predefined layout (e.g. BLANK, TITLE, TITLE_AND_BODY). Returns the new slide's object ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "presentation_id": {"type": "string", "description": "Google Slides presentation ID"},
+                "layout": {"type": "string", "description": "Predefined layout name (default BLANK)"},
+            },
+            "required": ["presentation_id"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "insert_slide_text",
+        "description": "Add a text box to a specific slide and insert text into it. Use a slide_object_id from read_presentation, create_presentation, or add_slide.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "presentation_id": {"type": "string", "description": "Google Slides presentation ID"},
+                "slide_object_id": {"type": "string", "description": "Object ID of the target slide/page"},
+                "text": {"type": "string", "description": "Text to place in the new text box"},
+            },
+            "required": ["presentation_id", "slide_object_id", "text"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
+    {
+        "name": "replace_presentation_text",
+        "description": "Find and replace all occurrences of a string across an entire Google Slides presentation. Returns how many occurrences changed. Great for filling templates.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "presentation_id": {"type": "string", "description": "Google Slides presentation ID"},
+                "find": {"type": "string", "description": "Text to find"},
+                "replace": {"type": "string", "description": "Replacement text"},
+                "match_case": {"type": "boolean", "description": "Case-sensitive match (default false)"},
+            },
+            "required": ["presentation_id", "find", "replace"],
+        },
+        "kind": "workspace",
+        "writes": True,
+    },
 ]
 
 
@@ -1676,9 +1956,12 @@ def get_tool_definitions(
     integration_tools: list[dict] | None = None,
     dynamic_real_tools: list[dict] | None = None,
     import_mode: bool = False,
+    workspace_read_enabled: bool = False,
+    workspace_write_enabled: bool = False,
     multi_gmail: bool = False,
     multi_calendar: bool = False,
     multi_drive: bool = False,
+    multi_workspace: bool = False,
     background_mode: bool = False,
 ) -> list[dict]:
     """Return the full list of tool definitions for the given feature flags.
@@ -1726,6 +2009,12 @@ def get_tool_definitions(
     if drive_write_enabled:
         tools.extend(DRIVE_WRITE_TOOLS)
 
+    # Workspace (Docs / Sheets / Slides)
+    if workspace_read_enabled:
+        tools.extend(WORKSPACE_READ_TOOLS)
+    if workspace_write_enabled:
+        tools.extend(WORKSPACE_WRITE_TOOLS)
+
     if web_enabled:
         tools.extend(WEB_TOOLS)
     if real_tools_enabled:
@@ -1754,6 +2043,8 @@ def get_tool_definitions(
         multi_services.add("calendar")
     if multi_drive:
         multi_services.add("drive")
+    if multi_workspace:
+        multi_services.add("workspace")
     if multi_services:
         import copy
         _ACCOUNT_PROP = {

--- a/backend/core/agents/tool_definitions.py
+++ b/backend/core/agents/tool_definitions.py
@@ -1020,12 +1020,12 @@ DRIVE_WRITE_TOOLS = [
     },
     {
         "name": "delete_drive_file",
-        "description": "Delete a Google Drive file (including a Google Doc, Sheet, or Slides deck) by ID. Moves it to Trash (recoverable) by default; set permanent=true for an irreversible hard delete. To delete an arbitrary existing file the Drive scope must be 'full' (the 'app files only' scope can only delete files this app created).",
+        "description": "Delete a Google Drive file (including a Google Doc, Sheet, or Slides deck) by ID. Moves it to Trash (recoverable) by default; set permanent=true for an irreversible hard delete (which requires the 'Full access' Drive scope). To delete an arbitrary existing file the Drive scope must be 'full' (the 'app files only' scope can only act on files this app created).",
         "input_schema": {
             "type": "object",
             "properties": {
                 "file_id": {"type": "string", "description": "ID of the file to delete"},
-                "permanent": {"type": "boolean", "description": "True to permanently delete instead of trashing (default false)"},
+                "permanent": {"type": "boolean", "description": "True to permanently delete instead of trashing (default false). Requires 'Full access' Drive scope."},
             },
             "required": ["file_id"],
         },

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -538,10 +538,24 @@ class ToolRegistry:
                 # Irreversible hard-delete requires full Drive access; 'file' scope
                 # may only trash (recoverable). Blocks a prompt-injected agent from
                 # permanently destroying app-created files under a narrow grant.
-                level = self.account_info_map.get(aid, {}).get("scope_grants", {}).get("drive", "none")
-                if level != "full":
-                    return {"error": "Permanent deletion requires 'Full access' Drive scope. "
-                                     "Use permanent=false to move the file to Trash (recoverable)."}
+                def _drive_level(a):
+                    return self.account_info_map.get(a, {}).get("scope_grants", {}).get("drive", "none")
+                if _drive_level(aid) != "full":
+                    # The auto-selected account may be 'file'-scoped while another
+                    # assigned account is 'full'; prefer that one — unless the model
+                    # pinned a specific account by email.
+                    if not email:
+                        full_aid = next(
+                            (a for a in self.drive_account_ids
+                             if self.account_info_map.get(a, {}).get("connection_status") != "broken"
+                             and _drive_level(a) == "full"),
+                            None,
+                        )
+                        if full_aid:
+                            aid = full_aid
+                    if _drive_level(aid) != "full":
+                        return {"error": "Permanent deletion requires 'Full access' Drive scope. "
+                                         "Use permanent=false to move the file to Trash (recoverable)."}
             return delete_drive_file(aid, file_id=args["file_id"], permanent=permanent)
         return {"error": f"Unknown drive tool: {tool_name}"}
 

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -533,10 +533,16 @@ class ToolRegistry:
                 folder_id=args.get("folder_id"),
             )
         elif tool_name == "delete_drive_file":
-            return delete_drive_file(
-                aid, file_id=args["file_id"],
-                permanent=args.get("permanent", False),
-            )
+            permanent = args.get("permanent", False)
+            if permanent:
+                # Irreversible hard-delete requires full Drive access; 'file' scope
+                # may only trash (recoverable). Blocks a prompt-injected agent from
+                # permanently destroying app-created files under a narrow grant.
+                level = self.account_info_map.get(aid, {}).get("scope_grants", {}).get("drive", "none")
+                if level != "full":
+                    return {"error": "Permanent deletion requires 'Full access' Drive scope. "
+                                     "Use permanent=false to move the file to Trash (recoverable)."}
+            return delete_drive_file(aid, file_id=args["file_id"], permanent=permanent)
         return {"error": f"Unknown drive tool: {tool_name}"}
 
     def _execute_workspace(self, tool_name: str, args: dict) -> dict:

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -533,7 +533,9 @@ class ToolRegistry:
                 folder_id=args.get("folder_id"),
             )
         elif tool_name == "delete_drive_file":
-            permanent = args.get("permanent", False)
+            # Strict True only: a stray string like "false" must NOT trigger an
+            # irreversible delete — anything non-True falls back to safe trashing.
+            permanent = args.get("permanent", False) is True
             if permanent:
                 # Irreversible hard-delete requires full Drive access; 'file' scope
                 # may only trash (recoverable). Blocks a prompt-injected agent from

--- a/backend/core/agents/tool_registry.py
+++ b/backend/core/agents/tool_registry.py
@@ -43,12 +43,33 @@ from integrations.google.tools import (
     copy_drive_file,
     create_drive_file,
     create_drive_folder,
+    delete_drive_file,
     get_drive_file_info,
     list_drive_folder,
     move_drive_file,
     read_drive_file_content,
     rename_drive_file,
     search_drive_files,
+    # Workspace: Docs
+    read_google_doc,
+    create_google_doc,
+    insert_doc_text,
+    append_doc_text,
+    replace_doc_text,
+    # Workspace: Sheets
+    read_sheet_range,
+    read_sheet_metadata,
+    write_sheet_range,
+    append_sheet_rows,
+    clear_sheet_range,
+    create_spreadsheet,
+    add_sheet_tab,
+    # Workspace: Slides
+    read_presentation,
+    create_presentation,
+    add_slide,
+    insert_slide_text,
+    replace_presentation_text,
 )
 from core.agents.tools.web_tools import web_search, web_fetch
 from core.agents.tools.real_tools import (
@@ -76,13 +97,20 @@ class ToolRegistry:
                   "mark_all_emails_as_read"},
         "calendar": {"create_calendar_event", "update_calendar_event", "delete_calendar_event"},
         "drive": {"create_drive_folder", "create_drive_file", "move_drive_file",
-                  "rename_drive_file", "copy_drive_file"},
+                  "rename_drive_file", "copy_drive_file", "delete_drive_file"},
+        "workspace": {"create_google_doc", "insert_doc_text", "append_doc_text", "replace_doc_text",
+                      "write_sheet_range", "append_sheet_rows", "clear_sheet_range",
+                      "create_spreadsheet", "add_sheet_tab",
+                      "create_presentation", "add_slide", "insert_slide_text",
+                      "replace_presentation_text"},
     }
-    _WRITE_SCOPE_KEY = {"gmail": "gmail", "calendar": "calendar", "drive": "drive"}
+    _WRITE_SCOPE_KEY = {"gmail": "gmail", "calendar": "calendar", "drive": "drive",
+                        "workspace": "workspace"}
     _WRITE_SCOPE_LEVELS = {
         "gmail": {"send"},
         "calendar": {"full"},
         "drive": {"file", "full"},
+        "workspace": {"edit"},
     }
 
     def __init__(
@@ -93,6 +121,7 @@ class ToolRegistry:
         gmail_account_ids: list[str] | None = None,
         calendar_account_ids: list[str] | None = None,
         drive_account_ids: list[str] | None = None,
+        workspace_account_ids: list[str] | None = None,
         account_info_map: dict[str, dict] | None = None,
         integration_executors: dict | None = None,
         agent_slug: str = "",
@@ -106,6 +135,7 @@ class ToolRegistry:
         self.gmail_account_ids = gmail_account_ids or []
         self.calendar_account_ids = calendar_account_ids or []
         self.drive_account_ids = drive_account_ids or []
+        self.workspace_account_ids = workspace_account_ids or []
         self.account_info_map: dict[str, dict] = account_info_map or {}
         self.integration_executors: dict = integration_executors or {}
         self.agent_slug = agent_slug
@@ -153,6 +183,8 @@ class ToolRegistry:
                 return self._execute_calendar(tool_name, tool_args)
             elif kind == "drive":
                 return self._execute_drive(tool_name, tool_args)
+            elif kind == "workspace":
+                return self._execute_workspace(tool_name, tool_args)
             elif kind == "web":
                 return self._execute_web(tool_name, tool_args)
             elif kind == "real_tool":
@@ -500,7 +532,63 @@ class ToolRegistry:
                 new_name=args.get("new_name"),
                 folder_id=args.get("folder_id"),
             )
+        elif tool_name == "delete_drive_file":
+            return delete_drive_file(
+                aid, file_id=args["file_id"],
+                permanent=args.get("permanent", False),
+            )
         return {"error": f"Unknown drive tool: {tool_name}"}
+
+    def _execute_workspace(self, tool_name: str, args: dict) -> dict:
+        """Dispatch Docs / Sheets / Slides tools. All resolve against the single
+        bundled 'workspace' account assignment, then route by tool name."""
+        email = args.get("account")
+        args = {k: v for k, v in args.items() if k != "account"}
+        aid = self._resolve_account("workspace", email, tool_name)
+        if isinstance(aid, dict):
+            return aid
+
+        # Docs
+        if tool_name == "read_google_doc":
+            return read_google_doc(aid, document_id=args["document_id"], max_chars=args.get("max_chars", 50000))
+        elif tool_name == "create_google_doc":
+            return create_google_doc(aid, title=args["title"], content=args.get("content", ""))
+        elif tool_name == "insert_doc_text":
+            return insert_doc_text(aid, document_id=args["document_id"], text=args["text"], index=args.get("index", 1))
+        elif tool_name == "append_doc_text":
+            return append_doc_text(aid, document_id=args["document_id"], text=args["text"])
+        elif tool_name == "replace_doc_text":
+            return replace_doc_text(aid, document_id=args["document_id"], find=args["find"],
+                                    replace=args["replace"], match_case=args.get("match_case", False))
+        # Sheets
+        elif tool_name == "read_sheet_range":
+            return read_sheet_range(aid, spreadsheet_id=args["spreadsheet_id"], range=args["range"])
+        elif tool_name == "read_sheet_metadata":
+            return read_sheet_metadata(aid, spreadsheet_id=args["spreadsheet_id"])
+        elif tool_name == "write_sheet_range":
+            return write_sheet_range(aid, spreadsheet_id=args["spreadsheet_id"], range=args["range"], values=args["values"])
+        elif tool_name == "append_sheet_rows":
+            return append_sheet_rows(aid, spreadsheet_id=args["spreadsheet_id"], range=args["range"], values=args["values"])
+        elif tool_name == "clear_sheet_range":
+            return clear_sheet_range(aid, spreadsheet_id=args["spreadsheet_id"], range=args["range"])
+        elif tool_name == "create_spreadsheet":
+            return create_spreadsheet(aid, title=args["title"])
+        elif tool_name == "add_sheet_tab":
+            return add_sheet_tab(aid, spreadsheet_id=args["spreadsheet_id"], title=args["title"])
+        # Slides
+        elif tool_name == "read_presentation":
+            return read_presentation(aid, presentation_id=args["presentation_id"], max_chars=args.get("max_chars", 50000))
+        elif tool_name == "create_presentation":
+            return create_presentation(aid, title=args["title"])
+        elif tool_name == "add_slide":
+            return add_slide(aid, presentation_id=args["presentation_id"], layout=args.get("layout", "BLANK"))
+        elif tool_name == "insert_slide_text":
+            return insert_slide_text(aid, presentation_id=args["presentation_id"],
+                                     slide_object_id=args["slide_object_id"], text=args["text"])
+        elif tool_name == "replace_presentation_text":
+            return replace_presentation_text(aid, presentation_id=args["presentation_id"], find=args["find"],
+                                             replace=args["replace"], match_case=args.get("match_case", False))
+        return {"error": f"Unknown workspace tool: {tool_name}"}
 
     def _execute_web(self, tool_name: str, args: dict) -> dict:
         if tool_name == "web_search":

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -73,11 +73,30 @@ DRIVE_SCOPE_LEVELS = {
     "full": ["https://www.googleapis.com/auth/drive"],
 }
 
+# Bundled Workspace service: Docs + Sheets + Slides. "read" grants the
+# read-only variant of each API; "edit" grants full create/read/update.
+# Deleting a Workspace file is a Drive operation (delete_drive_file), gated
+# on Drive write — not on these scopes.
+WORKSPACE_SCOPE_LEVELS = {
+    "none": [],
+    "read": [
+        "https://www.googleapis.com/auth/documents.readonly",
+        "https://www.googleapis.com/auth/spreadsheets.readonly",
+        "https://www.googleapis.com/auth/presentations.readonly",
+    ],
+    "edit": [
+        "https://www.googleapis.com/auth/documents",
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/presentations",
+    ],
+}
+
 
 def build_google_scopes(
     gmail_level: str = "none",
     calendar_level: str = "none",
     drive_level: str = "none",
+    workspace_level: str = "none",
     include_ai: bool = False,
 ) -> list[str]:
     """Build the Google OAuth scope list for a user-chosen access profile.
@@ -91,6 +110,7 @@ def build_google_scopes(
     scopes.extend(GMAIL_SCOPE_LEVELS.get(gmail_level, []))
     scopes.extend(CALENDAR_SCOPE_LEVELS.get(calendar_level, []))
     scopes.extend(DRIVE_SCOPE_LEVELS.get(drive_level, []))
+    scopes.extend(WORKSPACE_SCOPE_LEVELS.get(workspace_level, []))
     # De-duplicate while preserving order
     seen: set[str] = set()
     deduped = []

--- a/backend/integrations/google/client.py
+++ b/backend/integrations/google/client.py
@@ -177,13 +177,14 @@ def _fire_broken_alerts(account_id: str, email: str) -> None:
     try:
         from agents.db import list_agents
         from core.agents.alerts.service import create_alert
+        from integrations.google.policy import GOOGLE_SERVICES
         for agent in list_agents():
             ga = agent.get("google_accounts", {})
             if not isinstance(ga, dict):
                 continue
             uses_account = any(
                 account_id in (ga.get(svc) or [])
-                for svc in ("gmail", "calendar", "drive")
+                for svc in GOOGLE_SERVICES
             )
             if uses_account:
                 create_alert(
@@ -191,7 +192,7 @@ def _fire_broken_alerts(account_id: str, email: str) -> None:
                     title=f"Google connection broken: {email}",
                     message=(
                         f"The Google account {email} has lost its connection. "
-                        f"Email, calendar, and drive tools for this account are disabled. "
+                        f"Email, calendar, drive, and workspace tools for this account are disabled. "
                         f"Reconnect at Settings → Integrations → Google."
                     ),
                     source="google_connection",
@@ -268,6 +269,24 @@ def get_drive_service(account_id: str):
     """Return an authenticated Drive v3 service for the given account."""
     access = _ensure_fresh_token(account_id)
     return _build_service("drive", "v3", access)
+
+
+def get_docs_service(account_id: str):
+    """Return an authenticated Docs v1 service for the given account."""
+    access = _ensure_fresh_token(account_id)
+    return _build_service("docs", "v1", access)
+
+
+def get_sheets_service(account_id: str):
+    """Return an authenticated Sheets v4 service for the given account."""
+    access = _ensure_fresh_token(account_id)
+    return _build_service("sheets", "v4", access)
+
+
+def get_slides_service(account_id: str):
+    """Return an authenticated Slides v1 service for the given account."""
+    access = _ensure_fresh_token(account_id)
+    return _build_service("slides", "v1", access)
 
 
 # ── Retry wrapper for tool handlers ──────────────────────────────────────────

--- a/backend/integrations/google/docs_ops.py
+++ b/backend/integrations/google/docs_ops.py
@@ -1,0 +1,130 @@
+"""Google Docs operations — each function takes an authenticated Docs v1 service.
+
+Curated CRUD: get (read), create, insert_text, append_text, replace_text.
+Listing/finding Docs is done via Drive search; deleting is delete_drive_file.
+batchUpdate request-building patterns adapted from the Hermes agent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_DOC_URL = "https://docs.google.com/document/d/{}/edit"
+
+
+def _extract_doc_text(doc: dict) -> str:
+    """Flatten a Docs document's structured body into plain text."""
+    parts: list[str] = []
+    for element in doc.get("body", {}).get("content", []):
+        paragraph = element.get("paragraph", {})
+        for pe in paragraph.get("elements", []):
+            run = pe.get("textRun", {})
+            if run.get("content"):
+                parts.append(run["content"])
+    return "".join(parts)
+
+
+def _end_index(doc: dict) -> int:
+    """Return the insert index just before the document body's trailing newline.
+
+    Docs indexes are 1-based and the body always ends with a newline at the
+    last index, so we insert at endIndex - 1 to append at the true end.
+    """
+    end = 1
+    for element in doc.get("body", {}).get("content", []):
+        ei = element.get("endIndex")
+        if isinstance(ei, int) and ei > end:
+            end = ei
+    return max(end - 1, 1)
+
+
+# ── Read ─────────────────────────────────────────────────────────────────────
+
+def get_document_op(service, document_id: str, max_chars: int = 50000) -> dict:
+    """Read a Google Doc's title and plain-text body (truncated to max_chars)."""
+    doc = service.documents().get(documentId=document_id).execute()
+    body = _extract_doc_text(doc)
+    return {
+        "document_id": doc.get("documentId", document_id),
+        "title": doc.get("title", ""),
+        "content": body[:max_chars],
+        "truncated": len(body) > max_chars,
+        "char_count": len(body),
+        "web_link": _DOC_URL.format(document_id),
+    }
+
+
+# ── Write ────────────────────────────────────────────────────────────────────
+
+def create_document_op(service, title: str, content: str = "") -> dict:
+    """Create a new Google Doc, optionally seeded with initial body text."""
+    doc = service.documents().create(body={"title": title}).execute()
+    doc_id = doc.get("documentId", "")
+    if content and doc_id:
+        service.documents().batchUpdate(
+            documentId=doc_id,
+            body={"requests": [{"insertText": {"location": {"index": 1}, "text": content}}]},
+        ).execute()
+    return {
+        "ok": True,
+        "document_id": doc_id,
+        "title": doc.get("title", title),
+        "web_link": _DOC_URL.format(doc_id),
+    }
+
+
+def insert_text_op(service, document_id: str, text: str, index: int = 1) -> dict:
+    """Insert text at a 1-based character index (default 1 = start of body)."""
+    if index < 1:
+        index = 1
+    service.documents().batchUpdate(
+        documentId=document_id,
+        body={"requests": [{"insertText": {"location": {"index": index}, "text": text}}]},
+    ).execute()
+    return {
+        "ok": True, "document_id": document_id,
+        "inserted_at": index, "characters": len(text),
+        "web_link": _DOC_URL.format(document_id),
+    }
+
+
+def append_text_op(service, document_id: str, text: str) -> dict:
+    """Append text to the end of the document body."""
+    doc = service.documents().get(documentId=document_id).execute()
+    index = _end_index(doc)
+    body_text = text if text.startswith("\n") else "\n" + text
+    service.documents().batchUpdate(
+        documentId=document_id,
+        body={"requests": [{"insertText": {"location": {"index": index}, "text": body_text}}]},
+    ).execute()
+    return {
+        "ok": True, "document_id": document_id,
+        "inserted_at": index, "characters": len(body_text),
+        "web_link": _DOC_URL.format(document_id),
+    }
+
+
+def replace_text_op(
+    service, document_id: str, find: str, replace: str, match_case: bool = False,
+) -> dict:
+    """Find-and-replace all occurrences of `find` with `replace`."""
+    resp = service.documents().batchUpdate(
+        documentId=document_id,
+        body={"requests": [{
+            "replaceAllText": {
+                "containsText": {"text": find, "matchCase": match_case},
+                "replaceText": replace,
+            }
+        }]},
+    ).execute()
+    replies = resp.get("replies", [])
+    changed = 0
+    if replies:
+        changed = replies[0].get("replaceAllText", {}).get("occurrencesChanged", 0) or 0
+    return {
+        "ok": True, "document_id": document_id,
+        "occurrences_changed": changed,
+        "web_link": _DOC_URL.format(document_id),
+    }

--- a/backend/integrations/google/docs_ops.py
+++ b/backend/integrations/google/docs_ops.py
@@ -18,16 +18,32 @@ _DOC_URL = "https://docs.google.com/document/d/{}/edit"
 _MAX_READ_CHARS = 200_000
 
 
-def _extract_doc_text(doc: dict) -> str:
-    """Flatten a Docs document's structured body into plain text."""
+def _structural_text(elements: list) -> list[str]:
+    """Recursively flatten Docs structural elements (paragraphs + table cells)."""
     parts: list[str] = []
-    for element in doc.get("body", {}).get("content", []):
-        paragraph = element.get("paragraph", {})
-        for pe in paragraph.get("elements", []):
-            run = pe.get("textRun", {})
-            if run.get("content"):
-                parts.append(run["content"])
-    return "".join(parts)
+    for element in elements:
+        paragraph = element.get("paragraph")
+        if paragraph:
+            for pe in paragraph.get("elements", []):
+                run = pe.get("textRun", {})
+                if run.get("content"):
+                    parts.append(run["content"])
+            continue
+        table = element.get("table")
+        if table:
+            for row in table.get("tableRows", []):
+                for cell in row.get("tableCells", []):
+                    parts.extend(_structural_text(cell.get("content", [])))
+    return parts
+
+
+def _extract_doc_text(doc: dict) -> str:
+    """Flatten a Docs document's structured body into plain text.
+
+    Walks paragraphs and table cells. Reads the document's primary body (tab 1);
+    additional tabs in multi-tab documents are not included.
+    """
+    return "".join(_structural_text(doc.get("body", {}).get("content", [])))
 
 
 def _end_index(doc: dict) -> int:

--- a/backend/integrations/google/docs_ops.py
+++ b/backend/integrations/google/docs_ops.py
@@ -13,6 +13,10 @@ logger = logging.getLogger(__name__)
 
 _DOC_URL = "https://docs.google.com/document/d/{}/edit"
 
+# Hard ceiling on returned characters so an agent (or injected document content)
+# can't request an arbitrarily large read and stuff the model context.
+_MAX_READ_CHARS = 200_000
+
 
 def _extract_doc_text(doc: dict) -> str:
     """Flatten a Docs document's structured body into plain text."""
@@ -44,6 +48,7 @@ def _end_index(doc: dict) -> int:
 
 def get_document_op(service, document_id: str, max_chars: int = 50000) -> dict:
     """Read a Google Doc's title and plain-text body (truncated to max_chars)."""
+    max_chars = max(1, min(max_chars, _MAX_READ_CHARS))
     doc = service.documents().get(documentId=document_id).execute()
     body = _extract_doc_text(doc)
     return {

--- a/backend/integrations/google/drive_ops.py
+++ b/backend/integrations/google/drive_ops.py
@@ -266,3 +266,23 @@ def copy_file_op(
         fields="id,name,mimeType,modifiedTime,webViewLink",
     ).execute()
     return {"ok": True, **_format_file(copied)}
+
+
+def delete_file_op(service, file_id: str, permanent: bool = False) -> dict:
+    """Delete a Drive file. Trashes (recoverable) by default; permanent=True is
+    an irreversible hard delete. Trashing requires the file to be owned by the
+    user; this also covers deleting Docs/Sheets/Slides created via Workspace."""
+    if permanent:
+        service.files().delete(fileId=file_id).execute()
+        return {"ok": True, "file_id": file_id, "permanently_deleted": True}
+    updated = service.files().update(
+        fileId=file_id,
+        body={"trashed": True},
+        fields="id,name,trashed",
+    ).execute()
+    return {
+        "ok": True,
+        "file_id": updated.get("id", file_id),
+        "name": updated.get("name", ""),
+        "trashed": updated.get("trashed", True),
+    }

--- a/backend/integrations/google/drive_ops.py
+++ b/backend/integrations/google/drive_ops.py
@@ -273,12 +273,13 @@ def delete_file_op(service, file_id: str, permanent: bool = False) -> dict:
     an irreversible hard delete. Trashing requires the file to be owned by the
     user; this also covers deleting Docs/Sheets/Slides created via Workspace."""
     if permanent:
-        service.files().delete(fileId=file_id).execute()
+        service.files().delete(fileId=file_id, supportsAllDrives=True).execute()
         return {"ok": True, "file_id": file_id, "permanently_deleted": True}
     updated = service.files().update(
         fileId=file_id,
         body={"trashed": True},
         fields="id,name,trashed",
+        supportsAllDrives=True,
     ).execute()
     return {
         "ok": True,

--- a/backend/integrations/google/onboarding.py
+++ b/backend/integrations/google/onboarding.py
@@ -127,12 +127,13 @@ def _clear_stale_assignments(account_id: str, scope_grants: dict) -> None:
     """Clear agent assignments for services that were downgraded to 'none'."""
     try:
         from agents.db import list_agents, update_agent
+        from .policy import GOOGLE_SERVICES
         for agent in list_agents():
             ga = agent.get("google_accounts", {})
             if not isinstance(ga, dict):
                 continue
             changed = False
-            for svc in ("gmail", "calendar", "drive"):
+            for svc in GOOGLE_SERVICES:
                 val = ga.get(svc)
                 if scope_grants.get(svc, "none") == "none":
                     if isinstance(val, list) and account_id in val:
@@ -172,13 +173,14 @@ def _clear_agent_references(account_id: str = "") -> None:
     """Clear google_accounts on agents that reference a removed account."""
     try:
         from agents.db import list_agents, update_agent
+        from .policy import GOOGLE_SERVICES
         for agent in list_agents():
             ga = agent.get("google_accounts", {})
             if not isinstance(ga, dict):
                 continue
             changed = False
             if account_id:
-                for svc in ("gmail", "calendar", "drive"):
+                for svc in GOOGLE_SERVICES:
                     val = ga.get(svc)
                     if isinstance(val, list) and account_id in val:
                         ga[svc] = [a for a in val if a != account_id]
@@ -188,7 +190,7 @@ def _clear_agent_references(account_id: str = "") -> None:
                         changed = True
             else:
                 if any(v for v in ga.values()):
-                    ga = {"gmail": [], "calendar": [], "drive": []}
+                    ga = {svc: [] for svc in GOOGLE_SERVICES}
                     changed = True
             if changed:
                 update_agent(agent["id"], google_accounts=json.dumps(ga))

--- a/backend/integrations/google/policy.py
+++ b/backend/integrations/google/policy.py
@@ -2,11 +2,18 @@
 Chatty — Google capability resolution (multi-account).
 
 Each agent can have different Google accounts assigned per service
-(Gmail, Calendar, Drive). Capabilities are resolved per-account.
+(Gmail, Calendar, Drive, Workspace). Capabilities are resolved per-account.
+
+`GOOGLE_SERVICES` is the single source of truth for the list of assignable
+Google services. Iterate it instead of hardcoding ("gmail", "calendar",
+"drive", ...) tuples so adding a service stays a one-line change.
 """
 
 from __future__ import annotations
 
+# Single source of truth for the assignable Google services. Order matters only
+# for stable iteration; "workspace" bundles Docs + Sheets + Slides.
+GOOGLE_SERVICES = ("gmail", "calendar", "drive", "workspace")
 
 _GMAIL_READ_LEVELS = {"read", "send"}
 _GMAIL_SEND_LEVELS = {"send"}
@@ -14,6 +21,8 @@ _CALENDAR_READ_LEVELS = {"read", "full"}
 _CALENDAR_WRITE_LEVELS = {"full"}
 _DRIVE_READ_LEVELS = {"file", "readonly", "full"}
 _DRIVE_WRITE_LEVELS = {"file", "full"}
+_WORKSPACE_READ_LEVELS = {"read", "edit"}
+_WORKSPACE_WRITE_LEVELS = {"edit"}
 
 _ALL_DISABLED = {
     "gmail_read_enabled": False,
@@ -22,6 +31,17 @@ _ALL_DISABLED = {
     "calendar_write_enabled": False,
     "drive_read_enabled": False,
     "drive_write_enabled": False,
+    "workspace_read_enabled": False,
+    "workspace_write_enabled": False,
+}
+
+# Per-service capability flag keys, used to scope flags to the right service
+# when flattening per-service account assignments into tool-definition kwargs.
+_SERVICE_FLAG_KEYS = {
+    "gmail": ("gmail_read_enabled", "gmail_send_enabled"),
+    "calendar": ("calendar_read_enabled", "calendar_write_enabled"),
+    "drive": ("drive_read_enabled", "drive_write_enabled"),
+    "workspace": ("workspace_read_enabled", "workspace_write_enabled"),
 }
 
 
@@ -49,6 +69,7 @@ def google_capabilities(account_id: str = "") -> dict[str, bool]:
     gmail = grants.get("gmail", "none")
     calendar = grants.get("calendar", "none")
     drive = grants.get("drive", "none")
+    workspace = grants.get("workspace", "none")
 
     return {
         "gmail_read_enabled": gmail in _GMAIL_READ_LEVELS,
@@ -57,6 +78,8 @@ def google_capabilities(account_id: str = "") -> dict[str, bool]:
         "calendar_write_enabled": calendar in _CALENDAR_WRITE_LEVELS,
         "drive_read_enabled": drive in _DRIVE_READ_LEVELS,
         "drive_write_enabled": drive in _DRIVE_WRITE_LEVELS,
+        "workspace_read_enabled": workspace in _WORKSPACE_READ_LEVELS,
+        "workspace_write_enabled": workspace in _WORKSPACE_WRITE_LEVELS,
     }
 
 
@@ -71,3 +94,26 @@ def google_capabilities_union(account_ids: list[str]) -> dict[str, bool]:
             if val:
                 result[key] = True
     return result
+
+
+def google_tool_flags(ids_by_service: dict[str, list[str]]) -> dict[str, bool]:
+    """Flatten per-service account assignments into get_tool_definitions() kwargs.
+
+    For each service in GOOGLE_SERVICES, unions that service's assigned accounts
+    and keeps only that service's own capability flags (so an account assigned to
+    Drive does not enable Gmail tools just because it also granted Gmail). Also
+    emits a `multi_<service>` flag (True when >1 account is assigned) so the
+    multi-account `account` param is injected into that service's tools.
+
+    The returned dict is spreadable directly: get_tool_definitions(**flags, ...).
+    """
+    flags: dict[str, bool] = {}
+    for svc in GOOGLE_SERVICES:
+        ids = ids_by_service.get(svc, []) or []
+        caps = google_capabilities_union(ids)
+        # Tolerate partial capability dicts (e.g. older stubs): a missing flag
+        # simply means that capability is disabled.
+        for key in _SERVICE_FLAG_KEYS[svc]:
+            flags[key] = caps.get(key, False)
+        flags[f"multi_{svc}"] = len(ids) > 1
+    return flags

--- a/backend/integrations/google/policy.py
+++ b/backend/integrations/google/policy.py
@@ -84,7 +84,12 @@ def google_capabilities(account_id: str = "") -> dict[str, bool]:
 
 
 def google_capabilities_union(account_ids: list[str]) -> dict[str, bool]:
-    """Return capability flags as the union across multiple accounts."""
+    """Return capability flags as the union across multiple accounts.
+
+    Internal helper for google_tool_flags(). New tool-building call sites should
+    use google_tool_flags() instead, which scopes flags per service and emits
+    the multi_* flags ready to spread into get_tool_definitions().
+    """
     if not account_ids:
         return dict(_ALL_DISABLED)
     result = dict(_ALL_DISABLED)

--- a/backend/integrations/google/sheets_ops.py
+++ b/backend/integrations/google/sheets_ops.py
@@ -1,0 +1,150 @@
+"""Google Sheets operations — each function takes an authenticated Sheets v4 service.
+
+Curated CRUD: read_range, read_metadata (read), write_range, append_rows,
+clear_range, create, add_tab (write). Deleting a spreadsheet is delete_drive_file.
+Patterns adapted from the Hermes agent and CAKE OS sheets writers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_SHEET_URL = "https://docs.google.com/spreadsheets/d/{}/edit"
+
+# Soft cap on the number of cells returned by a single read so a huge range
+# can't blow up tool output / context. Rows past the cap are dropped.
+_MAX_READ_CELLS = 20000
+
+
+# ── Read ─────────────────────────────────────────────────────────────────────
+
+def get_values_op(service, spreadsheet_id: str, range_a1: str) -> dict:
+    """Read cell values from an A1 range (e.g. "Sheet1!A1:D10")."""
+    resp = service.spreadsheets().values().get(
+        spreadsheetId=spreadsheet_id, range=range_a1,
+    ).execute()
+    values = resp.get("values", [])
+    truncated = False
+    cells = sum(len(row) for row in values)
+    if cells > _MAX_READ_CELLS:
+        kept: list[list] = []
+        running = 0
+        for row in values:
+            running += len(row)
+            if running > _MAX_READ_CELLS:
+                break
+            kept.append(row)
+        values = kept
+        truncated = True
+    return {
+        "spreadsheet_id": spreadsheet_id,
+        "range": resp.get("range", range_a1),
+        "values": values,
+        "row_count": len(values),
+        "truncated": truncated,
+        "web_link": _SHEET_URL.format(spreadsheet_id),
+    }
+
+
+def get_metadata_op(service, spreadsheet_id: str) -> dict:
+    """Read spreadsheet title and the list of its sheets/tabs with dimensions."""
+    meta = service.spreadsheets().get(
+        spreadsheetId=spreadsheet_id,
+        fields="properties.title,sheets.properties(sheetId,title,gridProperties)",
+    ).execute()
+    sheets = []
+    for s in meta.get("sheets", []):
+        p = s.get("properties", {})
+        grid = p.get("gridProperties", {})
+        sheets.append({
+            "sheet_id": p.get("sheetId"),
+            "title": p.get("title", ""),
+            "row_count": grid.get("rowCount"),
+            "column_count": grid.get("columnCount"),
+        })
+    return {
+        "spreadsheet_id": spreadsheet_id,
+        "title": meta.get("properties", {}).get("title", ""),
+        "sheets": sheets,
+        "web_link": _SHEET_URL.format(spreadsheet_id),
+    }
+
+
+# ── Write ────────────────────────────────────────────────────────────────────
+
+def update_values_op(service, spreadsheet_id: str, range_a1: str, values: list[list]) -> dict:
+    """Overwrite the given A1 range with a 2D array of values (USER_ENTERED)."""
+    resp = service.spreadsheets().values().update(
+        spreadsheetId=spreadsheet_id,
+        range=range_a1,
+        valueInputOption="USER_ENTERED",
+        body={"values": values},
+    ).execute()
+    return {
+        "ok": True, "spreadsheet_id": spreadsheet_id,
+        "updated_range": resp.get("updatedRange", range_a1),
+        "updated_cells": resp.get("updatedCells", 0),
+        "web_link": _SHEET_URL.format(spreadsheet_id),
+    }
+
+
+def append_rows_op(service, spreadsheet_id: str, range_a1: str, values: list[list]) -> dict:
+    """Append rows after the last row of data in the given range (INSERT_ROWS)."""
+    resp = service.spreadsheets().values().append(
+        spreadsheetId=spreadsheet_id,
+        range=range_a1,
+        valueInputOption="USER_ENTERED",
+        insertDataOption="INSERT_ROWS",
+        body={"values": values},
+    ).execute()
+    updates = resp.get("updates", {})
+    return {
+        "ok": True, "spreadsheet_id": spreadsheet_id,
+        "updated_range": updates.get("updatedRange", ""),
+        "updated_rows": updates.get("updatedRows", 0),
+        "web_link": _SHEET_URL.format(spreadsheet_id),
+    }
+
+
+def clear_values_op(service, spreadsheet_id: str, range_a1: str) -> dict:
+    """Clear all values in the given A1 range (keeps formatting)."""
+    resp = service.spreadsheets().values().clear(
+        spreadsheetId=spreadsheet_id, range=range_a1, body={},
+    ).execute()
+    return {
+        "ok": True, "spreadsheet_id": spreadsheet_id,
+        "cleared_range": resp.get("clearedRange", range_a1),
+        "web_link": _SHEET_URL.format(spreadsheet_id),
+    }
+
+
+def create_spreadsheet_op(service, title: str) -> dict:
+    """Create a new spreadsheet."""
+    ss = service.spreadsheets().create(
+        body={"properties": {"title": title}},
+        fields="spreadsheetId,properties.title",
+    ).execute()
+    ss_id = ss.get("spreadsheetId", "")
+    return {
+        "ok": True, "spreadsheet_id": ss_id,
+        "title": ss.get("properties", {}).get("title", title),
+        "web_link": _SHEET_URL.format(ss_id),
+    }
+
+
+def add_sheet_op(service, spreadsheet_id: str, title: str) -> dict:
+    """Add a new sheet/tab to an existing spreadsheet."""
+    resp = service.spreadsheets().batchUpdate(
+        spreadsheetId=spreadsheet_id,
+        body={"requests": [{"addSheet": {"properties": {"title": title}}}]},
+    ).execute()
+    replies = resp.get("replies", [])
+    new_props = replies[0].get("addSheet", {}).get("properties", {}) if replies else {}
+    return {
+        "ok": True, "spreadsheet_id": spreadsheet_id,
+        "sheet_id": new_props.get("sheetId"),
+        "title": new_props.get("title", title),
+        "web_link": _SHEET_URL.format(spreadsheet_id),
+    }

--- a/backend/integrations/google/sheets_ops.py
+++ b/backend/integrations/google/sheets_ops.py
@@ -29,13 +29,15 @@ def get_values_op(service, spreadsheet_id: str, range_a1: str) -> dict:
     truncated = False
     cells = sum(len(row) for row in values)
     if cells > _MAX_READ_CELLS:
+        # Keep whole rows up to the cap, but always return at least the first
+        # row so a very wide first row doesn't yield "truncated but 0 rows".
         kept: list[list] = []
         running = 0
         for row in values:
-            running += len(row)
-            if running > _MAX_READ_CELLS:
+            if kept and running + len(row) > _MAX_READ_CELLS:
                 break
             kept.append(row)
+            running += len(row)
         values = kept
         truncated = True
     return {

--- a/backend/integrations/google/sheets_ops.py
+++ b/backend/integrations/google/sheets_ops.py
@@ -13,9 +13,15 @@ logger = logging.getLogger(__name__)
 
 _SHEET_URL = "https://docs.google.com/spreadsheets/d/{}/edit"
 
-# Soft cap on the number of cells returned by a single read so a huge range
-# can't blow up tool output / context. Rows past the cap are dropped.
+# Soft caps on a single read so a huge range — or a small range of very large
+# cell strings — can't blow up tool output / context. Whole rows past either
+# cap are dropped (at least the first row is always returned).
 _MAX_READ_CELLS = 20000
+_MAX_READ_CHARS = 200_000
+
+
+def _row_chars(row: list) -> int:
+    return sum(len(str(c)) for c in row)
 
 
 # ── Read ─────────────────────────────────────────────────────────────────────
@@ -28,16 +34,19 @@ def get_values_op(service, spreadsheet_id: str, range_a1: str) -> dict:
     values = resp.get("values", [])
     truncated = False
     cells = sum(len(row) for row in values)
-    if cells > _MAX_READ_CELLS:
-        # Keep whole rows up to the cap, but always return at least the first
-        # row so a very wide first row doesn't yield "truncated but 0 rows".
+    chars = sum(_row_chars(row) for row in values)
+    if cells > _MAX_READ_CELLS or chars > _MAX_READ_CHARS:
+        # Keep whole rows up to both the cell and character caps, but always
+        # return at least the first row so we never yield "truncated but 0 rows".
         kept: list[list] = []
-        running = 0
+        run_cells = run_chars = 0
         for row in values:
-            if kept and running + len(row) > _MAX_READ_CELLS:
+            rc, rch = len(row), _row_chars(row)
+            if kept and (run_cells + rc > _MAX_READ_CELLS or run_chars + rch > _MAX_READ_CHARS):
                 break
             kept.append(row)
-            running += len(row)
+            run_cells += rc
+            run_chars += rch
         values = kept
         truncated = True
     return {

--- a/backend/integrations/google/slides_ops.py
+++ b/backend/integrations/google/slides_ops.py
@@ -24,15 +24,23 @@ def _new_id(prefix: str) -> str:
     return f"{prefix}_{secrets.token_hex(8)}"
 
 
+def _text_runs(text: dict) -> list[str]:
+    return [te["textRun"]["content"]
+            for te in text.get("textElements", [])
+            if te.get("textRun", {}).get("content")]
+
+
 def _extract_slide_text(page: dict) -> str:
-    """Flatten all text runs on a single slide/page into plain text."""
+    """Flatten all text runs on a single slide/page into plain text.
+
+    Covers both shape text and table cells (the two common text containers).
+    """
     parts: list[str] = []
     for el in page.get("pageElements", []):
-        text = el.get("shape", {}).get("text", {})
-        for te in text.get("textElements", []):
-            run = te.get("textRun", {})
-            if run.get("content"):
-                parts.append(run["content"])
+        parts.extend(_text_runs(el.get("shape", {}).get("text", {})))
+        for row in el.get("table", {}).get("tableRows", []):
+            for cell in row.get("tableCells", []):
+                parts.extend(_text_runs(cell.get("text", {})))
     return "".join(parts)
 
 

--- a/backend/integrations/google/slides_ops.py
+++ b/backend/integrations/google/slides_ops.py
@@ -1,0 +1,157 @@
+"""Google Slides operations — each function takes an authenticated Slides v1 service.
+
+Curated CRUD: get (read), create, add_slide, insert_text, replace_all_text (write).
+Deleting a presentation is delete_drive_file. No public reference implementation
+existed; built fresh from the Slides batchUpdate API.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+
+logger = logging.getLogger(__name__)
+
+_SLIDES_URL = "https://docs.google.com/presentation/d/{}/edit"
+
+# Default text-box geometry (EMU). A standard slide is 9144000 x 6858000 EMU.
+_BOX_W, _BOX_H = 6858000, 1200000
+_BOX_X, _BOX_Y = 1143000, 1000000
+
+
+def _new_id(prefix: str) -> str:
+    """Generate a unique objectId (5-50 chars, [a-zA-Z0-9_-])."""
+    return f"{prefix}_{secrets.token_hex(8)}"
+
+
+def _extract_slide_text(page: dict) -> str:
+    """Flatten all text runs on a single slide/page into plain text."""
+    parts: list[str] = []
+    for el in page.get("pageElements", []):
+        text = el.get("shape", {}).get("text", {})
+        for te in text.get("textElements", []):
+            run = te.get("textRun", {})
+            if run.get("content"):
+                parts.append(run["content"])
+    return "".join(parts)
+
+
+# ── Read ─────────────────────────────────────────────────────────────────────
+
+def get_presentation_op(service, presentation_id: str, max_chars: int = 50000) -> dict:
+    """Read a presentation's title and per-slide plain text."""
+    pres = service.presentations().get(presentationId=presentation_id).execute()
+    slides = []
+    total = 0
+    truncated = False
+    for page in pres.get("slides", []):
+        text = _extract_slide_text(page)
+        if total + len(text) > max_chars:
+            text = text[: max(max_chars - total, 0)]
+            truncated = True
+        total += len(text)
+        slides.append({"slide_object_id": page.get("objectId", ""), "text": text})
+        if truncated:
+            break
+    return {
+        "presentation_id": pres.get("presentationId", presentation_id),
+        "title": pres.get("title", ""),
+        "slide_count": len(pres.get("slides", [])),
+        "slides": slides,
+        "truncated": truncated,
+        "web_link": _SLIDES_URL.format(presentation_id),
+    }
+
+
+# ── Write ────────────────────────────────────────────────────────────────────
+
+def create_presentation_op(service, title: str) -> dict:
+    """Create a new presentation (starts with one default slide)."""
+    pres = service.presentations().create(body={"title": title}).execute()
+    pres_id = pres.get("presentationId", "")
+    first_slide = ""
+    if pres.get("slides"):
+        first_slide = pres["slides"][0].get("objectId", "")
+    return {
+        "ok": True, "presentation_id": pres_id,
+        "title": pres.get("title", title),
+        "first_slide_object_id": first_slide,
+        "web_link": _SLIDES_URL.format(pres_id),
+    }
+
+
+def add_slide_op(service, presentation_id: str, layout: str = "BLANK") -> dict:
+    """Add a new slide using a predefined layout (e.g. BLANK, TITLE, TITLE_AND_BODY)."""
+    slide_id = _new_id("slide")
+    service.presentations().batchUpdate(
+        presentationId=presentation_id,
+        body={"requests": [{
+            "createSlide": {
+                "objectId": slide_id,
+                "slideLayoutReference": {"predefinedLayout": layout},
+            }
+        }]},
+    ).execute()
+    return {
+        "ok": True, "presentation_id": presentation_id,
+        "slide_object_id": slide_id, "layout": layout,
+        "web_link": _SLIDES_URL.format(presentation_id),
+    }
+
+
+def insert_text_op(service, presentation_id: str, slide_object_id: str, text: str) -> dict:
+    """Create a text box on the given slide and insert text into it."""
+    box_id = _new_id("txt")
+    requests = [
+        {
+            "createShape": {
+                "objectId": box_id,
+                "shapeType": "TEXT_BOX",
+                "elementProperties": {
+                    "pageObjectId": slide_object_id,
+                    "size": {
+                        "width": {"magnitude": _BOX_W, "unit": "EMU"},
+                        "height": {"magnitude": _BOX_H, "unit": "EMU"},
+                    },
+                    "transform": {
+                        "scaleX": 1, "scaleY": 1,
+                        "translateX": _BOX_X, "translateY": _BOX_Y, "unit": "EMU",
+                    },
+                },
+            }
+        },
+        {"insertText": {"objectId": box_id, "text": text, "insertionIndex": 0}},
+    ]
+    service.presentations().batchUpdate(
+        presentationId=presentation_id, body={"requests": requests},
+    ).execute()
+    return {
+        "ok": True, "presentation_id": presentation_id,
+        "slide_object_id": slide_object_id, "text_box_object_id": box_id,
+        "characters": len(text),
+        "web_link": _SLIDES_URL.format(presentation_id),
+    }
+
+
+def replace_all_text_op(
+    service, presentation_id: str, find: str, replace: str, match_case: bool = False,
+) -> dict:
+    """Replace all occurrences of `find` with `replace` across the presentation."""
+    resp = service.presentations().batchUpdate(
+        presentationId=presentation_id,
+        body={"requests": [{
+            "replaceAllText": {
+                "containsText": {"text": find, "matchCase": match_case},
+                "replaceText": replace,
+            }
+        }]},
+    ).execute()
+    replies = resp.get("replies", [])
+    changed = 0
+    if replies:
+        changed = replies[0].get("replaceAllText", {}).get("occurrencesChanged", 0) or 0
+    return {
+        "ok": True, "presentation_id": presentation_id,
+        "occurrences_changed": changed,
+        "web_link": _SLIDES_URL.format(presentation_id),
+    }

--- a/backend/integrations/google/slides_ops.py
+++ b/backend/integrations/google/slides_ops.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 
 _SLIDES_URL = "https://docs.google.com/presentation/d/{}/edit"
 
+# Hard ceiling on returned characters (see docs_ops._MAX_READ_CHARS).
+_MAX_READ_CHARS = 200_000
+
 # Default text-box geometry (EMU). A standard slide is 9144000 x 6858000 EMU.
 _BOX_W, _BOX_H = 6858000, 1200000
 _BOX_X, _BOX_Y = 1143000, 1000000
@@ -48,14 +51,18 @@ def _extract_slide_text(page: dict) -> str:
 
 def get_presentation_op(service, presentation_id: str, max_chars: int = 50000) -> dict:
     """Read a presentation's title and per-slide plain text."""
+    max_chars = max(1, min(max_chars, _MAX_READ_CHARS))
     pres = service.presentations().get(presentationId=presentation_id).execute()
     slides = []
     total = 0
     truncated = False
     for page in pres.get("slides", []):
+        if total >= max_chars:
+            truncated = True
+            break
         text = _extract_slide_text(page)
         if total + len(text) > max_chars:
-            text = text[: max(max_chars - total, 0)]
+            text = text[: max_chars - total]
             truncated = True
         total += len(text)
         slides.append({"slide_object_id": page.get("objectId", ""), "text": text})

--- a/backend/integrations/google/tools.py
+++ b/backend/integrations/google/tools.py
@@ -16,10 +16,13 @@ from .client import (
     GoogleAuthError,
     call_with_refresh,
     get_calendar_service,
+    get_docs_service,
     get_drive_service,
     get_gmail_service,
+    get_sheets_service,
+    get_slides_service,
 )
-from . import gmail_ops, calendar_ops, drive_ops
+from . import gmail_ops, calendar_ops, drive_ops, docs_ops, sheets_ops, slides_ops
 
 logger = logging.getLogger(__name__)
 
@@ -468,3 +471,97 @@ def rename_drive_file(account_id: str, file_id: str, new_name: str) -> dict:
 def copy_drive_file(account_id: str, file_id: str, new_name: str | None = None, folder_id: str | None = None) -> dict:
     return _wrap(account_id, get_drive_service, drive_ops.copy_file_op,
                  file_id=file_id, new_name=new_name, folder_id=folder_id)
+
+
+def delete_drive_file(account_id: str, file_id: str, permanent: bool = False) -> dict:
+    return _wrap(account_id, get_drive_service, drive_ops.delete_file_op,
+                 file_id=file_id, permanent=permanent)
+
+
+# ── Workspace: Docs ──────────────────────────────────────────────────────────
+
+def read_google_doc(account_id: str, document_id: str, max_chars: int = 50000) -> dict:
+    return _wrap(account_id, get_docs_service, docs_ops.get_document_op,
+                 document_id=document_id, max_chars=max_chars)
+
+
+def create_google_doc(account_id: str, title: str, content: str = "") -> dict:
+    return _wrap(account_id, get_docs_service, docs_ops.create_document_op,
+                 title=title, content=content)
+
+
+def insert_doc_text(account_id: str, document_id: str, text: str, index: int = 1) -> dict:
+    return _wrap(account_id, get_docs_service, docs_ops.insert_text_op,
+                 document_id=document_id, text=text, index=index)
+
+
+def append_doc_text(account_id: str, document_id: str, text: str) -> dict:
+    return _wrap(account_id, get_docs_service, docs_ops.append_text_op,
+                 document_id=document_id, text=text)
+
+
+def replace_doc_text(account_id: str, document_id: str, find: str, replace: str, match_case: bool = False) -> dict:
+    return _wrap(account_id, get_docs_service, docs_ops.replace_text_op,
+                 document_id=document_id, find=find, replace=replace, match_case=match_case)
+
+
+# ── Workspace: Sheets ────────────────────────────────────────────────────────
+
+def read_sheet_range(account_id: str, spreadsheet_id: str, range: str) -> dict:
+    return _wrap(account_id, get_sheets_service, sheets_ops.get_values_op,
+                 spreadsheet_id=spreadsheet_id, range_a1=range)
+
+
+def read_sheet_metadata(account_id: str, spreadsheet_id: str) -> dict:
+    return _wrap(account_id, get_sheets_service, sheets_ops.get_metadata_op,
+                 spreadsheet_id=spreadsheet_id)
+
+
+def write_sheet_range(account_id: str, spreadsheet_id: str, range: str, values: list[list]) -> dict:
+    return _wrap(account_id, get_sheets_service, sheets_ops.update_values_op,
+                 spreadsheet_id=spreadsheet_id, range_a1=range, values=values)
+
+
+def append_sheet_rows(account_id: str, spreadsheet_id: str, range: str, values: list[list]) -> dict:
+    return _wrap(account_id, get_sheets_service, sheets_ops.append_rows_op,
+                 spreadsheet_id=spreadsheet_id, range_a1=range, values=values)
+
+
+def clear_sheet_range(account_id: str, spreadsheet_id: str, range: str) -> dict:
+    return _wrap(account_id, get_sheets_service, sheets_ops.clear_values_op,
+                 spreadsheet_id=spreadsheet_id, range_a1=range)
+
+
+def create_spreadsheet(account_id: str, title: str) -> dict:
+    return _wrap(account_id, get_sheets_service, sheets_ops.create_spreadsheet_op, title=title)
+
+
+def add_sheet_tab(account_id: str, spreadsheet_id: str, title: str) -> dict:
+    return _wrap(account_id, get_sheets_service, sheets_ops.add_sheet_op,
+                 spreadsheet_id=spreadsheet_id, title=title)
+
+
+# ── Workspace: Slides ────────────────────────────────────────────────────────
+
+def read_presentation(account_id: str, presentation_id: str, max_chars: int = 50000) -> dict:
+    return _wrap(account_id, get_slides_service, slides_ops.get_presentation_op,
+                 presentation_id=presentation_id, max_chars=max_chars)
+
+
+def create_presentation(account_id: str, title: str) -> dict:
+    return _wrap(account_id, get_slides_service, slides_ops.create_presentation_op, title=title)
+
+
+def add_slide(account_id: str, presentation_id: str, layout: str = "BLANK") -> dict:
+    return _wrap(account_id, get_slides_service, slides_ops.add_slide_op,
+                 presentation_id=presentation_id, layout=layout)
+
+
+def insert_slide_text(account_id: str, presentation_id: str, slide_object_id: str, text: str) -> dict:
+    return _wrap(account_id, get_slides_service, slides_ops.insert_text_op,
+                 presentation_id=presentation_id, slide_object_id=slide_object_id, text=text)
+
+
+def replace_presentation_text(account_id: str, presentation_id: str, find: str, replace: str, match_case: bool = False) -> dict:
+    return _wrap(account_id, get_slides_service, slides_ops.replace_all_text_op,
+                 presentation_id=presentation_id, find=find, replace=replace, match_case=match_case)

--- a/backend/integrations/paperclip/webhook.py
+++ b/backend/integrations/paperclip/webhook.py
@@ -170,7 +170,8 @@ async def handle_heartbeat(request: Request):
         gmail_ids = ga.get("gmail", [])
         calendar_ids = ga.get("calendar", [])
         drive_ids = ga.get("drive", [])
-        google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+        workspace_ids = ga.get("workspace", [])
+        google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
 
         from integrations.registry import list_google_accounts as _list_ga
         all_ga = _list_ga()
@@ -201,6 +202,7 @@ async def handle_heartbeat(request: Request):
             gmail_account_ids=gmail_ids,
             calendar_account_ids=calendar_ids,
             drive_account_ids=drive_ids,
+            workspace_account_ids=workspace_ids,
             account_info_map=account_info_map,
         )
 

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -278,13 +278,11 @@ def migrate_google_json() -> None:
 
     try:
         from agents.db import list_agents, update_agent
+        from integrations.google.policy import GOOGLE_SERVICES
         ga: dict[str, list[str]] = {}
-        if scope_grants.get("gmail", "none") != "none":
-            ga["gmail"] = [account_id]
-        if scope_grants.get("calendar", "none") != "none":
-            ga["calendar"] = [account_id]
-        if scope_grants.get("drive", "none") != "none":
-            ga["drive"] = [account_id]
+        for svc in GOOGLE_SERVICES:
+            if scope_grants.get(svc, "none") != "none":
+                ga[svc] = [account_id]
 
         if ga:
             import json as _json
@@ -305,6 +303,7 @@ def migrate_agent_google_accounts_to_arrays() -> None:
     except Exception:
         return
     try:
+        from integrations.google.policy import GOOGLE_SERVICES
         db = _get_db()
         rows = db.execute("SELECT id, google_accounts FROM agents").fetchall()
         for row in rows:
@@ -314,7 +313,7 @@ def migrate_agent_google_accounts_to_arrays() -> None:
             except (ValueError, TypeError):
                 continue
             changed = False
-            for svc in ("gmail", "calendar", "drive"):
+            for svc in GOOGLE_SERVICES:
                 val = parsed.get(svc)
                 if isinstance(val, str):
                     parsed[svc] = [val] if val else []

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -238,6 +238,7 @@ class GoogleSetupRequest(BaseModel):
     gmail_level: Literal["none", "read", "send"] = "none"
     calendar_level: Literal["none", "read", "full"] = "none"
     drive_level: Literal["none", "file", "readonly", "full"] = "none"
+    workspace_level: Literal["none", "read", "edit"] = "none"
 
 
 @router.post("/google/setup")
@@ -252,14 +253,15 @@ async def setup_google(body: GoogleSetupRequest, user=Depends(get_current_user))
     from core.config import build_google_scopes
 
     # Reject "all none" — user must grant at least one capability
-    if body.gmail_level == "none" and body.calendar_level == "none" and body.drive_level == "none":
+    if (body.gmail_level == "none" and body.calendar_level == "none"
+            and body.drive_level == "none" and body.workspace_level == "none"):
         raise HTTPException(
             status_code=400,
-            detail="At least one of Gmail, Calendar, or Drive must be enabled",
+            detail="At least one of Gmail, Calendar, Drive, or Workspace must be enabled",
         )
 
     # Include Gemini AI scope if Google is already the active AI provider, so
-    # we don't break Gemini when the user connects Gmail/Calendar/Drive.
+    # we don't break Gemini when the user connects Gmail/Calendar/Drive/Workspace.
     from core.providers.credentials import CredentialStore
     store = CredentialStore()
     include_ai = store.data.get("active_provider") == "google"
@@ -268,6 +270,7 @@ async def setup_google(body: GoogleSetupRequest, user=Depends(get_current_user))
         gmail_level=body.gmail_level,
         calendar_level=body.calendar_level,
         drive_level=body.drive_level,
+        workspace_level=body.workspace_level,
         include_ai=include_ai,
     )
 
@@ -279,6 +282,7 @@ async def setup_google(body: GoogleSetupRequest, user=Depends(get_current_user))
                 "gmail_level": body.gmail_level,
                 "calendar_level": body.calendar_level,
                 "drive_level": body.drive_level,
+                "workspace_level": body.workspace_level,
                 "include_ai": include_ai,
             },
             prompt="consent select_account",
@@ -309,6 +313,7 @@ def _google_complete_common(flow, require_refresh_token: bool = True):
         "gmail": meta.get("gmail_level", "none"),
         "calendar": meta.get("calendar_level", "none"),
         "drive": meta.get("drive_level", "none"),
+        "workspace": meta.get("workspace_level", "none"),
     }
 
     return tokens, scope_grants
@@ -378,7 +383,8 @@ async def setup_google_account(account_id: str, body: GoogleSetupRequest, user=D
     if not existing:
         raise HTTPException(status_code=404, detail="Google account not found")
 
-    if body.gmail_level == "none" and body.calendar_level == "none" and body.drive_level == "none":
+    if (body.gmail_level == "none" and body.calendar_level == "none"
+            and body.drive_level == "none" and body.workspace_level == "none"):
         raise HTTPException(status_code=400, detail="At least one scope must be enabled")
 
     from core.providers.credentials import CredentialStore
@@ -389,6 +395,7 @@ async def setup_google_account(account_id: str, body: GoogleSetupRequest, user=D
         gmail_level=body.gmail_level,
         calendar_level=body.calendar_level,
         drive_level=body.drive_level,
+        workspace_level=body.workspace_level,
         include_ai=include_ai,
     )
 
@@ -400,6 +407,7 @@ async def setup_google_account(account_id: str, body: GoogleSetupRequest, user=D
                 "gmail_level": body.gmail_level,
                 "calendar_level": body.calendar_level,
                 "drive_level": body.drive_level,
+                "workspace_level": body.workspace_level,
                 "include_ai": include_ai,
                 "account_id": account_id,
             },

--- a/backend/integrations/telegram/service.py
+++ b/backend/integrations/telegram/service.py
@@ -174,7 +174,8 @@ async def process_message(
     gmail_ids = ga.get("gmail", [])
     calendar_ids = ga.get("calendar", [])
     drive_ids = ga.get("drive", [])
-    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+    workspace_ids = ga.get("workspace", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
 
     from integrations.registry import list_google_accounts as _list_ga
     all_ga = _list_ga()
@@ -203,6 +204,7 @@ async def process_message(
         gmail_account_ids=gmail_ids,
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
+        workspace_account_ids=workspace_ids,
         account_info_map=account_info_map,
     )
 
@@ -277,7 +279,8 @@ async def process_group_message(
     gmail_ids = ga.get("gmail", [])
     calendar_ids = ga.get("calendar", [])
     drive_ids = ga.get("drive", [])
-    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+    workspace_ids = ga.get("workspace", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
 
     from integrations.registry import list_google_accounts as _list_ga
     all_ga = _list_ga()
@@ -306,6 +309,7 @@ async def process_group_message(
         gmail_account_ids=gmail_ids,
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
+        workspace_account_ids=workspace_ids,
         account_info_map=account_info_map,
     )
 

--- a/backend/integrations/whatsapp/service.py
+++ b/backend/integrations/whatsapp/service.py
@@ -179,11 +179,17 @@ def _process_message_locked(
             system_prompt += "\n\n# Recent Conversation Context\n\n" + "\n".join(context_lines)
 
     # 8. Build tool registry
+    from integrations.google.policy import google_tool_flags
     ga = config.google_accounts
     gmail_ids = ga.get("gmail", [])
     calendar_ids = ga.get("calendar", [])
     drive_ids = ga.get("drive", [])
-    google_connected = bool(gmail_ids or calendar_ids or drive_ids)
+    workspace_ids = ga.get("workspace", [])
+    google_connected = bool(gmail_ids or calendar_ids or drive_ids or workspace_ids)
+    google_flags = google_tool_flags({
+        "gmail": gmail_ids, "calendar": calendar_ids,
+        "drive": drive_ids, "workspace": workspace_ids,
+    })
 
     from integrations.registry import list_google_accounts as _list_ga
     all_ga = _list_ga()
@@ -223,27 +229,16 @@ def _process_message_locked(
         gmail_account_ids=gmail_ids,
         calendar_account_ids=calendar_ids,
         drive_account_ids=drive_ids,
+        workspace_account_ids=workspace_ids,
         account_info_map=account_info_map,
     )
 
     # 9. Build tool definitions
     dynamic_real_tools = load_all_real_tools(agent_slug)
-    from integrations.google.policy import google_capabilities_union
-    gmail_caps = google_capabilities_union(gmail_ids)
-    cal_caps = google_capabilities_union(calendar_ids)
-    drive_caps = google_capabilities_union(drive_ids)
     tool_defs = get_tool_definitions(
         integration_tools=integration_tool_defs or None,
         dynamic_real_tools=dynamic_real_tools or None,
-        gmail_read_enabled=gmail_caps["gmail_read_enabled"],
-        gmail_send_enabled=gmail_caps["gmail_send_enabled"],
-        calendar_read_enabled=cal_caps["calendar_read_enabled"],
-        calendar_write_enabled=cal_caps["calendar_write_enabled"],
-        drive_read_enabled=drive_caps["drive_read_enabled"],
-        drive_write_enabled=drive_caps["drive_write_enabled"],
-        multi_gmail=len(gmail_ids) > 1,
-        multi_calendar=len(calendar_ids) > 1,
-        multi_drive=len(drive_ids) > 1,
+        **google_flags,
     )
 
     # Apply integration permission ceilings — messaging channels have no approval UI,

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -128,6 +128,7 @@ def _no_caps(ids):
         "gmail_read_enabled": False, "gmail_send_enabled": False,
         "calendar_read_enabled": False, "calendar_write_enabled": False,
         "drive_read_enabled": False, "drive_write_enabled": False,
+        "workspace_read_enabled": False, "workspace_write_enabled": False,
     }
 
 

--- a/backend/tests/test_google_accounts_context.py
+++ b/backend/tests/test_google_accounts_context.py
@@ -3,11 +3,11 @@
 from core.agents.ai_service import _google_accounts_context
 
 
-def _make_info(email, *, status="ok", gmail="send", calendar="full", drive="full"):
+def _make_info(email, *, status="ok", gmail="send", calendar="full", drive="full", workspace="none"):
     return {
         "email": email,
         "connection_status": status,
-        "scope_grants": {"gmail": gmail, "calendar": calendar, "drive": drive},
+        "scope_grants": {"gmail": gmail, "calendar": calendar, "drive": drive, "workspace": workspace},
     }
 
 
@@ -62,3 +62,27 @@ class TestUnassignedAccounts:
     def test_empty_account_info_map(self):
         result = _google_accounts_context({}, {})
         assert result == ""
+
+
+class TestWorkspaceService:
+    def test_workspace_grant_unassigned_is_surfaced(self):
+        info_map = {"a1": _make_info("alice@example.com", workspace="edit")}
+        ga = {"gmail": ["a1"], "calendar": ["a1"], "drive": ["a1"]}
+        result = _google_accounts_context(info_map, ga)
+        assert "Workspace not assigned" in result
+
+    def test_workspace_fully_assigned_not_listed(self):
+        info_map = {"a1": _make_info("alice@example.com", workspace="edit")}
+        ga = {"gmail": ["a1"], "calendar": ["a1"], "drive": ["a1"], "workspace": ["a1"]}
+        result = _google_accounts_context(info_map, ga)
+        assert "Not Assigned" not in result
+
+    def test_multi_workspace_section_uses_account_param_copy(self):
+        info_map = {
+            "a1": _make_info("w1@example.com", gmail="none", calendar="none", drive="none", workspace="edit"),
+            "a2": _make_info("w2@example.com", gmail="none", calendar="none", drive="none", workspace="edit"),
+        }
+        ga = {"workspace": ["a1", "a2"]}
+        result = _google_accounts_context(info_map, ga)
+        assert "Workspace" in result
+        assert "w1@example.com" in result and "w2@example.com" in result

--- a/backend/tests/test_google_scopes.py
+++ b/backend/tests/test_google_scopes.py
@@ -100,3 +100,23 @@ class TestGoogleCapabilitiesWorkspace:
         assert flags["multi_workspace"] is True
         assert flags["multi_gmail"] is False
         assert flags["gmail_read_enabled"] is False
+
+    def test_shared_account_flags_scoped_per_service(self, monkeypatch):
+        from integrations.google import policy
+        import integrations.registry as registry
+
+        # One account granted BOTH gmail-send and workspace-edit.
+        accounts = {"shared": {"connection_status": "ok",
+                               "scope_grants": {"gmail": "send", "workspace": "edit"}}}
+        monkeypatch.setattr(registry, "get_google_account", lambda aid: accounts.get(aid))
+
+        # Assigned to gmail only: its workspace grant must NOT leak into workspace flags.
+        gmail_only = policy.google_tool_flags({"gmail": ["shared"]})
+        assert gmail_only["gmail_send_enabled"] is True
+        assert gmail_only["workspace_read_enabled"] is False
+        assert gmail_only["workspace_write_enabled"] is False
+
+        # Assigned to both services: each service's own flags turn on.
+        both = policy.google_tool_flags({"gmail": ["shared"], "workspace": ["shared"]})
+        assert both["gmail_send_enabled"] is True
+        assert both["workspace_write_enabled"] is True

--- a/backend/tests/test_google_scopes.py
+++ b/backend/tests/test_google_scopes.py
@@ -1,6 +1,6 @@
 """Tests for build_google_scopes and GMAIL_SCOPE_LEVELS in core.config."""
 
-from core.config import build_google_scopes, GMAIL_SCOPE_LEVELS
+from core.config import build_google_scopes, GMAIL_SCOPE_LEVELS, WORKSPACE_SCOPE_LEVELS
 
 
 class TestGmailScopeLevels:
@@ -44,3 +44,59 @@ class TestBuildGoogleScopes:
         scopes = build_google_scopes(gmail_level="bogus")
         assert "openid" in scopes
         assert len(scopes) == 3
+
+    def test_workspace_edit_includes_full_scopes(self):
+        scopes = build_google_scopes(workspace_level="edit")
+        assert "https://www.googleapis.com/auth/documents" in scopes
+        assert "https://www.googleapis.com/auth/spreadsheets" in scopes
+        assert "https://www.googleapis.com/auth/presentations" in scopes
+
+    def test_workspace_read_uses_readonly_variants(self):
+        scopes = build_google_scopes(workspace_level="read")
+        assert "https://www.googleapis.com/auth/documents.readonly" in scopes
+        assert "https://www.googleapis.com/auth/spreadsheets.readonly" in scopes
+        assert "https://www.googleapis.com/auth/presentations.readonly" in scopes
+        assert "https://www.googleapis.com/auth/documents" not in scopes
+
+    def test_workspace_none_adds_nothing(self):
+        scopes = build_google_scopes(workspace_level="none")
+        assert len(scopes) == 3
+
+
+class TestWorkspaceScopeLevels:
+    def test_edit_is_full_not_readonly(self):
+        assert "https://www.googleapis.com/auth/documents" in WORKSPACE_SCOPE_LEVELS["edit"]
+        assert "https://www.googleapis.com/auth/documents.readonly" not in WORKSPACE_SCOPE_LEVELS["edit"]
+
+    def test_none_is_empty(self):
+        assert WORKSPACE_SCOPE_LEVELS["none"] == []
+
+
+class TestGoogleCapabilitiesWorkspace:
+    def test_capabilities_and_tool_flags(self, monkeypatch):
+        from integrations.google import policy
+        import integrations.registry as registry
+
+        accounts = {
+            "w_edit": {"connection_status": "ok", "scope_grants": {"workspace": "edit"}},
+            "w_read": {"connection_status": "ok", "scope_grants": {"workspace": "read"}},
+        }
+        # policy.google_capabilities imports get_google_account from integrations.registry
+        # lazily, so patch it on the registry module.
+        monkeypatch.setattr(registry, "get_google_account", lambda aid: accounts.get(aid))
+
+        edit = policy.google_capabilities("w_edit")
+        assert edit["workspace_read_enabled"] is True
+        assert edit["workspace_write_enabled"] is True
+
+        read = policy.google_capabilities("w_read")
+        assert read["workspace_read_enabled"] is True
+        assert read["workspace_write_enabled"] is False
+
+        # google_tool_flags scopes flags to the right service and emits multi_*
+        flags = policy.google_tool_flags({"workspace": ["w_edit", "w_read"]})
+        assert flags["workspace_read_enabled"] is True
+        assert flags["workspace_write_enabled"] is True
+        assert flags["multi_workspace"] is True
+        assert flags["multi_gmail"] is False
+        assert flags["gmail_read_enabled"] is False

--- a/backend/tests/test_persistence_chronology.py
+++ b/backend/tests/test_persistence_chronology.py
@@ -88,6 +88,7 @@ def _no_caps(ids):
         "gmail_read_enabled": False, "gmail_send_enabled": False,
         "calendar_read_enabled": False, "calendar_write_enabled": False,
         "drive_read_enabled": False, "drive_write_enabled": False,
+        "workspace_read_enabled": False, "workspace_write_enabled": False,
     }
 
 

--- a/backend/tests/test_tool_definitions.py
+++ b/backend/tests/test_tool_definitions.py
@@ -59,6 +59,26 @@ class TestGoogleFlagGating:
         assert "search_emails" in names
         assert "send_email" not in names
 
+    def test_workspace_read_write_gating(self):
+        read_names = _tool_names(get_tool_definitions(workspace_read_enabled=True))
+        assert "read_google_doc" in read_names
+        assert "read_sheet_range" in read_names
+        assert "read_presentation" in read_names
+        assert "create_google_doc" not in read_names
+
+        write_names = _tool_names(get_tool_definitions(workspace_write_enabled=True))
+        assert {"create_google_doc", "replace_doc_text", "write_sheet_range",
+                "add_sheet_tab", "create_presentation", "add_slide"} <= write_names
+
+    def test_workspace_disabled_by_default(self):
+        names = _tool_names(get_tool_definitions())
+        assert "read_google_doc" not in names
+        assert "create_presentation" not in names
+
+    def test_delete_drive_file_gated_on_drive_write(self):
+        assert "delete_drive_file" not in _tool_names(get_tool_definitions(drive_read_enabled=True))
+        assert "delete_drive_file" in _tool_names(get_tool_definitions(drive_write_enabled=True))
+
 
 class TestPlaybookTools:
     def test_playbook_tools_present(self):
@@ -121,6 +141,19 @@ class TestMultiAccountInjection:
         for tool in gmail_tools:
             props = tool["input_schema"]["properties"]
             assert "account" not in props
+
+    def test_multi_workspace_injects_account_param(self):
+        defs = get_tool_definitions(workspace_write_enabled=True, multi_workspace=True)
+        ws_tools = [t for t in defs if t.get("kind") == "workspace"]
+        assert ws_tools
+        for tool in ws_tools:
+            assert "account" in tool["input_schema"]["properties"], f"{tool['name']} missing account param"
+
+    def test_single_workspace_no_injection(self):
+        defs = get_tool_definitions(workspace_write_enabled=True, multi_workspace=False)
+        ws_tools = [t for t in defs if t.get("kind") == "workspace"]
+        for tool in ws_tools:
+            assert "account" not in tool["input_schema"]["properties"]
 
 
 class TestToolMerging:

--- a/backend/tests/test_tool_definitions.py
+++ b/backend/tests/test_tool_definitions.py
@@ -155,6 +155,14 @@ class TestMultiAccountInjection:
         for tool in ws_tools:
             assert "account" not in tool["input_schema"]["properties"]
 
+    def test_multi_workspace_injects_into_read_tools(self):
+        # injection is keyed on kind, so read tools must get the account param too
+        defs = get_tool_definitions(workspace_read_enabled=True, multi_workspace=True)
+        read_tools = [t for t in defs if t.get("kind") == "workspace" and not t.get("writes")]
+        assert read_tools
+        for tool in read_tools:
+            assert "account" in tool["input_schema"]["properties"], f"{tool['name']} missing account param"
+
 
 class TestToolMerging:
     def test_integration_tools_appended(self):

--- a/backend/tests/test_tool_registry.py
+++ b/backend/tests/test_tool_registry.py
@@ -58,6 +58,12 @@ class TestWorkspaceResolution:
         res = _run(reg.execute_tool("bogus_ws_tool", {}, "workspace"))
         assert res == {"error": "Unknown workspace tool: bogus_ws_tool"}
 
+    def test_email_path_blocks_write_on_read_account(self, tmp_path):
+        # The explicit-email branch of _resolve_account must also enforce write scope
+        reg = _ws_registry(str(tmp_path), workspace_level="read")
+        res = reg._resolve_account("workspace", "w@x.com", "create_google_doc")
+        assert isinstance(res, dict) and "error" in res
+
 
 class TestDriveDeleteGating:
     def test_delete_needs_full_drive(self, tmp_path):
@@ -70,9 +76,15 @@ class TestDriveDeleteGating:
         assert reg._resolve_account("drive", None, "delete_drive_file") == "d1"
 
     def test_delete_allowed_with_file_scope(self, tmp_path):
-        # drive.file can delete app-created files, so the gate must allow it
+        # drive.file can trash app-created files, so the gate must allow it
         reg = _ws_registry(str(tmp_path), drive_level="file")
         assert reg._resolve_account("drive", None, "delete_drive_file") == "d1"
+
+    def test_permanent_delete_requires_full_drive(self, tmp_path):
+        # file scope may trash but NOT permanently delete (irreversible)
+        reg = _ws_registry(str(tmp_path), drive_level="file")
+        res = _run(reg.execute_tool("delete_drive_file", {"file_id": "F", "permanent": True}, "drive"))
+        assert isinstance(res, dict) and "Full access" in res.get("error", "")
 
 
 # ── Context tools: real filesystem ──────────────────────────────────────────

--- a/backend/tests/test_tool_registry.py
+++ b/backend/tests/test_tool_registry.py
@@ -86,6 +86,24 @@ class TestDriveDeleteGating:
         res = _run(reg.execute_tool("delete_drive_file", {"file_id": "F", "permanent": True}, "drive"))
         assert isinstance(res, dict) and "Full access" in res.get("error", "")
 
+    def test_permanent_delete_prefers_full_account_among_many(self, tmp_path):
+        # First write-capable account is 'file'; a later one is 'full' — permanent
+        # must select the full account rather than failing on the default.
+        reg = ToolRegistry(
+            context_dir=str(tmp_path),
+            drive_account_ids=["d_file", "d_full"],
+            account_info_map={
+                "d_file": {"email": "f@x.com", "connection_status": "ok",
+                           "scope_grants": {"drive": "file"}},
+                "d_full": {"email": "u@x.com", "connection_status": "ok",
+                           "scope_grants": {"drive": "full"}},
+            },
+        )
+        # No real tokens, so the handler resolves to d_full then fails at the API
+        # layer (needs_reconnect) — NOT with the 'Full access' scope error.
+        res = _run(reg.execute_tool("delete_drive_file", {"file_id": "F", "permanent": True}, "drive"))
+        assert "Full access" not in res.get("error", "")
+
 
 # ── Context tools: real filesystem ──────────────────────────────────────────
 

--- a/backend/tests/test_tool_registry.py
+++ b/backend/tests/test_tool_registry.py
@@ -69,6 +69,11 @@ class TestDriveDeleteGating:
         reg = _ws_registry(str(tmp_path), drive_level="full")
         assert reg._resolve_account("drive", None, "delete_drive_file") == "d1"
 
+    def test_delete_allowed_with_file_scope(self, tmp_path):
+        # drive.file can delete app-created files, so the gate must allow it
+        reg = _ws_registry(str(tmp_path), drive_level="file")
+        assert reg._resolve_account("drive", None, "delete_drive_file") == "d1"
+
 
 # ── Context tools: real filesystem ──────────────────────────────────────────
 

--- a/backend/tests/test_tool_registry.py
+++ b/backend/tests/test_tool_registry.py
@@ -104,6 +104,13 @@ class TestDriveDeleteGating:
         res = _run(reg.execute_tool("delete_drive_file", {"file_id": "F", "permanent": True}, "drive"))
         assert "Full access" not in res.get("error", "")
 
+    def test_permanent_string_false_is_not_permanent(self, tmp_path):
+        # A non-True value (e.g. the string "false") must fall back to safe trash,
+        # so the permanent-scope gate is skipped even on a file-scoped account.
+        reg = _ws_registry(str(tmp_path), drive_level="file")
+        res = _run(reg.execute_tool("delete_drive_file", {"file_id": "F", "permanent": "false"}, "drive"))
+        assert "Full access" not in res.get("error", "")
+
 
 # ── Context tools: real filesystem ──────────────────────────────────────────
 

--- a/backend/tests/test_tool_registry.py
+++ b/backend/tests/test_tool_registry.py
@@ -16,6 +16,60 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+# ── Workspace + Drive-delete account resolution / dispatch ───────────────────
+
+
+def _ws_registry(ctx_dir, *, workspace_level="edit", drive_level="full"):
+    return ToolRegistry(
+        context_dir=ctx_dir,
+        workspace_account_ids=["w1"],
+        drive_account_ids=["d1"],
+        account_info_map={
+            "w1": {"email": "w@x.com", "connection_status": "ok",
+                   "scope_grants": {"workspace": workspace_level}},
+            "d1": {"email": "d@x.com", "connection_status": "ok",
+                   "scope_grants": {"drive": drive_level}},
+        },
+    )
+
+
+class TestWorkspaceResolution:
+    def test_edit_resolves_for_write_tool(self, tmp_path):
+        reg = _ws_registry(str(tmp_path))
+        assert reg._resolve_account("workspace", None, "create_google_doc") == "w1"
+
+    def test_read_level_blocks_write_tool(self, tmp_path):
+        reg = _ws_registry(str(tmp_path), workspace_level="read")
+        res = reg._resolve_account("workspace", None, "create_google_doc")
+        assert isinstance(res, dict) and "error" in res
+
+    def test_read_level_allows_read_tool(self, tmp_path):
+        reg = _ws_registry(str(tmp_path), workspace_level="read")
+        assert reg._resolve_account("workspace", None, "read_google_doc") == "w1"
+
+    def test_no_workspace_account_returns_error(self, tmp_path):
+        reg = ToolRegistry(context_dir=str(tmp_path))
+        res = reg._resolve_account("workspace", None, "read_google_doc")
+        assert isinstance(res, dict) and res.get("needs_reconnect")
+
+    def test_unknown_workspace_tool_routes_to_dispatcher(self, tmp_path):
+        # Routing reaches _execute_workspace (resolve succeeds, then unknown name)
+        reg = _ws_registry(str(tmp_path))
+        res = _run(reg.execute_tool("bogus_ws_tool", {}, "workspace"))
+        assert res == {"error": "Unknown workspace tool: bogus_ws_tool"}
+
+
+class TestDriveDeleteGating:
+    def test_delete_needs_full_drive(self, tmp_path):
+        reg = _ws_registry(str(tmp_path), drive_level="readonly")
+        res = reg._resolve_account("drive", None, "delete_drive_file")
+        assert isinstance(res, dict) and "error" in res
+
+    def test_delete_allowed_with_full_drive(self, tmp_path):
+        reg = _ws_registry(str(tmp_path), drive_level="full")
+        assert reg._resolve_account("drive", None, "delete_drive_file") == "d1"
+
+
 # ── Context tools: real filesystem ──────────────────────────────────────────
 
 

--- a/backend/tests/test_workspace_ops.py
+++ b/backend/tests/test_workspace_ops.py
@@ -1,0 +1,188 @@
+"""Tests for Workspace ops (Docs/Sheets/Slides) and Drive delete.
+
+Each op takes an authenticated googleapiclient service. We mock the service
+and assert the right API request is issued (the batchUpdate request shapes are
+the fiddly part) and that read output is truncated.
+"""
+
+from unittest.mock import MagicMock
+
+from integrations.google import docs_ops, sheets_ops, slides_ops, drive_ops
+
+
+# ── Docs ─────────────────────────────────────────────────────────────────────
+
+class TestDocsOps:
+    def test_get_document_extracts_text_and_truncates(self):
+        service = MagicMock()
+        service.documents.return_value.get.return_value.execute.return_value = {
+            "documentId": "DOC1", "title": "My Doc",
+            "body": {"content": [
+                {"paragraph": {"elements": [
+                    {"textRun": {"content": "Hello "}},
+                    {"textRun": {"content": "world"}},
+                ]}},
+            ]},
+        }
+        out = docs_ops.get_document_op(service, "DOC1", max_chars=8)
+        assert out["title"] == "My Doc"
+        assert out["content"] == "Hello wo"
+        assert out["truncated"] is True
+        assert out["char_count"] == 11
+        assert out["web_link"].endswith("/DOC1/edit")
+
+    def test_create_document_seeds_initial_content(self):
+        service = MagicMock()
+        service.documents.return_value.create.return_value.execute.return_value = {
+            "documentId": "NEW", "title": "T",
+        }
+        out = docs_ops.create_document_op(service, "T", content="seed")
+        _, kwargs = service.documents.return_value.batchUpdate.call_args
+        req = kwargs["body"]["requests"][0]["insertText"]
+        assert req["location"]["index"] == 1
+        assert req["text"] == "seed"
+        assert out["document_id"] == "NEW"
+
+    def test_create_document_no_content_skips_batch_update(self):
+        service = MagicMock()
+        service.documents.return_value.create.return_value.execute.return_value = {"documentId": "NEW", "title": "T"}
+        docs_ops.create_document_op(service, "T")
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+    def test_append_text_inserts_before_trailing_newline(self):
+        service = MagicMock()
+        service.documents.return_value.get.return_value.execute.return_value = {
+            "body": {"content": [{"endIndex": 12}]}
+        }
+        out = docs_ops.append_text_op(service, "DOC1", "more")
+        _, kwargs = service.documents.return_value.batchUpdate.call_args
+        req = kwargs["body"]["requests"][0]["insertText"]
+        assert req["location"]["index"] == 11  # endIndex - 1
+        assert req["text"] == "\nmore"
+        assert out["inserted_at"] == 11
+
+    def test_replace_text_builds_replace_all_request(self):
+        service = MagicMock()
+        service.documents.return_value.batchUpdate.return_value.execute.return_value = {
+            "replies": [{"replaceAllText": {"occurrencesChanged": 3}}]
+        }
+        out = docs_ops.replace_text_op(service, "DOC1", "foo", "bar", match_case=True)
+        _, kwargs = service.documents.return_value.batchUpdate.call_args
+        req = kwargs["body"]["requests"][0]["replaceAllText"]
+        assert req["containsText"] == {"text": "foo", "matchCase": True}
+        assert req["replaceText"] == "bar"
+        assert out["occurrences_changed"] == 3
+
+
+# ── Sheets ───────────────────────────────────────────────────────────────────
+
+class TestSheetsOps:
+    def test_get_values_truncates_large_range(self, monkeypatch):
+        monkeypatch.setattr(sheets_ops, "_MAX_READ_CELLS", 3)
+        service = MagicMock()
+        service.spreadsheets.return_value.values.return_value.get.return_value.execute.return_value = {
+            "range": "S!A1:B3", "values": [["a", "b"], ["c", "d"], ["e", "f"]],
+        }
+        out = sheets_ops.get_values_op(service, "SS", "S!A1:B3")
+        assert out["truncated"] is True
+        assert out["row_count"] == 1  # first 2-cell row kept; next would exceed cap
+
+    def test_update_values_uses_user_entered(self):
+        service = MagicMock()
+        service.spreadsheets.return_value.values.return_value.update.return_value.execute.return_value = {
+            "updatedRange": "S!A1:B1", "updatedCells": 2,
+        }
+        out = sheets_ops.update_values_op(service, "SS", "S!A1", [["1", "2"]])
+        _, kwargs = service.spreadsheets.return_value.values.return_value.update.call_args
+        assert kwargs["valueInputOption"] == "USER_ENTERED"
+        assert kwargs["body"] == {"values": [["1", "2"]]}
+        assert out["updated_cells"] == 2
+
+    def test_append_rows_inserts_rows(self):
+        service = MagicMock()
+        service.spreadsheets.return_value.values.return_value.append.return_value.execute.return_value = {
+            "updates": {"updatedRange": "S!A2:C2", "updatedRows": 1},
+        }
+        out = sheets_ops.append_rows_op(service, "SS", "S!A:C", [["x", "y", "z"]])
+        _, kwargs = service.spreadsheets.return_value.values.return_value.append.call_args
+        assert kwargs["insertDataOption"] == "INSERT_ROWS"
+        assert out["updated_rows"] == 1
+
+    def test_add_sheet_returns_new_tab(self):
+        service = MagicMock()
+        service.spreadsheets.return_value.batchUpdate.return_value.execute.return_value = {
+            "replies": [{"addSheet": {"properties": {"sheetId": 5, "title": "Q3"}}}]
+        }
+        out = sheets_ops.add_sheet_op(service, "SS", "Q3")
+        _, kwargs = service.spreadsheets.return_value.batchUpdate.call_args
+        assert kwargs["body"]["requests"][0]["addSheet"]["properties"]["title"] == "Q3"
+        assert out["sheet_id"] == 5
+
+
+# ── Slides ───────────────────────────────────────────────────────────────────
+
+class TestSlidesOps:
+    def test_get_presentation_extracts_per_slide_text(self):
+        service = MagicMock()
+        service.presentations.return_value.get.return_value.execute.return_value = {
+            "presentationId": "P1", "title": "Deck",
+            "slides": [
+                {"objectId": "s1", "pageElements": [
+                    {"shape": {"text": {"textElements": [{"textRun": {"content": "Title"}}]}}}
+                ]},
+            ],
+        }
+        out = slides_ops.get_presentation_op(service, "P1")
+        assert out["title"] == "Deck"
+        assert out["slides"][0] == {"slide_object_id": "s1", "text": "Title"}
+
+    def test_add_slide_creates_slide_with_layout(self):
+        service = MagicMock()
+        service.presentations.return_value.batchUpdate.return_value.execute.return_value = {}
+        out = slides_ops.add_slide_op(service, "P1", layout="TITLE")
+        _, kwargs = service.presentations.return_value.batchUpdate.call_args
+        req = kwargs["body"]["requests"][0]["createSlide"]
+        assert req["slideLayoutReference"]["predefinedLayout"] == "TITLE"
+        assert out["slide_object_id"] == req["objectId"]
+
+    def test_insert_text_creates_textbox_then_inserts(self):
+        service = MagicMock()
+        service.presentations.return_value.batchUpdate.return_value.execute.return_value = {}
+        out = slides_ops.insert_text_op(service, "P1", "slide1", "Hi")
+        _, kwargs = service.presentations.return_value.batchUpdate.call_args
+        reqs = kwargs["body"]["requests"]
+        assert reqs[0]["createShape"]["shapeType"] == "TEXT_BOX"
+        assert reqs[0]["createShape"]["elementProperties"]["pageObjectId"] == "slide1"
+        assert reqs[1]["insertText"]["text"] == "Hi"
+        # the two requests reference the same new shape objectId
+        assert reqs[0]["createShape"]["objectId"] == reqs[1]["insertText"]["objectId"]
+        assert out["text_box_object_id"] == reqs[0]["createShape"]["objectId"]
+
+    def test_replace_all_text_counts_occurrences(self):
+        service = MagicMock()
+        service.presentations.return_value.batchUpdate.return_value.execute.return_value = {
+            "replies": [{"replaceAllText": {"occurrencesChanged": 2}}]
+        }
+        out = slides_ops.replace_all_text_op(service, "P1", "{{name}}", "Ada")
+        assert out["occurrences_changed"] == 2
+
+
+# ── Drive delete ─────────────────────────────────────────────────────────────
+
+class TestDriveDelete:
+    def test_delete_trashes_by_default(self):
+        service = MagicMock()
+        service.files.return_value.update.return_value.execute.return_value = {
+            "id": "F", "name": "doc", "trashed": True,
+        }
+        out = drive_ops.delete_file_op(service, "F")
+        _, kwargs = service.files.return_value.update.call_args
+        assert kwargs["body"] == {"trashed": True}
+        assert out["trashed"] is True
+        service.files.return_value.delete.assert_not_called()
+
+    def test_delete_permanent_hard_deletes(self):
+        service = MagicMock()
+        out = drive_ops.delete_file_op(service, "F", permanent=True)
+        service.files.return_value.delete.assert_called_once_with(fileId="F")
+        assert out["permanently_deleted"] is True

--- a/backend/tests/test_workspace_ops.py
+++ b/backend/tests/test_workspace_ops.py
@@ -136,6 +136,23 @@ class TestSlidesOps:
         assert out["title"] == "Deck"
         assert out["slides"][0] == {"slide_object_id": "s1", "text": "Title"}
 
+    def test_get_presentation_extracts_table_cell_text(self):
+        service = MagicMock()
+        service.presentations.return_value.get.return_value.execute.return_value = {
+            "presentationId": "P1", "title": "Deck",
+            "slides": [
+                {"objectId": "s1", "pageElements": [
+                    {"table": {"tableRows": [
+                        {"tableCells": [
+                            {"text": {"textElements": [{"textRun": {"content": "Cell"}}]}},
+                        ]},
+                    ]}},
+                ]},
+            ],
+        }
+        out = slides_ops.get_presentation_op(service, "P1")
+        assert out["slides"][0]["text"] == "Cell"
+
     def test_add_slide_creates_slide_with_layout(self):
         service = MagicMock()
         service.presentations.return_value.batchUpdate.return_value.execute.return_value = {}

--- a/backend/tests/test_workspace_ops.py
+++ b/backend/tests/test_workspace_ops.py
@@ -103,6 +103,23 @@ class TestDocsOps:
         assert out["content"] == "abcde"
         assert out["truncated"] is True
 
+    def test_get_document_reads_table_cell_text(self):
+        service = MagicMock()
+        service.documents.return_value.get.return_value.execute.return_value = {
+            "documentId": "D", "title": "T",
+            "body": {"content": [
+                {"paragraph": {"elements": [{"textRun": {"content": "Intro "}}]}},
+                {"table": {"tableRows": [
+                    {"tableCells": [
+                        {"content": [{"paragraph": {"elements": [{"textRun": {"content": "C1"}}]}}]},
+                        {"content": [{"paragraph": {"elements": [{"textRun": {"content": "C2"}}]}}]},
+                    ]},
+                ]}},
+            ]},
+        }
+        out = docs_ops.get_document_op(service, "D")
+        assert out["content"] == "Intro C1C2"
+
 
 # ── Sheets ───────────────────────────────────────────────────────────────────
 
@@ -116,6 +133,18 @@ class TestSheetsOps:
         out = sheets_ops.get_values_op(service, "SS", "S!A1:B3")
         assert out["truncated"] is True
         assert out["row_count"] == 1  # first 2-cell row kept; next would exceed cap
+
+    def test_get_values_truncates_on_char_cap(self, monkeypatch):
+        # Few cells, but huge cell strings -> char cap (not cell cap) truncates
+        monkeypatch.setattr(sheets_ops, "_MAX_READ_CELLS", 10000)
+        monkeypatch.setattr(sheets_ops, "_MAX_READ_CHARS", 5)
+        service = MagicMock()
+        service.spreadsheets.return_value.values.return_value.get.return_value.execute.return_value = {
+            "range": "S!A1:A2", "values": [["abc"], ["defghij"]],
+        }
+        out = sheets_ops.get_values_op(service, "SS", "S!A1:A2")
+        assert out["truncated"] is True
+        assert out["row_count"] == 1  # first row kept; second exceeds char cap
 
     def test_update_values_uses_user_entered(self):
         service = MagicMock()
@@ -280,11 +309,12 @@ class TestDriveDelete:
         out = drive_ops.delete_file_op(service, "F")
         _, kwargs = service.files.return_value.update.call_args
         assert kwargs["body"] == {"trashed": True}
+        assert kwargs["supportsAllDrives"] is True  # shared-drive safe
         assert out["trashed"] is True
         service.files.return_value.delete.assert_not_called()
 
     def test_delete_permanent_hard_deletes(self):
         service = MagicMock()
         out = drive_ops.delete_file_op(service, "F", permanent=True)
-        service.files.return_value.delete.assert_called_once_with(fileId="F")
+        service.files.return_value.delete.assert_called_once_with(fileId="F", supportsAllDrives=True)
         assert out["permanently_deleted"] is True

--- a/backend/tests/test_workspace_ops.py
+++ b/backend/tests/test_workspace_ops.py
@@ -73,6 +73,36 @@ class TestDocsOps:
         assert req["replaceText"] == "bar"
         assert out["occurrences_changed"] == 3
 
+    def test_insert_text_clamps_index_below_one(self):
+        service = MagicMock()
+        docs_ops.insert_text_op(service, "DOC1", "x", index=0)
+        _, kwargs = service.documents.return_value.batchUpdate.call_args
+        assert kwargs["body"]["requests"][0]["insertText"]["location"]["index"] == 1
+
+    def test_insert_text_passes_positive_index(self):
+        service = MagicMock()
+        docs_ops.insert_text_op(service, "DOC1", "x", index=5)
+        _, kwargs = service.documents.return_value.batchUpdate.call_args
+        assert kwargs["body"]["requests"][0]["insertText"]["location"]["index"] == 5
+
+    def test_append_to_empty_doc_inserts_at_index_one(self):
+        service = MagicMock()
+        service.documents.return_value.get.return_value.execute.return_value = {"body": {"content": []}}
+        docs_ops.append_text_op(service, "DOC1", "hi")
+        _, kwargs = service.documents.return_value.batchUpdate.call_args
+        assert kwargs["body"]["requests"][0]["insertText"]["location"]["index"] == 1
+
+    def test_get_document_clamps_max_chars(self, monkeypatch):
+        monkeypatch.setattr(docs_ops, "_MAX_READ_CHARS", 5)
+        service = MagicMock()
+        service.documents.return_value.get.return_value.execute.return_value = {
+            "documentId": "D", "title": "T",
+            "body": {"content": [{"paragraph": {"elements": [{"textRun": {"content": "abcdefghij"}}]}}]},
+        }
+        out = docs_ops.get_document_op(service, "D", max_chars=10_000_000)
+        assert out["content"] == "abcde"
+        assert out["truncated"] is True
+
 
 # ── Sheets ───────────────────────────────────────────────────────────────────
 
@@ -117,6 +147,45 @@ class TestSheetsOps:
         _, kwargs = service.spreadsheets.return_value.batchUpdate.call_args
         assert kwargs["body"]["requests"][0]["addSheet"]["properties"]["title"] == "Q3"
         assert out["sheet_id"] == 5
+
+    def test_get_metadata_lists_sheets(self):
+        service = MagicMock()
+        service.spreadsheets.return_value.get.return_value.execute.return_value = {
+            "properties": {"title": "Book"},
+            "sheets": [{"properties": {"sheetId": 0, "title": "Tab1",
+                                       "gridProperties": {"rowCount": 100, "columnCount": 26}}}],
+        }
+        out = sheets_ops.get_metadata_op(service, "SS")
+        assert out["title"] == "Book"
+        assert out["sheets"][0] == {"sheet_id": 0, "title": "Tab1", "row_count": 100, "column_count": 26}
+
+    def test_create_spreadsheet_returns_id(self):
+        service = MagicMock()
+        service.spreadsheets.return_value.create.return_value.execute.return_value = {
+            "spreadsheetId": "NEW", "properties": {"title": "Book"},
+        }
+        out = sheets_ops.create_spreadsheet_op(service, "Book")
+        assert out["spreadsheet_id"] == "NEW"
+        assert out["title"] == "Book"
+        assert out["web_link"].endswith("/NEW/edit")
+
+    def test_clear_range_echoes_cleared_range(self):
+        service = MagicMock()
+        service.spreadsheets.return_value.values.return_value.clear.return_value.execute.return_value = {
+            "clearedRange": "S!A2:Z",
+        }
+        out = sheets_ops.clear_values_op(service, "SS", "S!A2:Z")
+        assert out["cleared_range"] == "S!A2:Z"
+
+    def test_get_values_keeps_oversized_first_row(self, monkeypatch):
+        monkeypatch.setattr(sheets_ops, "_MAX_READ_CELLS", 2)
+        service = MagicMock()
+        service.spreadsheets.return_value.values.return_value.get.return_value.execute.return_value = {
+            "range": "S!A1:C1", "values": [["a", "b", "c"]],
+        }
+        out = sheets_ops.get_values_op(service, "SS", "S!A1:C1")
+        assert out["row_count"] == 1  # never returns "truncated but 0 rows"
+        assert out["truncated"] is True
 
 
 # ── Slides ───────────────────────────────────────────────────────────────────
@@ -182,6 +251,22 @@ class TestSlidesOps:
         }
         out = slides_ops.replace_all_text_op(service, "P1", "{{name}}", "Ada")
         assert out["occurrences_changed"] == 2
+
+    def test_get_presentation_truncates_across_slides(self):
+        service = MagicMock()
+        service.presentations.return_value.get.return_value.execute.return_value = {
+            "presentationId": "P1", "title": "Deck",
+            "slides": [
+                {"objectId": "s1", "pageElements": [
+                    {"shape": {"text": {"textElements": [{"textRun": {"content": "AAAAA"}}]}}}]},
+                {"objectId": "s2", "pageElements": [
+                    {"shape": {"text": {"textElements": [{"textRun": {"content": "BBBBB"}}]}}}]},
+            ],
+        }
+        out = slides_ops.get_presentation_op(service, "P1", max_chars=3)
+        assert out["truncated"] is True
+        # first slide truncated to the cap; no trailing empty-text slide entry
+        assert out["slides"] == [{"slide_object_id": "s1", "text": "AAA"}]
 
 
 # ── Drive delete ─────────────────────────────────────────────────────────────

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -15,7 +15,9 @@ export interface Agent {
   calendar_write_enabled?: boolean;
   drive_enabled?: boolean;
   drive_write_enabled?: boolean;
-  google_accounts?: { gmail?: string[]; calendar?: string[]; drive?: string[] };
+  workspace_read_enabled?: boolean;
+  workspace_write_enabled?: boolean;
+  google_accounts?: { gmail?: string[]; calendar?: string[]; drive?: string[]; workspace?: string[] };
   whatsapp_session_id?: string;
   telegram_enabled: boolean;
   telegram_bot_token?: string;
@@ -80,11 +82,13 @@ export interface Commitment {
 export type GmailScopeLevel = 'none' | 'read' | 'send';
 export type CalendarScopeLevel = 'none' | 'read' | 'full';
 export type DriveScopeLevel = 'none' | 'file' | 'readonly' | 'full';
+export type WorkspaceScopeLevel = 'none' | 'read' | 'edit';
 
 export interface GoogleScopeGrants {
   gmail: GmailScopeLevel;
   calendar: CalendarScopeLevel;
   drive: DriveScopeLevel;
+  workspace?: WorkspaceScopeLevel;
 }
 
 export interface GoogleAccount {

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -15,8 +15,6 @@ export interface Agent {
   calendar_write_enabled?: boolean;
   drive_enabled?: boolean;
   drive_write_enabled?: boolean;
-  workspace_read_enabled?: boolean;
-  workspace_write_enabled?: boolean;
   google_accounts?: { gmail?: string[]; calendar?: string[]; drive?: string[]; workspace?: string[] };
   whatsapp_session_id?: string;
   telegram_enabled: boolean;

--- a/frontend/src/dashboard/GoogleIntegrationCard.tsx
+++ b/frontend/src/dashboard/GoogleIntegrationCard.tsx
@@ -172,7 +172,8 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
       if (service === 'gmail') return g.gmail !== 'none';
       if (service === 'calendar') return g.calendar !== 'none';
       if (service === 'workspace') return !!g.workspace && g.workspace !== 'none';
-      return g.drive !== 'none';
+      if (service === 'drive') return g.drive !== 'none';
+      return false;
     });
   }
 

--- a/frontend/src/dashboard/GoogleIntegrationCard.tsx
+++ b/frontend/src/dashboard/GoogleIntegrationCard.tsx
@@ -9,6 +9,7 @@ import type {
   GmailScopeLevel,
   CalendarScopeLevel,
   DriveScopeLevel,
+  WorkspaceScopeLevel,
 } from '../core/types';
 
 interface Props {
@@ -35,11 +36,18 @@ const DRIVE_OPTIONS: { value: DriveScopeLevel; label: string; hint: string }[] =
   { value: 'full',      label: 'Full access', hint: 'Read, write, and delete any Drive file. Most powerful; requires verification.' },
 ];
 
+const WORKSPACE_OPTIONS: { value: WorkspaceScopeLevel; label: string; hint: string }[] = [
+  { value: 'none', label: 'Off', hint: 'Don\'t request Docs / Sheets / Slides access' },
+  { value: 'read', label: 'Read only', hint: 'Read Google Docs, Sheets & Slides by ID. Add Drive (read) to find files.' },
+  { value: 'edit', label: 'Read + edit', hint: 'Create and edit Docs, Sheets & Slides. To find files add Drive (readonly/full); to delete them add Drive (full).' },
+];
+
 function scopeSummary(grants: GoogleAccount['scope_grants']) {
   return [
     grants.gmail !== 'none' && `Gmail: ${grants.gmail === 'send' ? 'read+send' : grants.gmail}`,
     grants.calendar !== 'none' && `Calendar: ${grants.calendar}`,
     grants.drive !== 'none' && `Drive: ${grants.drive}`,
+    grants.workspace && grants.workspace !== 'none' && `Workspace: ${grants.workspace}`,
   ].filter(Boolean).join(' \u00b7 ');
 }
 
@@ -49,6 +57,7 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
   const [gmail, setGmail]       = useState<GmailScopeLevel>('none');
   const [calendar, setCalendar] = useState<CalendarScopeLevel>('none');
   const [drive, setDrive]       = useState<DriveScopeLevel>('none');
+  const [workspace, setWorkspace] = useState<WorkspaceScopeLevel>('none');
   const [disconnecting, setDisconnecting] = useState('');
   const [localError, setLocalError] = useState('');
   const [showCredForm, setShowCredForm] = useState(false);
@@ -93,16 +102,17 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
     setGmail(acct?.scope_grants?.gmail ?? 'none');
     setCalendar(acct?.scope_grants?.calendar ?? 'none');
     setDrive(acct?.scope_grants?.drive ?? 'none');
+    setWorkspace(acct?.scope_grants?.workspace ?? 'none');
     setPickerOpen(true);
     setLocalError('');
   }
 
-  const anyGranted = gmail !== 'none' || calendar !== 'none' || drive !== 'none';
+  const anyGranted = gmail !== 'none' || calendar !== 'none' || drive !== 'none' || workspace !== 'none';
 
   async function connect() {
     setLocalError('');
     if (!anyGranted) {
-      setLocalError('Enable at least one of Gmail, Calendar, or Drive.');
+      setLocalError('Enable at least one of Gmail, Calendar, Drive, or Workspace.');
       return;
     }
     const base = editingAccountId
@@ -113,7 +123,7 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
       : '/api/integrations/google/setup/complete';
     await oauth.start({
       setupUrl: base,
-      setupBody: { gmail_level: gmail, calendar_level: calendar, drive_level: drive },
+      setupBody: { gmail_level: gmail, calendar_level: calendar, drive_level: drive, workspace_level: workspace },
       completeUrl: complete,
     });
   }
@@ -133,7 +143,7 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
     }
   }
 
-  async function toggleAgentAccount(agentId: string, service: 'gmail' | 'calendar' | 'drive', accountId: string) {
+  async function toggleAgentAccount(agentId: string, service: 'gmail' | 'calendar' | 'drive' | 'workspace', accountId: string) {
     setSavingAgent(agentId);
     const agent = agents.find(a => a.id === agentId);
     const current = agent?.google_accounts || {};
@@ -156,11 +166,12 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
     }
   }
 
-  function accountsForService(service: 'gmail' | 'calendar' | 'drive') {
+  function accountsForService(service: 'gmail' | 'calendar' | 'drive' | 'workspace') {
     return accounts.filter(a => {
       const g = a.scope_grants;
       if (service === 'gmail') return g.gmail !== 'none';
       if (service === 'calendar') return g.calendar !== 'none';
+      if (service === 'workspace') return !!g.workspace && g.workspace !== 'none';
       return g.drive !== 'none';
     });
   }
@@ -283,14 +294,14 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
                 return (
                   <div key={agent.id} className="bg-gray-900/30 rounded-lg px-3 py-2">
                     <p className="text-white text-xs font-medium mb-1.5">{agent.agent_name}</p>
-                    <div className="grid grid-cols-3 gap-2">
-                      {(['gmail', 'calendar', 'drive'] as const).map(svc => {
+                    <div className="grid grid-cols-2 gap-2">
+                      {(['gmail', 'calendar', 'drive', 'workspace'] as const).map(svc => {
                         const available = accountsForService(svc);
                         const selected = ga[svc] || [];
                         return (
                           <div key={svc}>
                             <label className="text-gray-500 text-[10px] uppercase tracking-wide block mb-0.5">
-                              {svc === 'gmail' ? 'Gmail' : svc === 'calendar' ? 'Calendar' : 'Drive'}
+                              {svc === 'gmail' ? 'Gmail' : svc === 'calendar' ? 'Calendar' : svc === 'drive' ? 'Drive' : 'Workspace'}
                             </label>
                             {available.length === 0 && (
                               <span className="text-gray-600 text-[10px]">No accounts</span>
@@ -335,6 +346,8 @@ export function GoogleIntegrationCard({ integration, onChanged }: Props) {
             onChange={(v) => setCalendar(v as CalendarScopeLevel)} />
           <ScopeGroup title="Google Drive" options={DRIVE_OPTIONS} value={drive}
             onChange={(v) => setDrive(v as DriveScopeLevel)} />
+          <ScopeGroup title="Workspace (Docs, Sheets & Slides)" options={WORKSPACE_OPTIONS} value={workspace}
+            onChange={(v) => setWorkspace(v as WorkspaceScopeLevel)} />
 
           <div className="flex gap-2 pt-2">
             <button onClick={() => { setPickerOpen(false); setEditingAccountId(''); }} disabled={isRunning}


### PR DESCRIPTION
## Summary
- Adds a new bundled **"Workspace"** Google service (`none`/`read`/`edit`) giving agents full **create/read/update** over Google Docs, Sheets, and Slides — plus a Drive **trash/delete** tool to complete the "D". Implemented natively on the existing Google integration (no external CLI), so auth/refresh, multi-account assignment, scope gating, write budgets, and untrusted-result wrapping are all inherited.
- **~18 curated, AI-friendly tools** (no raw `batchUpdate` passthrough): Docs read/create/insert/append/replace · Sheets read/metadata/write/append/clear/create-spreadsheet/add-tab · Slides read/create/add-slide/insert-text/replace · Drive `delete_drive_file`. New ops modules (`docs_ops`/`sheets_ops`/`slides_ops`) lift batchUpdate patterns from the Hermes reference; Slides built fresh.
- **Cross-cutting wiring:** centralizes the assignable-service list as `GOOGLE_SERVICES` + a `google_tool_flags` helper, then threads `workspace` through **every** `ToolRegistry`/`get_tool_definitions` site (chat, CLI, scheduled actions, heartbeat, Telegram, WhatsApp, Paperclip) and refactors the cleanup/migration/alert paths that hardcoded `("gmail","calendar","drive")`. Adding the next Google service is now a one-line change.
- Scope levels (`documents`/`spreadsheets`/`presentations` + readonly variants), `multi_workspace` account-param injection, untrusted-result wrapping, OAuth setup routes, agent-assignment validation, and a frontend Workspace scope dropdown + per-agent assignment row.

**Scope note:** Workspace edit covers C/R/U on a known file ID. *Finding* a file uses Drive search (readonly/full) and *deleting* an arbitrary existing file needs Drive `full` — so the recommended setup is **Workspace: Edit + Drive: Full**. The UI copy says so.

## Test plan
- [x] `pytest` — full backend suite green (1005 passed), incl. new `test_workspace_ops.py` and added Workspace cases in scopes/registry/tool-definitions/accounts-context tests
- [x] New tests cover: scope/capability resolution, `google_tool_flags` service-scoping + `multi_*`, batchUpdate request shapes (replaceAllText, createShape+insertText, addSheet), read truncation, trash-vs-permanent delete, write-scope gating (`edit` required), and `delete_drive_file` gated on Drive `full`
- [x] Frontend `tsc -b` + `vite build` pass
- [x] All touched modules import cleanly; no orphaned capability refs after refactor
- [ ] **Manual E2E** (needs a real Google account): connect Workspace=Edit + Drive=Full, assign to an agent, then create→edit→read a Doc, create→add-tab→write→read a Sheet, create→add-slide→insert-text a deck, and search→delete a file (verify it lands in Trash)